### PR TITLE
update the ubuntu iso url

### DIFF
--- a/images/capi/config/ubuntu-1804.json
+++ b/images/capi/config/ubuntu-1804.json
@@ -3,7 +3,7 @@
   "distro_name": "ubuntu",
   "os_display_name": "Ubuntu 18.04",
   "guest_os_type": "ubuntu-64",
-  "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/bionic/release/ubuntu-18.04.2-server-amd64.iso",
+  "iso_url": "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-server-amd64.iso",
   "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
   "iso_checksum_type": "sha256",
   "ssh_username": "ubuntu",


### PR DESCRIPTION
the 18.04.2 url been moved to old-releases domain, which is permanent now.

Signed-off-by: Hui Luo <luoh@vmware.com>

cc @akutz 