### PR TITLE
Allow customize kubernetes, cni source

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -22,7 +22,7 @@ all: build
 BUILD_NAMES ?= centos-7 ubuntu-1804
 
 # The version of Kubernetes to install.
-KUBE_JSON ?= config/kubernetes.json
+KUBE_JSON ?= config/kubernetes.json config/cni.json
 
 # The flags to give to Packer.
 PACKER_VAR_FILES := $(KUBE_JSON)

--- a/images/capi/ansible/roles/kubernetes/defaults/main.yml
+++ b/images/capi/ansible/roles/kubernetes/defaults/main.yml
@@ -12,20 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-kubernetes_semver: "latest"
-kubernetes_source: "pkg"
-kubernetes_version: "latest"
-kubernetes_cni_version: "latest"
-
-kubernetes_rpm_repo: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64"
-kubernetes_rpm_gpg_key: "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
-kubernetes_rpm_gpg_check: True
-
-# Currently Kubernetes does not publish a repo specifically for Bionic, instead hardcode xenial here for now
-# https://github.com/kubernetes/release/issues/557
-#kubernetes_deb_repo: "http://apt.kubernetes.io/ kubernetes-' ~ (ansible_distribution_release | lower)"
-kubernetes_deb_repo: "http://apt.kubernetes.io/ kubernetes-xenial"
-kubernetes_deb_gpg_key: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+kubernetes_goarch: "amd64"
 
 kubernetes_bins:
 - kubeadm
@@ -37,7 +24,3 @@ kubernetes_imgs:
 - kube-controller-manager.tar
 - kube-scheduler.tar
 - kube-proxy.tar
-
-# TODO(akutz) Refactor this the same way Kubernetes versions are now handled.
-#             For now this is only used when kubernetes_source != "pkg".
-kubernetes_cni_source: "https://storage.googleapis.com/capv-images/extra/cni-plugins-amd64-v0.7.5.tgz"

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -19,7 +19,7 @@
   when: kubernetes_source == "pkg" and ansible_os_family == "RedHat"
 
 - import_tasks: url.yml
-  when: kubernetes_source != "pkg"
+  when: kubernetes_source != "pkg" and kubernetes_cni_source != "pkg"
 
 - name: Ensure that the kubelet is running
   service:

--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -32,8 +32,8 @@
 
 - name: Download CNI tarball
   get_url:
-    url: "{{ kubernetes_cni_source }}"
-    checksum: "sha1:{{ kubernetes_cni_source }}.sha1"
+    url: "{{ kubernetes_cni_source }}/{{ kubernetes_cni_semver }}/cni-plugins-{{ kubernetes_goarch }}-{{ kubernetes_cni_semver }}.tgz"
+    checksum: "sha1:{{ kubernetes_cni_source }}/{{ kubernetes_cni_semver }}/cni-plugins-{{ kubernetes_goarch }}-{{ kubernetes_cni_semver }}.tgz.sha1"
     dest: /tmp/cni.tar.gz
     mode: 0755
     owner: root
@@ -52,7 +52,7 @@
 
 - name: Download Kubernetes binaries
   get_url:
-    url: "{{ kubernetes_source }}/bin/linux/amd64/{{ item }}"
+    url: "{{ kubernetes_source }}/bin/linux/{{ kubernetes_goarch }}/{{ item }}"
     # TODO(akutz) Write a script to separately download the checksum
     #             and verify the associated file using the correct
     #             checksum file format
@@ -65,7 +65,7 @@
 
 - name: Download Kubernetes images
   get_url:
-    url: "{{ kubernetes_source }}/bin/linux/amd64/{{ item }}"
+    url: "{{ kubernetes_source }}/bin/linux/{{ kubernetes_goarch }}/{{ item }}"
     # TODO(akutz) Write a script to separately download the checksum
     #             and verify the associated file using the correct
     #             checksum file format
@@ -87,6 +87,14 @@
   file:
     state: directory
     path: /etc/kubernetes/manifests
+    mode: 0755
+    owner: root
+    group: root
+
+- name: Create kubelet sysconfig directory
+  file:
+    state: directory
+    path: /etc/sysconfig
     mode: 0755
     owner: root
     group: root

--- a/images/capi/config/cni.json
+++ b/images/capi/config/cni.json
@@ -1,0 +1,5 @@
+{
+    "kubernetes_cni_semver": "v0.7.5",
+    "kubernetes_cni_version": "0.7.5-00",
+    "kubernetes_cni_source": "pkg"
+}

--- a/images/capi/config/kubernetes.json
+++ b/images/capi/config/kubernetes.json
@@ -1,5 +1,10 @@
 {
   "kubernetes_semver": "v1.13.6",
   "kubernetes_version": "1.13.6-00",
-  "kubernetes_source": "pkg"
+  "kubernetes_source": "pkg",
+  "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",
+  "kubernetes_rpm_gpg_key": "\"https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg\"",
+  "kubernetes_rpm_gpg_check": "True",
+  "kubernetes_deb_repo": "\"https://apt.kubernetes.io/ kubernetes-xenial\"",
+  "kubernetes_deb_gpg_key": "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 }

--- a/images/capi/packer/packer.json
+++ b/images/capi/packer/packer.json
@@ -6,10 +6,17 @@
     "capv_version": "",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "headless": "true",
-    "kubernetes_cni_version": "0.7.5-00",
-    "kubernetes_semver": "v1.13.6",
-    "kubernetes_source": "pkg",
-    "kubernetes_version": "1.13.6-00",
+    "kubernetes_cni_version": null,
+    "kubernetes_cni_semver": null,
+    "kubernetes_cni_source": null,
+    "kubernetes_semver": null,
+    "kubernetes_source": null,
+    "kubernetes_version": null,
+    "kubernetes_rpm_repo": null,
+    "kubernetes_rpm_gpg_key": null,
+    "kubernetes_deb_repo": null,
+    "kubernetes_deb_gpg_key": null,
+    "kubernetes_rpm_gpg_check": null,
     "vnc_bind_address": "127.0.0.1",
     "vnc_port_min": "5900",
     "vnc_port_max": "6000"
@@ -60,7 +67,7 @@
       ],
       "extra_arguments": [
         "--extra-vars",
-        "kubernetes_cni_version={{user `kubernetes_cni_version`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source={{user `kubernetes_source`}} kubernetes_version={{user `kubernetes_version`}}"
+        "kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_version={{user `kubernetes_cni_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source={{user `kubernetes_cni_source`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source={{user `kubernetes_source`}} kubernetes_version={{user `kubernetes_version`}}"
       ]
     }
   ],


### PR DESCRIPTION
the image-builder tool getting kubernetes, cni from two source types:
1) rpm, deb repos, container registry
2) binary download site

the default behavior does not change, still getting them from upstream rpm, deb repo and k8s. gcr.io. this change enable us to configure rpm,deb source and binary source for kuberentes, cni

note: one more change needed to allow customize container registry for k8s images.

Signed-off-by: Hui Luo <luoh@vmware.com>


cc @codenrhoden @akutz @moshloop @timothysc 