### PR TITLE
Use a newer version of cloud-init for CentOS

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -37,5 +37,5 @@ common_pinned_debs:
 - "cloud-init={{ cloud_init_version }}"
 common_extra_debs: []
 common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-common_redhat_cloud_init_copr_rpm: "https://copr.fedorainfracloud.org/coprs/jdetiber/cloud-init/repo/epel-7/jdetiber-cloud-init-epel-7.repo"
+common_redhat_cloud_init_copr_rpm: "https://copr.fedorainfracloud.org/coprs/trhoden/cloud-init/repo/epel-7/trhoden-cloud-init-epel-7.repo"
 common_deb_cloud_init_ppr_repo: "ppa:detiber/cloud-init"


### PR DESCRIPTION
This patch changes the ansible script to install cloud-init from a
different COPR repository, namely
https://copr.fedorainfracloud.org/coprs/trhoden/cloud-init/, which
contains a cloud-init package newer than what can be found on EPEL. This
version is currently 19.2.

Fixes #17 

I tested that I could build the CentOS image locally, and after booting it up, saw that cloud-init had run (I could SSH in with the injected SSH key) and could look at the cloud-init logs and package version. Currently installed version is `cloud-init-19.2-1.el7.noarch`.