### PR TITLE
Fix for AMI build to detect Amazon Linux

### DIFF
--- a/images/capi/ansible/roles/common/tasks/redhat.yml
+++ b/images/capi/ansible/roles/common/tasks/redhat.yml
@@ -55,4 +55,4 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_distribution == "Amazon" and ansible_distribution_major_version == "NA"
+  when: ansible_distribution == "Amazon"


### PR DESCRIPTION
This patch re-introduces a fix to the Ansible role to properly detect AML2. This patch was originally introduced in https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/979, but since the Ansible roles were originally imported from CAPV, not CAPA, this fix did not carry over.

/assign @figo 