### PR TITLE
remove centos default root password access

### DIFF
--- a/images/capi/packer/ova/linux/centos/http/7/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/7/ks.cfg
@@ -38,7 +38,6 @@ unsupported_hardware
 
 # Configure the user(s)
 auth --enableshadow --passalgo=sha512 --kickstart
-rootpw centos
 user --name=centos --plaintext --password centos --groups=centos,wheel
 
 # Disable general install minutia


### PR DESCRIPTION
looks like the kickstart configure of root access will
triumph over cloud-init disable_root configure, the effect
of that is: root access is enabled.

removing this configure from ks.cfg will disable root access.

Signed-off-by: Hui Luo <luoh@vmware.com>

cc @akutz 
fix #32 
