### PR TITLE
Don't .gitignore pkg/imagebuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ dist/
 *.log
 *.vmdk
 *.out
-image-builder
+./image-builder

--- a/images/kube-deploy/imagebuilder/.gitignore
+++ b/images/kube-deploy/imagebuilder/.gitignore
@@ -1,3 +1,2 @@
 *~
-imagebuilder
-
+./imagebuilder


### PR DESCRIPTION
The .gitignore is, by default, recursive, and this meant we ignored
pkg/imagebuilder accidentally.