### PR TITLE
Add targets to build images on remote ESX host

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -22,6 +22,7 @@ all: build
 OVA_BUILD_NAMES ?= ova-centos-7 ova-ubuntu-1804
 AMI_BUILD_NAMES ?= ami-default
 GCE_BUILD_NAMES ?= gce-default
+OVA_BUILD_NAMES_ESX ?= esx-ova-centos-7 esx-ova-ubuntu-1804
 
 # The version of Kubernetes to install.
 KUBE_JSON ?= packer/config/kubernetes.json packer/config/cni.json packer/config/containerd.json
@@ -35,6 +36,8 @@ PACKER_FLAGS += $(OLD_PACKER_FLAGS)
 OVA_BUILD_TARGETS := $(addprefix build-,$(OVA_BUILD_NAMES))
 AMI_BUILD_TARGETS := $(addprefix build-,$(AMI_BUILD_NAMES))
 GCE_BUILD_TARGETS := $(addprefix build-,$(GCE_BUILD_NAMES))
+OVA_BUILD_TARGETS_ESX := $(addprefix build-,$(OVA_BUILD_NAMES_ESX))
+
 $(OVA_BUILD_TARGETS):
 	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-,,$@).json)" packer/ova/packer.json
 .PHONY: $(OVA_BUILD_TARGETS)
@@ -46,6 +49,10 @@ $(AMI_BUILD_TARGETS):
 $(GCE_BUILD_TARGETS):
 	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/gce/$(subst build-,,$@).json)" packer/gce/packer.json
 .PHONY: $(GCE_BUILD_TARGETS)
+
+$(OVA_BUILD_TARGETS_ESX):
+	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-esx-,,$@).json)" -var-file="packer/ova/esx.json" -except=shell-local packer/ova/packer.json
+.PHONY: $(OVA_BUILD_TARGETS_ESX)
 
 CLEAN_TARGETS := $(addprefix clean-,$(OVA_BUILD_NAMES)) $(addprefix clean-,$(AMI_BUILD_NAMES)) $(addprefix clean-,$(GCE_BUILD_NAMES))
 $(CLEAN_TARGETS):

--- a/images/capi/packer/ova/esx.json
+++ b/images/capi/packer/ova/esx.json
@@ -1,0 +1,12 @@
+{
+    "disk_type_id": "thin",
+    "format": "ova",
+    "remote_type": "esx5",
+    "remote_host": "",
+    "remote_datastore": "",
+    "remote_username": "",
+    "remote_password": "",
+    "skip_compaction": "true",
+    "vnc_bind_address": "",
+    "vnc_disable_password": "true"
+}

--- a/images/capi/packer/ova/ova-ubuntu-1804.json
+++ b/images/capi/packer/ova/ova-ubuntu-1804.json
@@ -8,7 +8,7 @@
   "iso_checksum_type": "sha256",
   "ssh_username": "ubuntu",
   "ssh_password": "ubuntu",
-  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda noapic preseed/url=",
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
   "boot_command_suffix": "/18.04/preseed.cfg -- <wait><enter><wait>",
   "goss_vars_file": "goss/ubuntu-vars.yaml",
   "shutdown_command": "shutdown -P now"

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -3,13 +3,15 @@
     "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",
     "capi_version": "v1alpha1",
-    "disable_public_repos": "false",
-    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
-    "extra_repos": "",
-    "headless": "true",
     "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "disable_public_repos": "false",
+    "disk_type_id": "0",
+    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "extra_repos": "",
+    "format": "",
+    "headless": "true",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,
@@ -28,22 +30,29 @@
     "kubernetes_container_registry": null,
     "reenable_public_repos": "true",
     "remove_extra_repos": "false",
+    "remote_type": "",
+    "remote_host": "",
+    "remote_datastore": "",
+    "remote_username": "",
+    "remote_password": "",
+    "skip_compaction": "false",
     "vnc_bind_address": "127.0.0.1",
+    "vnc_disable_password": "false",
     "vnc_port_min": "5900",
     "vnc_port_max": "6000"
   },
   "builders": [
     {
       "name": "{{user `build_name`}}",
-      "vm_name": "{{build_name}}+kube-{{user `kubernetes_semver`}}",
+      "vm_name": "{{build_name}}-kube-{{user `kubernetes_semver`}}",
       "vmdk_name": "{{build_name}}",
-      "output_directory": "./output/{{build_name}}+kube-{{user `kubernetes_semver`}}",
+      "output_directory": "./output/{{build_name}}-kube-{{user `kubernetes_semver`}}",
       "type": "vmware-iso",
       "cpus": 1,
       "cores": 1,
       "memory": 2048,
       "disk_size": 20480,
-      "disk_type_id": 0,
+      "disk_type_id": "{{user `disk_type_id`}}",
       "disk_adapter_type": "scsi",
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
@@ -62,10 +71,20 @@
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E {{user `shutdown_command`}}",
-      "skip_compaction": false,
+      "skip_compaction": "{{user `skip_compaction`}}",
       "vnc_bind_address": "{{user `vnc_bind_address`}}",
       "vnc_port_min": "{{user `vnc_port_min`}}",
-      "vnc_port_max": "{{user `vnc_port_max`}}"
+      "vnc_port_max": "{{user `vnc_port_max`}}",
+      "remote_type": "{{user `remote_type`}}",
+      "remote_host": "{{user `remote_host`}}",
+      "remote_datastore": "{{user `remote_datastore`}}",
+      "remote_username": "{{user `remote_username`}}",
+      "remote_password": "{{user `remote_password`}}",
+      "vnc_disable_password": "{{user `vnc_disable_password`}}",
+      "format": "{{user `format`}}",
+      "vmx_data": {
+        "ethernet0.networkName": "VM Network"
+      }
     }
   ],
   "provisioners": [
@@ -85,7 +104,7 @@
   "post-processors": [
     {
       "type": "manifest",
-      "output": "./output/{{build_name}}+kube-{{user `kubernetes_semver`}}/packer-manifest.json",
+      "output": "./output/{{build_name}}-kube-{{user `kubernetes_semver`}}/packer-manifest.json",
       "strip_path": true,
       "custom_data": {
         "build_timestamp": "{{user `build_timestamp`}}",
@@ -102,11 +121,11 @@
     },
     {
       "type": "shell-local",
-      "command": "./hack/image-build-ova.py ./output/{{build_name}}+kube-{{user `kubernetes_semver`}}"
+      "command": "./hack/image-build-ova.py ./output/{{build_name}}-kube-{{user `kubernetes_semver`}}"
     },
     {
       "type": "shell-local",
-      "command": "./hack/image-post-create-config.sh ./output/{{build_name}}+kube-{{user `kubernetes_semver`}}"
+      "command": "./hack/image-post-create-config.sh ./output/{{build_name}}-kube-{{user `kubernetes_semver`}}"
     }
   ]
 }


### PR DESCRIPTION
Add `build-esx-ova-ubuntu-1804` and `build-esx-ova-centos-7` two targets to enable build on remote ESX host.

Special note: replaced "+" to "-" in VM names because `ovftool` unescapes "+" to " " (whitespace) and this will cause error when transferring images back to local. 