### PR TITLE
Add ability to inject/remove extra repos

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -39,3 +39,4 @@ common_extra_debs: []
 common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 common_redhat_cloud_init_copr_rpm: "https://copr.fedorainfracloud.org/coprs/jdetiber/cloud-init/repo/epel-7/jdetiber-cloud-init-epel-7.repo"
 common_deb_cloud_init_ppr_repo: "ppa:detiber/cloud-init"
+extra_repos: ""

--- a/images/capi/ansible/roles/common/tasks/debian.yml
+++ b/images/capi/ansible/roles/common/tasks/debian.yml
@@ -16,6 +16,13 @@
   apt_repository:
     repo: "{{ common_deb_cloud_init_ppr_repo }}"
 
+- name: Install extra repos
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/apt/sources.list.d/{{ item | basename }}"
+  loop: "{{ extra_repos.split(',') }}"
+  when: extra_repos != ""
+
 - name: update apt cache
   apt:
     force_apt_get: True

--- a/images/capi/ansible/roles/common/tasks/redhat.yml
+++ b/images/capi/ansible/roles/common/tasks/redhat.yml
@@ -30,6 +30,13 @@
     line: 'priority=1'
   when: ansible_distribution == "Amazon"
 
+- name: Install extra repos
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/yum.repos.d/{{ item | basename }}"
+  loop: "{{ extra_repos.split(',') }}"
+  when: extra_repos != ""
+
 - name: perform a yum update
   yum:
     name: '*'

--- a/images/capi/ansible/roles/sysprep/defaults/main.yml
+++ b/images/capi/ansible/roles/sysprep/defaults/main.yml
@@ -1,0 +1,16 @@
+# Copyright 2019 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+extra_repos: ""
+remove_extra_repos: false

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -17,6 +17,14 @@
     last_log_mode:   "0664"
     machine_id_mode: "0644"
 
+- name: Remove extra repos
+  file:
+    path: "/etc/apt/sources.list.d/{{ item | basename }}"
+    state: absent
+  loop: "{{ extra_repos.split() }}"
+  when: remove_extra_repos and extra_repos != ""
+
+
 - name: Stop auditing
   service:
     name: rsyslog

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -17,6 +17,13 @@
     last_log_mode:   "0644"
     machine_id_mode: "0444"
 
+- name: Remove extra repos
+  file:
+    path: "/etc/yum.repos.d/{{ item | basename }}"
+    state: absent
+  loop: "{{ extra_repos.split() }}"
+  when: remove_extra_repos and extra_repos != ""
+
 - name: Remove yum package caches
   yum:
     autoremove: yes

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -5,6 +5,7 @@
     "aws_region": "",
     "build_timestamp": "{{timestamp}}",
     "encrypted": "false",
+    "extra_repos": "",
     "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
@@ -27,6 +28,7 @@
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "ami_groups": "all",
     "ami_users": "",
+    "remove_extra_repos": "false",
     "snapshot_groups": "all",
     "snapshot_users": "",
     "ami_regions": "ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2",
@@ -171,7 +173,7 @@
       ],
       "extra_arguments": [
         "--extra-vars",
-        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}}"
+        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} extra_repos={{user `extra_repos`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} remove_extra_repos={{user `remove_extra_repos`}}"
       ]
     },
     {

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -9,6 +9,7 @@
     "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "extra_repos": "",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,
@@ -26,7 +27,8 @@
     "kubernetes_deb_gpg_key": null,
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
-    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}"
+    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "remove_extra_repos": "false"
   },
   "builders": [
     {
@@ -69,7 +71,7 @@
       ],
       "extra_arguments": [
         "--extra-vars",
-        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}}"
+        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} extra_repos={{user `extra_repos`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} remove_extra_repos={{user `remove_extra_repos`}}"
       ]
     }
   ]

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -4,6 +4,7 @@
     "build_timestamp": "{{timestamp}}",
     "capi_version": "v1alpha1",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "extra_repos": "",
     "headless": "true",
     "containerd_version": null,
     "containerd_sha256": null,
@@ -24,6 +25,7 @@
     "kubernetes_deb_gpg_key": null,
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
+    "remove_extra_repos": "false",
     "vnc_bind_address": "127.0.0.1",
     "vnc_port_min": "5900",
     "vnc_port_max": "6000"
@@ -74,7 +76,7 @@
       ],
       "extra_arguments": [
         "--extra-vars",
-        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}}"
+        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} extra_repos={{user `extra_repos`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} remove_extra_repos={{user `remove_extra_repos`}}"
       ]
     }
   ],


### PR DESCRIPTION
This patch adds to two new variables to Ansible, and Packer support for
them when building.

`extra_repos`: This is a comma delimited list of files to copy into the
build target as repo definitions. For CentOS, these should be `.repo`
files and will go to `/etc/yum.repos.d`, and for Ubuntu these should be
`.list` files and will to `/etc/apt/sources.list.d`.

The list of files can use relative or absolute paths. If using relative
paths, the paths must reference files within Ansible's search
directories.

`remove_extra_repos`: This is a boolean flag that controls whether the
repo files added via `extra_repos` will be deleted during the sysprep
task. The default is `false`.

The motivation behind this PR is for enterprise consumers to be able to add repo definitions pointing to internal resources. If used, it may be desirable to remove those internal repo definitions afterwards to avoid leaking internal details.