### PR TITLE
OVA: Make CentOS kickstart not rely on internet

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -13,14 +13,18 @@
 # limitations under the License.
 ---
 common_rpms:
-- yum-utils
-- python2-pip
-- python-requests
+- ca-certificates
+- conntrack-tools
+- curl
 - ebtables
-- socat
-- ntp
-- jq
 - nfs-utils
+- ntp
+- open-vm-tools
+- python2-pip
+- python-netifaces
+- python-requests
+- socat
+- yum-utils
 common_extra_rpms: []
 common_debs:
 - openssh-client

--- a/images/capi/packer/ova/linux/centos/http/7/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/7/ks.cfg
@@ -15,7 +15,6 @@
 # Perform a fresh install, not an upgrade
 install
 cdrom
-url --url=http://mirror.centos.org/centos/7/os/x86_64/
 
 # Perform a text installation
 text
@@ -47,35 +46,13 @@ eula --agreed
 # Create a single partition with no swap space
 bootloader --location=mbr
 zerombr
-clearpart --all --initlabel 
+clearpart --all --initlabel
 part / --grow --asprimary --fstype=ext4 --label=slash
 
-# Include the EPEL repo in order to install python2-pip
-repo --name=epel --baseurl=http://download.fedoraproject.org/pub/epel/7/x86_64
-
 %packages --ignoremissing --excludedocs
-ca-certificates
-conntrack-tools
-curl
-ebtables
-jq
-libnetfilter_conntrack
-libnetfilter_cthelper
-libnetfilter_cttimeout
-libnetfilter_queue
-nfs-utils
-nginx
-ntp
-openssh-clients
 openssh-server
-python-netifaces
-python-requests
-python2-pip
 sed
-socat
 sudo
-vim
-yum-utils
 
 # Remove unnecessary firmware
 -*-firmware


### PR DESCRIPTION
This patch changes the ova centos kickstart to only install packages
from the cdrom/iso. We are already relying on Ansible as a follow-on
provisioner to install required packages after the OS is installed, so
these steps aren't really necessary. There was also a good bit of
overlap where the Ansible tasks were installing packages that were
listed in the kickstart -- this just leaves it to Ansible.

This makes building in enterprise environments w/o internet access
simpler as well.