### PR TITLE
OVA: Make ubuntu preseed not rely on internet

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -25,15 +25,28 @@ common_rpms:
 - python-requests
 - socat
 - yum-utils
+
 common_debs:
-- openssh-client
-- openssh-server
 - apt-transport-https
+- conntrack
+- conntrackd
+- curl
 - ebtables
-- socat
-- ntp
 - jq
-- nfs-client
+- gnupg
+- libnetfilter-acct1
+- libnetfilter-cttimeout1
+- libnetfilter-log1
+- linux-cloud-tools-virtual
+- linux-tools-virtual
+- nfs-common
+- ntp
+- open-vm-tools
+- python3-distutils
+- python3-netifaces
+- python3-pip
+- socat
+
 common_photon_rpms:
 - conntrack-tools
 - distrib-compat

--- a/images/capi/ansible/roles/common/tasks/debian.yml
+++ b/images/capi/ansible/roles/common/tasks/debian.yml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+- name: Put templated sources.list in place
+  template:
+    src: etc/apt/sources.list.j2
+    dest: /etc/apt/sources.list
+
 - name: Find existing repo files
   find:
     depth: 1
@@ -38,7 +43,6 @@
   apt:
     force_apt_get: True
     update_cache: True
-    cache_valid_time: 3600
 
 - name: perform a dist-upgrade
   apt:

--- a/images/capi/ansible/roles/common/templates/etc/apt/sources.list.j2
+++ b/images/capi/ansible/roles/common/templates/etc/apt/sources.list.j2
@@ -1,0 +1,4 @@
+deb http://us.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} main restricted universe
+deb http://us.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-updates main restricted universe
+deb http://us.archive.ubuntu.com/ubuntu {{ ansible_distribution_release }}-backports main restricted universe
+deb http://security.ubuntu.com/ubuntu {{ ansible_distribution_release }}-security main restricted universe

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -90,37 +90,15 @@ d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 d-i pkgsel/update-policy select none
 
-# Select the apt mirror.
-d-i mirror/country string manual
-d-i mirror/http/hostname string us.archive.ubuntu.com
-d-i mirror/http/directory string /ubuntu
-d-i mirror/http/proxy string
+# Disable use of the apt mirror during base install
+# This means only packages available in the ISO can be installed
+d-i apt-setup/use_mirror boolean false
+
+# Disable the security repo as well (it's on by default)
+d-i apt-setup/services-select multiselect none
 
 # Customize the list of packages installed.
-d-i pkgsel/include string apt-transport-https \
-                          curl \
-                          ebtables \
-                          gnupg gnupg1 gnupg2 \
-                          jq \
-                          linux-cloud-tools-virtual \
-                          linux-tools-virtual \
-                          open-vm-tools \
-                          openssh-client openssh-server \
-                          conntrack conntrackd \
-                          libnetfilter-acct1 \
-                          libnetfilter-conntrack3 \
-                          libnetfilter-cthelper0 \
-                          libnetfilter-cttimeout1 \
-                          libnetfilter-log1 \
-                          libnetfilter-queue1 \
-                          nfs-client \
-                          ntp \
-                          python3-distutils \
-                          python3-netifaces \
-                          python3-pip \
-                          sed \
-                          socat \
-                          vim
+d-i pkgsel/include string openssh-server
 
 
 # Ensure questions about these packages do not bother the installer.
@@ -144,8 +122,4 @@ d-i preseed/late_command string \
     in-target swapoff -a ; \
     in-target rm -f /swapfile ; \
     in-target sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab ; \
-    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules ;
-    #in-target ln -s /dev/null /etc/udev/rules.d/70-persistent-net.rules
-    #in-target apt-get -y autoremove --purge
-    #in-target apt-get -y clean
-    #in-target rm -fr /var/lib/apt/lists/*
+    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules


### PR DESCRIPTION
This patch changes the ova ubuntu preseed to only install packages
from the cdrom/iso. We are already relying on Ansible as a follow-on
provisioner to install required packages after the OS is installed, so
these steps aren't really necessary. There was also a good bit of
overlap where the Ansible tasks were installing packages that were
listed in the kickstart -- this just leaves it to Ansible.

This makes building in enterprise environments w/o internet access
simpler as well.

This is the Ubuntu flavor of #45.

/assign @detiber 

I've again left nginx out. If that's needed I can add it back.