### PR TITLE
[capi] Rev versions

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -52,7 +52,7 @@
         "owners": ["099720109477"],
         "most_recent": true
       },
-      "ami_name": "capa-ami-ubuntu-18.04-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
+      "ami_name": "capa-ami-ubuntu-18.04-{{user `kubernetes_deb_version`}}-{{user `build_timestamp`}}",
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
@@ -91,7 +91,7 @@
         "owners": ["410186602215"],
         "most_recent": true
       },
-      "ami_name": "capa-ami-centos-7-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
+      "ami_name": "capa-ami-centos-7-{{user `kubernetes_deb_version`}}-{{user `build_timestamp`}}",
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
@@ -131,7 +131,7 @@
         "owners": ["amazon"],
         "most_recent": true
       },
-      "ami_name": "capa-ami-amazon-2-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
+      "ami_name": "capa-ami-amazon-2-{{user `kubernetes_deb_version`}}-{{user `build_timestamp`}}",
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,4 +1,4 @@
 {
-    "containerd_version": "1.2.8",
-    "containerd_sha256": "1f2f0fb928179df90492a83c326a194b8e9d992538498efb44cbb6ef15465627"
+    "containerd_version": "1.2.9",
+    "containerd_sha256": "a1e8d3f6427f3146d8a3cce7a5d5fd55db0365697ece91506f74d116bdf0dff3"
 }

--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
   "kubernetes_series": "v1.15",
-  "kubernetes_semver": "v1.15.3",
-  "kubernetes_rpm_version": "1.15.3-0",
-  "kubernetes_deb_version": "1.15.3-00",
+  "kubernetes_semver": "v1.15.4",
+  "kubernetes_rpm_version": "1.15.4-0",
+  "kubernetes_deb_version": "1.15.4-00",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",


### PR DESCRIPTION
- Update containerd to v1.2.9
- Update kubernetes to v1.15.4
- Fix image naming for CAPI AMIs