### PR TITLE
Only download k8s images from http when user want

### DIFF
--- a/images/capi/ansible/roles/kubernetes/defaults/main.yml
+++ b/images/capi/ansible/roles/kubernetes/defaults/main.yml
@@ -24,3 +24,6 @@ kubernetes_imgs:
 - kube-controller-manager.tar
 - kube-scheduler.tar
 - kube-proxy.tar
+- pause.tar
+- coredns.tar
+- etcd.tar

--- a/images/capi/ansible/roles/kubernetes/tasks/kubeadmpull.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/kubeadmpull.yml
@@ -1,0 +1,12 @@
+- name: Create kubeadm config file
+  template:
+    dest: /etc/kubeadm.yml
+    src: etc/kubeadm.yml
+
+- name: Kubeadm pull images
+  shell: 'kubeadm config images pull --config /etc/kubeadm.yml'
+
+- name: delete kubeadm config
+  file:
+    path: /etc/kubeadm.yml
+    state: absent

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -31,15 +31,5 @@
     dest: /etc/kubernetes-version
     src: etc/kubernetes-version
 
-- name: Create kubeadm config file
-  template:
-    dest: /etc/kubeadm.yml
-    src: etc/kubeadm.yml
-
-- name: Kubeadm pull images
-  shell: 'kubeadm config images pull --config /etc/kubeadm.yml'
-
-- name: delete kubeadm config
-  file:
-    path: /etc/kubeadm.yml
-    state: absent
+- import_tasks: kubeadmpull.yml
+  when: kubernetes_source_type == "pkg"


### PR DESCRIPTION
When user set kubernetes_source_type != pkg,
it will download kubernetes binaries and container through
http site, it will not pull through "kubeadm config images pull"
(which is pulling from container registry) anymore.

Signed-off-by: Hui Luo <luoh@vmware.com>


cc @akutz @jiatongw @frapposelli 