### PR TITLE
OVA: parameterize network name

### DIFF
--- a/images/capi/packer/ova/esx.json
+++ b/images/capi/packer/ova/esx.json
@@ -1,6 +1,7 @@
 {
     "disk_type_id": "thin",
     "format": "ova",
+    "network": "VM Network",
     "remote_type": "esx5",
     "remote_host": "",
     "remote_datastore": "",

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -28,6 +28,7 @@
     "kubernetes_deb_gpg_key": null,
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
+    "network": "",
     "reenable_public_repos": "true",
     "remove_extra_repos": "false",
     "remote_type": "",
@@ -83,7 +84,7 @@
       "vnc_disable_password": "{{user `vnc_disable_password`}}",
       "format": "{{user `format`}}",
       "vmx_data": {
-        "ethernet0.networkName": "VM Network"
+        "ethernet0.networkName": "{{user `network`}}"	
       }
     }
   ],


### PR DESCRIPTION
A recent commit hardcoded the network name to "VM Network". This
appears to work fine when building with Fusion, but if building
Workstation and that network is not found, there is no network connected
and the VM fails to boot.

Rather than hardcoding the `vmx_data` field, we can just set `network`
instead, and go back to the default value of "". Then this can be
overridden if a user needs to use a specific network by name.

/hold
/assign @jiatongw 

Jiatong, I need your help testing this to see if it still meets your needs for building on remote ESX hosts. I found that after your patch went in, I could still build locally with Fusion, but building on Linux hosts with WorkStation failed. I tracked it down to this. This patch changes it back to the previous default behavior, but should still allow you to set what ever network name you need in `esx.json`.