### PR TITLE
Fix vmx_data field to make build on linux host work

### DIFF
--- a/images/capi/packer/ova/esx.json
+++ b/images/capi/packer/ova/esx.json
@@ -8,5 +8,8 @@
     "remote_password": "",
     "skip_compaction": "true",
     "vnc_bind_address": "",
-    "vnc_disable_password": "true"
+    "vnc_disable_password": "true",
+    "vmx_data": {
+        "ethernet0.networkname": "VM Network"
+    }
 }

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -83,7 +83,7 @@
       "vnc_disable_password": "{{user `vnc_disable_password`}}",
       "format": "{{user `format`}}",
       "vmx_data": {
-        "ethernet0.networkName": "VM Network"
+        "ethernet0.networkname": "{{user `ethernet0.networkname`}}"
       }
     }
   ],


### PR DESCRIPTION
Thanks to @codenrhoden to find this error: A previous commit hardcoded the network name to "VM Network". This work fine when building with Fusion, but not with Workstation. 

This PR #61 doesn't work on ESX host so I made this patch.
This patch fix the building failure with workstation in linux host. I tested locally with Fusion, in linux host with Workstation and remotely with ESX host and they all worked. Could you please double check @codenrhoden ?