### PR TITLE
Add OWNERS file to images/capi

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  cluster-api-admins:
+    - justinsb
+    - detiber
+    - davidewatson
+    - vincepri
+    - ncdc

--- a/images/capi/OWNERS
+++ b/images/capi/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-admins


### PR DESCRIPTION
Adds the Cluster API admins as approvers to the subfolder