### PR TITLE
chore: stop and disable rpcbind{service,socket}

### DIFF
--- a/images/capi/ansible/roles/common/tasks/debian.yml
+++ b/images/capi/ansible/roles/common/tasks/debian.yml
@@ -63,3 +63,15 @@
     name: "{{ common_pinned_debs }}"
     state: present
     force: yes
+
+- name: Stop and disable rpcbind.service
+  service:
+    name: rpcbind
+    state: stopped
+    enabled: no
+
+- name: Stop and disable rpcbind.socket
+  service:
+    name: rpcbind.socket
+    state: stopped
+    enabled: no


### PR DESCRIPTION
We noticed this was running during an internal security scan - 111 Portmapper. 

We were using `capa-ami-ubuntu-18.04-*` AMIs. 