### PR TITLE
fix AMI names for CAPI AMI image build

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -53,7 +53,7 @@
         "owners": ["099720109477"],
         "most_recent": true
       },
-      "ami_name": "capa-ami-ubuntu-18.04-{{user `kubernetes_deb_version`}}-{{user `build_timestamp`}}",
+      "ami_name": "capa-ami-ubuntu-18.04-{{user `kubernetes_deb_version` | clean_resource_name}}-{{user `build_timestamp`}}",
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
@@ -93,7 +93,7 @@
         "owners": ["410186602215"],
         "most_recent": true
       },
-      "ami_name": "capa-ami-centos-7-{{user `kubernetes_deb_version`}}-{{user `build_timestamp`}}",
+      "ami_name": "capa-ami-centos-7-{{user `kubernetes_deb_version` | clean_resource_name}}-{{user `build_timestamp`}}",
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
@@ -134,7 +134,7 @@
         "owners": ["amazon"],
         "most_recent": true
       },
-      "ami_name": "capa-ami-amazon-2-{{user `kubernetes_deb_version`}}-{{user `build_timestamp`}}",
+      "ami_name": "capa-ami-amazon-2-{{user `kubernetes_deb_version` | clean_resource_name}}-{{user `build_timestamp`}}",
       "ami_groups": "{{user `ami_groups`}}",
       "ami_users": "{{user `ami_users`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",


### PR DESCRIPTION
This PR makes 2 fixes to the AMI names for the CAPI AMI image build:

1. Currently, the name of the AMI for Ubuntu, CentOS and Amazon Linux 2 are taken from `kubernetes_deb_version` variable.  If a user is only building CentOS and/or Amazon Linux 2, the name of the deb version is not relevant. This updates the CentOS and Amazon Linux images to use the `kubernetes_rpm_version`.

2. If the `kubernetes_rpm_version` or `kubernetes_rpm_version` containers an invalid AMI character like a `+`, packer will error. One use case for this is the VMware binaries. This PR uses packer's `clean_resource_name` which will replace invalid character with a `-`.