### PR TITLE
Bump Containerd version to 1.3.0

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,4 +1,4 @@
 {
-    "containerd_version": "1.2.9",
-    "containerd_sha256": "a1e8d3f6427f3146d8a3cce7a5d5fd55db0365697ece91506f74d116bdf0dff3"
+    "containerd_version": "1.3.0",
+    "containerd_sha256": "47653ab55b58668ce93704e47b727b41f57d296e4048d6860daf55d6b7c2bf18"
 }


### PR DESCRIPTION
Fix for https://github.com/opencontainers/runc/issues/1884
is in https://github.com/opencontainers/runc/pull/1916

- problem described in 1884 is independent of kubernetes version.
- happens with kernel >= v4.8
- fixed in runc version v1.0.0-rc6 and above ( https://github.com/opencontainers/runc/pull/1916/commits/9a3a8a5ebf58234d12d5120f3a377c39256120d6 )
- which got pulled into containerd v1.3.0-beta.0 and above ( https://github.com/containerd/containerd/commit/97dd5df66fb70cf3ec0c6e4bdb17f01d1d6936d9#diff-4061fcef378a6d912e14e2ce162a1995)