### PR TITLE
Add gsutil to GCE based images

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/googlecompute.yml
+++ b/images/capi/ansible/roles/providers/tasks/googlecompute.yml
@@ -1,0 +1,39 @@
+# Copyright 2019 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Download gcloud SDK
+  get_url:
+    url:  https://sdk.cloud.google.com/
+    dest: /tmp/install-gcloud.sh
+
+- name: Execute install-gcloud.sh
+  shell: bash -o errexit -o pipefail /tmp/install-gcloud.sh --disable-prompts --install-dir=/
+
+- name: Remove install-gcloud.sh
+  file:
+    path:  /tmp/install-gcloud.sh
+    state: absent
+
+- name: Find all files in /google-cloud-sdk/bin/
+  find:
+    paths: /google-cloud-sdk/bin/
+  register: find
+
+- name: Create symlinks to /bin
+  become: True
+  file:
+    src: "{{ item.path }}"
+    path: "/bin/{{ item.path | basename }}"
+    state: link
+  with_items: "{{ find.files }}"

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -17,3 +17,6 @@
 
 - include_tasks: vmware.yml
   when: packer_builder_type | search('vmware')
+
+- include_tasks: googlecompute.yml
+  when: packer_builder_type.startswith('googlecompute')


### PR DESCRIPTION
Adding `gsutil` will help help us with the CI testing scenarios where we have to pull debs and container images from GCS buckets

Once this is in, we can remove the code in CAPG that downloads this utility.

Please see how we download/use it in CAPG:
https://cs.k8s.io/?q=gsutil&i=nope&files=.*%5C.yaml&repos=kubernetes-sigs/cluster-api-provider-gcp