### PR TITLE
Lock default user before shutdown OVA VM

### DIFF
--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -74,7 +74,7 @@
         "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
         "{{user `boot_command_suffix`}}"
       ],
-      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E {{user `shutdown_command`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
       "skip_compaction": "{{user `skip_compaction`}}",
       "vnc_bind_address": "{{user `vnc_bind_address`}}",
       "vnc_port_min": "{{user `vnc_port_min`}}",


### PR DESCRIPTION
Although cloud-init will lock default user, but cloud-init configure
can be override by user-data later.

This patch is to lock default user within OS, not through cloud-init.

Signed-off-by: Hui Luo <luoh@vmware.com>

cc @akutz @andrewsykim @jiatongw @detiber @frapposelli 