### PR TITLE
🏃Bump Kubernetes version to 16.2 in packer config

### DIFF
--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
-  "kubernetes_series": "v1.15",
-  "kubernetes_semver": "v1.15.4",
-  "kubernetes_rpm_version": "1.15.4-0",
-  "kubernetes_deb_version": "1.15.4-00",
+  "kubernetes_series": "v1.16",
+  "kubernetes_semver": "v1.16.2",
+  "kubernetes_rpm_version": "1.16.2-0",
+  "kubernetes_deb_version": "1.16.2-00",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",


### PR DESCRIPTION

**What this PR does / why we need it**:
Change the version Kubernetes to `16.1` in the packer config used when building `capi` images to be compatible with latest images needed by providers