### PR TITLE
Fix CentOS ISO download link

### DIFF
--- a/images/capi/packer/ova/ova-centos-7.json
+++ b/images/capi/packer/ova/ova-centos-7.json
@@ -3,7 +3,7 @@
   "distro_name": "centos",
   "os_display_name": "CentOS 7",
   "guest_os_type": "centos-64",
-  "iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso",
+  "iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-Minimal-1908.iso",
   "iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
   "iso_checksum_type": "sha256",
   "ssh_username": "centos",


### PR DESCRIPTION
The new link put in place the previous day was incorrect. Despite having
tested locally, it appears that Packer looked to see if a file with the
correct checksum was in place (it was), and therefore dididn't notice
the link was wrong. It wasn't until running on a machine w/o the ISO
already downloaded the mistake was noticed.

I knew packer would skip downloading already downloaded files, I just didn't think much about *how* it does that. :)

/assign @figo 