### PR TITLE
enable ipv6 forwarding on instances

### DIFF
--- a/images/capi/ansible/roles/common/tasks/main.yml
+++ b/images/capi/ansible/roles/common/tasks/main.yml
@@ -56,6 +56,24 @@
     reload: yes
     sysctl_file: "{{ sysctl_conf_file }}"
 
+- name: Ensure net.ipv6.conf.all.forwarding sysctl is present
+  sysctl:
+    name: net.ipv6.conf.all.forwarding
+    value: "1"
+    state: present
+    sysctl_set: yes
+    reload: yes
+    sysctl_file: "{{ sysctl_conf_file }}"
+
+- name: Ensure IPv6 is enable
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: "0"
+    state: present
+    sysctl_set: yes
+    reload: yes
+    sysctl_file: "{{ sysctl_conf_file }}"
+
 - name: Ensure net.bridge.bridge-nf-call-ip6tables sysctl is present
   sysctl:
     name: net.bridge.bridge-nf-call-ip6tables


### PR DESCRIPTION
We need to enable ipv6 forwarding on instance in order to support ipv6 k8s clusters.