### PR TITLE
fix(Ansible 2.9): use search test instead of filter

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -16,7 +16,7 @@
   when: packer_builder_type.startswith('amazon') 
 
 - include_tasks: vmware.yml
-  when: packer_builder_type | search('vmware')
+  when: packer_builder_type is search('vmware')
 
 - include_tasks: googlecompute.yml
   when: packer_builder_type.startswith('googlecompute')


### PR DESCRIPTION
Fixes the capi image building with Ansible 2.9: Using Ansible-provided jinja tests as filters was removed in Ansible 2.9. https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#jinja-tests-used-as-filters