### PR TITLE
[capi] Add capz Azure pipeline yaml

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -19,34 +19,8 @@ This directory contains tooling for building base images for use as nodes in Kub
 
 ### Building Managed Images in Shared Image Galleries
 
-- Create a resource group, shared image gallery and image definition in the desired correct subscription and location.
-
-For example:
-
-```sh
-az group create -n "cluster-api-images" -l southcentralus
-az sig create --resource-group cluster-api-images --gallery-name ClusterAPI
-az sig image-definition create \
-   --resource-group cluster-api-images \
-   --gallery-name ClusterAPI \
-   --gallery-image-definition capi-ubuntu-1804 \
-   --publisher capz \
-   --offer capz-demo \
-   --sku 18.04-LTS \
-   --os-type Linux
-```
-
-- From the images/capi directory, run `make build-azure-sig-ubuntu-1804`
+From the images/capi directory, run `make build-azure-sig-ubuntu-1804`
 
 ### Building VHDs
 
-- Create a resource group and storage account in the desired correct subscription and location.
-
-For example:
-
-```sh
-az group create -n "cluster-api-images" -l southcentralus
-az storage account create -n "clusterapiimages" -g "cluster-api-images"
-```
-
-- From the images/capi directory, run `make build-azure-vhd-ubuntu-1804`
+From the images/capi directory, run `make build-azure-vhd-ubuntu-1804`

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -57,7 +57,7 @@ $(OVA_BUILD_TARGETS_ESX):
 .PHONY: $(OVA_BUILD_TARGETS_ESX)
 
 $(AZURE_BUILD_TARGETS):
-	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/$(subst build-,,$@).json)" -only="$(subst build-azure-,,$@)" packer/azure/packer.json
+	. $(abspath packer/azure/scripts/init-$(subst build-azure-,,$@).sh) && packer build $(PACKER_FLAGS) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/$(subst build-,,$@).json)" -only="$(subst build-azure-,,$@)" packer/azure/packer.json
 .PHONY: $(AZURE_BUILD_TARGETS)
 
 CLEAN_TARGETS := $(addprefix clean-,$(OVA_BUILD_NAMES))

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Kubernetes Authors.
+# Copyright 2019 The Kubernetes Authors.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- include_tasks: aws.yml
-  when: packer_builder_type.startswith('amazon') 
-
-- include_tasks: azure.yml
-  when: packer_builder_type.startswith('azure') 
-
-- include_tasks: vmware.yml
-  when: packer_builder_type is search('vmware')
-
-- include_tasks: googlecompute.yml
-  when: packer_builder_type.startswith('googlecompute')
+- name: install Azure clients
+  pip:
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - azure-cli

--- a/images/capi/packer/azure/.pipelines/devops-pipeline.yaml
+++ b/images/capi/packer/azure/.pipelines/devops-pipeline.yaml
@@ -1,0 +1,63 @@
+# Required pipeline variables:
+# - BUILD_POOL - Azure DevOps build pool to use
+# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
+# - AZURE_TENANT_ID - tenant ID
+# - AZURE_CLIENT_ID - Service principal ID
+# - AZURE_CLIENT_SECRET - Service principal secret
+# - AZURE_SUBSCRIPTION_ID - Subscription ID used by the pipeline
+# - START_DATE - start date for the storage account SAS token
+# - EXPIRY_DATE - expiry date for the for the storage account SAS token
+# - KUBERNETES_VERSION - version of Kubernetes to build the image with, e.g. `1.16.2`
+
+trigger: none
+pr: none
+
+jobs:
+- job: build_vhd_linux
+  container: $[ variables['CONTAINER_IMAGE'] ]
+  timeoutInMinutes: 120
+  strategy:
+    maxParallel: 0
+  pool:
+    name: $(BUILD_POOL)
+  steps:
+  - script: |
+      KUBERNETES_RELEASE=$(echo ${KUBERNETES_VERSION} | cut -d "." -f -2)
+      sed -i "s/.*kubernetes_series.*/  \"kubernetes_series\": \"v${KUBERNETES_RELEASE}\",/g" kubernetes.json
+      sed -i "s/.*kubernetes_semver.*/  \"kubernetes_semver\": \"v${KUBERNETES_VERSION}\",/g" kubernetes.json
+      sed -i "s/.*kubernetes_rpm_version.*/  \"kubernetes_rpm_version\": \"${KUBERNETES_VERSION}-0\",/g" kubernetes.json
+      sed -i "s/.*kubernetes_deb_version.*/  \"kubernetes_deb_version\": \"${KUBERNETES_VERSION}-00\",/g" kubernetes.json
+      cat kubernetes.json
+    displayName: Write configuration files
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/config'
+  - script: |
+      export AZURE_CLIENT_ID=$(AZURE_CLIENT_ID)
+      export AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET)
+      make build-azure-vhd-ubuntu-1804 | tee packer/azure/packer.out
+    displayName: Building VHD
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
+  - script: |
+      RESOURCE_GROUP_NAME="$(cat packer.out | grep "resource group name:" | cut -d " " -f 4)"
+      STORAGE_ACCOUNT_NAME=$(cat packer.out | grep "storage name:" | cut -d " " -f 3)
+      OS_DISK_URI=$(cat packer.out | grep "OSDiskUri:" | cut -d " " -f 2)
+      printf "COPY ME ----> ${OS_DISK_URI}?" | tee vhd-url.out
+      az login --service-principal -u $(AZURE_CLIENT_ID) -p $(AZURE_CLIENT_SECRET) --tenant ${AZURE_TENANT_ID}
+      az account set -s ${AZURE_SUBSCRIPTION_ID}
+      ACCOUNT_KEY=$(az storage account keys list -g ${RESOURCE_GROUP_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --account-name ${STORAGE_ACCOUNT_NAME} --query '[0].value')
+      az storage container generate-sas --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start ${START_DATE} --expiry ${EXPIRY_DATE} | tr -d '\"' | tee -a vhd-url.out
+    displayName: Getting OS VHD URL
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/azure'
+    condition: eq(variables.CLEANUP, 'False')
+  - script: |
+      RESOURCE_GROUP_NAME="$(cat packer.out | grep "resource group name:" | cut -d " " -f 4)"
+      STORAGE_ACCOUNT_NAME="$(cat packer.out | grep "storage name:" | cut -d " " -f 3)"
+      az login --service-principal -u $(AZURE_CLIENT_ID) -p $(AZURE_CLIENT_SECRET) --tenant ${AZURE_TENANT_ID}
+      az account set -s ${AZURE_SUBSCRIPTION_ID}
+      az storage account delete -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} --yes
+    displayName: cleanup - delete storage account
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/azure'
+    condition: eq(variables.CLEANUP, 'True')
+  - script: |
+      chown -R $USER:$USER .
+    displayName: cleanup - chown all files in work directory 
+    condition: always()

--- a/images/capi/packer/azure/azure-config.json
+++ b/images/capi/packer/azure/azure-config.json
@@ -1,5 +1,5 @@
 {
-  "azure_location": "southcentralus",
+  "azure_location": "{{env `AZURE_LOCATION`}}",
   "vm_size": "Standard_B2ms",
   "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
   "client_id": "{{env `AZURE_CLIENT_ID`}}",

--- a/images/capi/packer/azure/azure-sig-ubuntu-1804.json
+++ b/images/capi/packer/azure/azure-sig-ubuntu-1804.json
@@ -1,7 +1,7 @@
 {
-    "resource_group_name": "cluster-api-images",
-    "shared_image_gallery_name": "ClusterAPI",
-    "replication_regions": "southcentralus",
+    "resource_group_name": "{{env `RESOURCE_GROUP_NAME`}}",
+    "shared_image_gallery_name": "{{env `GALLERY_NAME`}}",
+    "replication_regions": "{{env `AZURE_LOCATION`}}",
     "image_name": "capi-ubuntu-1804"
   }
   

--- a/images/capi/packer/azure/azure-vhd-ubuntu-1804.json
+++ b/images/capi/packer/azure/azure-vhd-ubuntu-1804.json
@@ -1,6 +1,6 @@
 {
-    "resource_group_name": "cluster-api-images",
-    "storage_account_name": "clusterapiimages",
+    "resource_group_name": "{{env `RESOURCE_GROUP_NAME`}}",
+    "storage_account_name": "{{env `STORAGE_ACCOUNT_NAME`}}",
     "capture_container_name": "cluster-api-vhds"
   }
   

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -3,7 +3,7 @@
     "subscription_id": null,
     "client_id": null,
     "client_secret": null,
-    "azure_location": "",
+    "azure_location": null,
     "vm_size": "",
     "build_timestamp": "{{timestamp}}",
     "containerd_version": null,
@@ -45,7 +45,7 @@
       "capture_name_prefix": "capi-{{user `build_timestamp`}}",
       "storage_account": "{{user `storage_account_name`}}",
       "location": "{{user `azure_location`}}",
-      "ssh_username": "ubuntu",
+      "ssh_username": "packer",
       "azure_tags": {
         "build_timestamp": "{{user `build_timestamp`}}",
         "distribution": "ubuntu",
@@ -77,7 +77,7 @@
         ]
       },
       "location": "{{user `azure_location`}}",
-      "ssh_username": "ubuntu",
+      "ssh_username": "packer",
       "azure_tags": {
         "build_timestamp": "{{user `build_timestamp`}}",
         "distribution": "ubuntu",
@@ -98,6 +98,7 @@
     {
       "type": "ansible",
       "playbook_file": "./ansible/playbook.yml",
+      "user": "packer",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
         "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"

--- a/images/capi/packer/azure/scripts/init-sig-ubuntu-1804.sh
+++ b/images/capi/packer/azure/scripts/init-sig-ubuntu-1804.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+az account set -s ${AZURE_SUBSCRIPTION_ID}
+export RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-cluster-api-images}"
+export AZURE_LOCATION="${AZURE_LOCATION:-southcentralus}"
+az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION}
+echo "resource group name: ${RESOURCE_GROUP_NAME}"
+export GALLERY_NAME="${GALLERY_NAME:-ClusterAPI}"
+az sig create --resource-group ${RESOURCE_GROUP_NAME} --gallery-name ${GALLERY_NAME}
+az sig image-definition create \
+   --resource-group ${RESOURCE_GROUP_NAME} \
+   --gallery-name ClusterAPI \
+   --gallery-image-definition capi-ubuntu-1804 \
+   --publisher capz \
+   --offer capz-demo \
+   --sku 18.04-LTS \
+   --os-type Linux

--- a/images/capi/packer/azure/scripts/init-vhd-ubuntu-1804.sh
+++ b/images/capi/packer/azure/scripts/init-vhd-ubuntu-1804.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+az account set -s ${AZURE_SUBSCRIPTION_ID}
+export RESOURCE_GROUP_NAME=cluster-api-images
+export AZURE_LOCATION="${AZURE_LOCATION:-southcentralus}"
+az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION}
+echo "resource group name: ${RESOURCE_GROUP_NAME}"
+CREATE_TIME="$(date +%s)"
+export STORAGE_ACCOUNT_NAME="capi${CREATE_TIME}"
+az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME}
+echo "storage name: ${STORAGE_ACCOUNT_NAME}"


### PR DESCRIPTION
Add yaml template to automate building images for cluster-api-provider-azure. Also automated the prerequisites and put them in a startup script that is run as part of the make targets for capz. The yaml takes environment variables and can be reused by anyone with their own subscription and credentials.

cc @devigned 