### PR TITLE
remove kubeadm patch for cloud-init

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -37,16 +37,9 @@
   when: ansible_os_family == "RedHat"
 
 - name: Install cloud-init and tools for VMware Photon OS
-  block:
-    - name: Install cloud-init packages
-      command: tdnf install {{ packages }} -y
-      vars:
-        packages: "cloud-init cloud-utils python3-netifaces"
-    - name: copy cloud-init 19.1-2 rpm
-      command: curl -LO https://vmware.bintray.com/photon_dev_x86_64/noarch/cloud-init-19.1-2.ph3.noarch.rpm
-
-    - name: Update cloud-init to 19.1-2.ph3
-      command: rpm -Uvh ./cloud-init-19.1-2.ph3.noarch.rpm
+  command: tdnf install {{ packages }} -y
+  vars:
+    packages: "cloud-init cloud-utils python3-netifaces"
   when: ansible_os_family == "VMware Photon OS"
 
 - name: Download cloud-init datasource for VMware Guestinfo


### PR DESCRIPTION
capv deployments do not rely on kubeadm cloud-init module anymore. as a result, the kubeadm patch for photon cloud-init is not required. removing it.