### PR TITLE
Support custom cloud-init DS for VMware GuestInfo

### DIFF
--- a/images/capi/.gitignore
+++ b/images/capi/.gitignore
@@ -1,3 +1,4 @@
+/guestinfo-datasource.json
 /capv-image-uploader.json
 /packer_cache/
 /output-*/

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -29,7 +29,7 @@ AZURE_BUILD_NAMES ?= azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804
 KUBE_JSON ?= packer/config/kubernetes.json packer/config/cni.json packer/config/containerd.json
 
 # The flags to give to Packer.
-PACKER_VAR_FILES := $(KUBE_JSON)
+PACKER_VAR_FILES += $(KUBE_JSON)
 OLD_PACKER_FLAGS := $(PACKER_FLAGS)
 PACKER_FLAGS := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" )
 PACKER_FLAGS += $(OLD_PACKER_FLAGS)

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -49,6 +49,9 @@
 
 - name: Execute cloud-init-vmware.sh
   shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh
+  environment:
+    REPO_SLUG: '{{ guestinfo_datasource_slug }}'
+    GIT_REF:   '{{ guestinfo_datasource_ref }}'
 
 - name: Remove cloud-init-vmware.sh
   file:

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -11,6 +11,8 @@
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "extra_repos": "",
     "format": "",
+    "guestinfo_datasource_slug": "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo",
+    "guestinfo_datasource_ref": "master",
     "headless": "true",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
@@ -101,7 +103,7 @@
       ],
       "extra_arguments": [
         "--extra-vars",
-        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} disable_public_repos={{user `disable_public_repos`}} extra_repos={{user `extra_repos`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} reenable_public_repos={{user `reenable_public_repos`}} remove_extra_repos={{user `remove_extra_repos`}}"
+        "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} disable_public_repos={{user `disable_public_repos`}} extra_repos={{user `extra_repos`}} guestinfo_datasource_slug={{user `guestinfo_datasource_slug`}} guestinfo_datasource_ref={{user `guestinfo_datasource_ref`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} reenable_public_repos={{user `reenable_public_repos`}} remove_extra_repos={{user `remove_extra_repos`}}"
       ]
     }
   ],


### PR DESCRIPTION
This patch adds the ability to build machine images using a custom cloud-init datasource for VMware GuestInfo by specifying a different GitHub slug and ref to use. For example, take the following file:

```json
{
  "guestinfo_datasource_slug": "https://raw.githubusercontent.com/akutz/cloud-init-vmware-guestinfo",
  "guestinfo_datasource_ref": "feature/cleanup-userdata"
}
```

If the above file is saved as `guestinfo.json`, the following command could be used to build an Ubuntu machine image with the custom datasource:

```shell
PACKER_VAR_FILES=guestinfo.json make build-ova-ubuntu-1804
```

FYI, this was tested at https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/582#issuecomment-563020529 with https://github.com/vmware/cloud-init-vmware-guestinfo/pull/25.

cc @codenrhoden @figo