### PR TITLE
Remove nginx from all OVA images

### DIFF
--- a/images/capi/packer/ova/linux/centos/http/7/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/7/ks.cfg
@@ -62,7 +62,7 @@ sudo
 %end
 
 # Enable/disable the following services
-services --disabled=nginx --enabled=sshd
+services --enabled=sshd
 
 # Perform a reboot once the installation has completed
 reboot

--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -21,7 +21,6 @@
       "libnetfilter_cttimeout",
       "libnetfilter_queue",
       "nfs-utils",
-      "nginx",
       "ntp",
       "openssh-clients",
       "openssh-server",
@@ -38,7 +37,6 @@
     "postinstall": [
                     "#!/bin/sh",
                     "useradd -U --groups  wheel photon && echo 'photon:photon' | chpasswd",
-                    "systemctl disable nginx",
                     "systemctl enable sshd",
                     "echo 'photon ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/photon",
                     "chmod 440 /etc/sudoers.d/photon",

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -138,16 +138,13 @@ libssl1.1:amd64 libssl1.1/restart-services string
 # 5. Disables swapfiles
 # 6. Removes the existing swapfile
 # 7. Removes the swapfile entry from /etc/fstab
-# 8. Install and disable nginx
 d-i preseed/late_command string \
     echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' >/target/etc/sudoers.d/ubuntu ; \
     in-target chmod 440 /etc/sudoers.d/ubuntu ; \
     in-target swapoff -a ; \
     in-target rm -f /swapfile ; \
     in-target sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab ; \
-    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules ; \
-    apt-install nginx ; \
-    in-target systemctl disable nginx
+    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules ;
     #in-target ln -s /dev/null /etc/udev/rules.d/70-persistent-net.rules
     #in-target apt-get -y autoremove --purge
     #in-target apt-get -y clean


### PR DESCRIPTION
nginx had already been removed from install in the CentOS image, but
a reference to disabling the service mistaken remained in the CentOS
kickstart. This patch fixes that, and removes nginx completely from the
Photon and Ubuntu images as well.

fixes #91 