### PR TITLE
Start containerd ALAP with respect to cloud-init's boot stages

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -39,6 +39,21 @@
     extra_opts:
       - --no-overwrite-dir
 
+- name: Creates unit file directory
+  file:
+    path: /etc/systemd/system/containerd.service.d
+    state: directory
+
+- name: Create containerd boot order drop in file
+  template:
+    dest: /etc/systemd/system/containerd.service.d/boot-order.conf
+    src: etc/systemd/system/containerd.service.d/boot-order.conf
+    
+- name: Create containerd memory pressure drop in file
+  template:
+    dest: /etc/systemd/system/containerd.service.d/memory-pressure.conf
+    src: etc/systemd/system/containerd.service.d/memory-pressure.conf
+
 - name: start containerd service
   systemd:
     name: containerd

--- a/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
+++ b/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
@@ -1,0 +1,25 @@
+[Unit]
+# Start containerd as late as possible with respect to cloud-init's
+# boot stages. This ensures that cloud-init modules such as
+# write-files may be used to configure containerd prior to it
+# starting.
+#
+# Please see the following link for more information about the
+# cloud-init boot stage managed by the cloud-config.service:
+# https://cloudinit.readthedocs.io/en/latest/topics/boot.html#config
+
+# Ensure containerd is started before the cloud-init boot stage
+# that executes the runcmd module. This module is responsible
+# for running "kubeadm init", and thus containerd must be
+# started before this command is processed.
+#
+# Please see the following link for more information about the
+# cloud-init boot stage managed by the cloud-final.service:
+# https://cloudinit.readthedocs.io/en/latest/topics/boot.html#final
+After=cloud-config.service
+Before=cloud-final.service
+
+[Install]
+Wants=cloud-config.service
+WantedBy=cloud-final.service
+

--- a/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/memory-pressure.conf
+++ b/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/memory-pressure.conf
@@ -1,0 +1,8 @@
+[Service]
+# Decreases the likelihood that containerd is killed due to memory
+# pressure.
+#
+# Please see the following link for more information about the
+# OOMScoreAdjust configuration property:
+# https://www.freedesktop.org/software/systemd/man/systemd.exec.html#OOMScoreAdjust=
+OOMScoreAdjust=-999


### PR DESCRIPTION
Add drop in unit configure file for containerd, Start
containerd as late as possible with respect to cloud-init's
boot stages. This ensures that cloud-init modules such as
write-files may be used to configure containerd prior to it
starting

Tested with change.
Run `systemd-analyze critical-chain`, got 
```
multi-user.target @47.324s
`-vmtoolsd.service @47.324s
  `-cloud-final.service @4.645s +42.677s
    `-containerd.service @4.642s +1ms
      `-cloud-config.service @4.224s +417ms
        `-network-online.target @4.224s
          `-cloud-init.service @3.456s +765ms
            `-systemd-networkd-wait-online.service @1.767s +1.688s
              `-systemd-networkd.service @1.756s +10ms
                `-network-pre.target @1.756s
                  `-cloud-init-local.service @420ms +1.335s
                    `-basic.target @412ms
```
Run `systemctl show containerd.service`
make sure, service settings exist

Signed-off-by: Hui Luo <luoh@vmware.com>

Thanks to @akutz @detiber for the great help.


This is to fix #1714
