### PR TITLE
containerd: Required by cloud-config instead of cloud-final

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
+++ b/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
@@ -16,10 +16,10 @@
 # Please see the following link for more information about the
 # cloud-init boot stage managed by the cloud-final.service:
 # https://cloudinit.readthedocs.io/en/latest/topics/boot.html#final
-After=cloud-config.service
-Before=cloud-final.service
+After=cloud-init.service
+Before=cloud-config.service
 
 [Install]
-Wants=cloud-config.service
-WantedBy=cloud-final.service
+Wants=cloud-init.service
+WantedBy=cloud-config.service
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/1714#issuecomment-571110030 
Critical chain becomes:

```
cloud-final.service +461ms
└─cloud-config.service @4.999s +638ms
  └─containerd.service @4.941s +9ms
    └─cloud-init.service @4.055s +875ms
      └─network.service @1.848s +2.201s
        └─network-pre.target @1.847s
          └─cloud-init-local.service @1.099s +748ms
            └─basic.target @1.042s
              └─sockets.target @1.042s
                └─dbus.socket @1.041s
                  └─sysinit.target @923ms
                    └─systemd-update-utmp.service @910ms +12ms
                      └─systemd-tmpfiles-setup.service @828ms +15ms
                        └─local-fs.target @821ms
                          └─local-fs-pre.target @820ms
                            └─lvm2-monitor.service @305ms +514ms
                              └─lvm2-lvmetad.service @399ms
                                └─lvm2-lvmetad.socket @274ms
                                  └─-.slice
```