### PR TITLE
Adding Ubuntu 20.04 LTS daily builds

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -19,10 +19,10 @@ all: build
 
 # A list of the supported distribution/version combinations. Each member
 # of *_BUILD_NAMES must have a corresponding file "config/*_BUILD_NAME.json".
-OVA_BUILD_NAMES ?= ova-centos-7 ova-ubuntu-1804 ova-photon-3
+OVA_BUILD_NAMES ?= ova-centos-7 ova-ubuntu-1804 ova-ubuntu-2004 ova-photon-3
 AMI_BUILD_NAMES ?= ami-default
 GCE_BUILD_NAMES ?= gce-default
-OVA_BUILD_NAMES_ESX ?= esx-ova-centos-7 esx-ova-ubuntu-1804
+OVA_BUILD_NAMES_ESX ?= esx-ova-centos-7 esx-ova-ubuntu-1804 esx-ova-ubuntu-2004
 AZURE_BUILD_NAMES ?= azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804
 
 # The version of Kubernetes to install.

--- a/images/capi/packer/ova/linux/ubuntu/http/20.04/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/20.04/preseed.cfg
@@ -1,0 +1,15 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+d-i preseed/include string ../base/preseed.cfg

--- a/images/capi/packer/ova/ova-ubuntu-2004.json
+++ b/images/capi/packer/ova/ova-ubuntu-2004.json
@@ -1,0 +1,14 @@
+{
+  "build_name": "ubuntu-2004",
+  "distro_name": "ubuntu",
+  "os_display_name": "Ubuntu 20.04",
+  "guest_os_type": "ubuntu-64",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-server/daily/20200107/focal-server-amd64.iso",
+  "iso_checksum": "4901eeba3ffaa56b9356bb496d161ade5bd1e2df579552aa6c40f33984a34614",
+  "iso_checksum_type": "sha256",
+  "ssh_username": "ubuntu",
+  "ssh_password": "ubuntu",
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
+  "boot_command_suffix": "/20.04/preseed.cfg -- <wait><enter><wait>",
+  "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
This patch is for providing the ability to do early validation testing against a daily build of Ubuntu 20.04 LTS.