### PR TITLE
Support for CentOS 8

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -58,7 +58,7 @@ PACKER_FLAGS := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" ) \
 ## --------------------------------------
 ## Platform and version combinations
 ## --------------------------------------
-CENTOS_VERSIONS			:=	centos-7
+CENTOS_VERSIONS			:=	centos-7 centos-8
 PHOTON_VERSIONS			:=	photon-3
 UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004
 
@@ -114,11 +114,13 @@ $(OVA_CLEAN_TARGETS):
 ## Documented targets
 ## --------------------------------------
 build-ova-centos-7: ## Builds CentOS 7 OVA w local hypervisor
+build-ova-centos-8: ## Builds CentOS 8 OVA w local hypervisor
 build-ova-photon-3: ## Builds Photon 3 OVA w local hypervisor
 build-ova-ubuntu-1804: ## Builds Ubuntu 18.04 OVA w local hypervisor
 build-ova-ubuntu-2004: ## Builds Ubuntu 20.04 OVA w local hypervisor
 
 build-esx-centos-7: ## Builds CentOS 7 OVA w remote hypervisor
+build-esx-centos-8: ## Builds CentOS 8 OVA w remote hypervisor
 build-esx-photon-3: ## Builds Photon 3 OVA w remote hypervisor
 build-esx-ubuntu-1804: ## Builds Ubuntu 18.04 OVA w remote hypervisor
 build-esx-ubuntu-2004: ## Builds Ubuntu 20.04 OVA w remote hypervisor

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -15,56 +15,130 @@
 # If you update this file, please follow
 # https://suva.sh/posts/well-documented-makefiles
 
-all: build
+# Ensure Make is run with bash shell as some syntax below is bash-specific
+SHELL := /usr/bin/env bash
 
-# A list of the supported distribution/version combinations. Each member
-# of *_BUILD_NAMES must have a corresponding file "config/*_BUILD_NAME.json".
-OVA_BUILD_NAMES ?= ova-centos-7 ova-ubuntu-1804 ova-ubuntu-2004 ova-photon-3
-AMI_BUILD_NAMES ?= ami-default
-GCE_BUILD_NAMES ?= gce-default
-OVA_BUILD_NAMES_ESX ?= esx-ova-centos-7 esx-ova-ubuntu-1804 esx-ova-ubuntu-2004 esx-ova-photon-3
-AZURE_BUILD_NAMES ?= azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804
+.DEFAULT_GOAL := help
 
-# The version of Kubernetes to install.
-KUBE_JSON ?= packer/config/kubernetes.json packer/config/cni.json packer/config/containerd.json
+## --------------------------------------
+## Help
+## --------------------------------------
+help: ## Display this help
+	@echo NOTE
+	@echo '  The "build-ova" targets have analogue "clean-ova" targets for'
+	@echo '  cleaning artifacts created from building OVAs using a local'
+	@echo '  hypervisor.'
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# The flags to give to Packer.
-PACKER_VAR_FILES += $(KUBE_JSON)
-OLD_PACKER_FLAGS := $(PACKER_FLAGS)
-PACKER_FLAGS := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" )
-PACKER_FLAGS += $(OLD_PACKER_FLAGS)
+## --------------------------------------
+## Packer flags
+## --------------------------------------
 
-OVA_BUILD_TARGETS := $(addprefix build-,$(OVA_BUILD_NAMES))
-AMI_BUILD_TARGETS := $(addprefix build-,$(AMI_BUILD_NAMES))
-GCE_BUILD_TARGETS := $(addprefix build-,$(GCE_BUILD_NAMES))
-OVA_BUILD_TARGETS_ESX := $(addprefix build-,$(OVA_BUILD_NAMES_ESX))
-AZURE_BUILD_TARGETS := $(addprefix build-,$(AZURE_BUILD_NAMES))
+# If FOREGROUND=1 then Packer will set headless to false, causing local builds
+# to build in the foreground, with a UI. This is very useful when debugging new
+# platforms or issues with existing ones.
+ifeq (1,$(strip $(FOREGROUND)))
+PACKER_FLAGS += -var="headless=false"
+endif
 
+# A list of variable files given to Packer to configure things like the versions
+# of Kubernetes, CNI, and ContainerD to install.
+PACKER_VAR_FILES +=	packer/config/kubernetes.json \
+					packer/config/cni.json \
+					packer/config/containerd.json
+
+# Initialize a list of flags to pass to Packer. This includes any existing flags
+# specified by PACKER_FLAGS, as well as prefixing the list with the variable
+# files from PACKER_VAR_FILES, with each file prefixed by -var-file=.
+#
+# Any existing values from PACKER_FLAGS take precendence over variable files.
+PACKER_FLAGS := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" ) \
+				$(PACKER_FLAGS)
+
+## --------------------------------------
+## Platform and version combinations
+## --------------------------------------
+CENTOS_VERSIONS			:=	centos-7
+PHOTON_VERSIONS			:=	photon-3
+UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004
+
+PLATFORMS_AND_VERSIONS	:=	$(CENTOS_VERSIONS) \
+							$(PHOTON_VERSIONS) \
+							$(UBUNTU_VERSIONS)
+
+OVA_BUILD_NAMES			:=	$(addprefix ova-,$(PLATFORMS_AND_VERSIONS))
+ESX_BUILD_NAMES			:=	$(addprefix esx-,$(OVA_BUILD_NAMES))
+
+AMI_BUILD_NAMES			?=	ami-default
+GCE_BUILD_NAMES			?=	gce-default
+AZURE_BUILD_NAMES		?=	azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804
+
+## --------------------------------------
+## Dynamic build targets
+## --------------------------------------
+OVA_BUILD_TARGETS	:= $(addprefix build-,$(OVA_BUILD_NAMES))
+ESX_BUILD_TARGETS	:= $(addprefix build-,$(ESX_BUILD_NAMES))
+AMI_BUILD_TARGETS	:= $(addprefix build-,$(AMI_BUILD_NAMES))
+GCE_BUILD_TARGETS	:= $(addprefix build-,$(GCE_BUILD_NAMES))
+AZURE_BUILD_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_NAMES))
+
+.PHONY: $(OVA_BUILD_TARGETS)
 $(OVA_BUILD_TARGETS):
 	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-,,$@).json)" packer/ova/packer.json
-.PHONY: $(OVA_BUILD_TARGETS)
 
+.PHONY: $(ESX_BUILD_TARGETS)
+$(ESX_BUILD_TARGETS):
+	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-esx-,,$@).json)" -var-file="packer/ova/esx.json" -except=shell-local packer/ova/packer.json
+
+.PHONY: $(AMI_BUILD_TARGETS)
 $(AMI_BUILD_TARGETS):
 	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ami/$(subst build-,,$@).json)" packer/ami/packer.json
-.PHONY: $(AMI_BUILD_TARGETS)
 
+.PHONY: $(GCE_BUILD_TARGETS)
 $(GCE_BUILD_TARGETS):
 	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/gce/$(subst build-,,$@).json)" packer/gce/packer.json
-.PHONY: $(GCE_BUILD_TARGETS)
 
-$(OVA_BUILD_TARGETS_ESX):
-	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-esx-,,$@).json)" -var-file="packer/ova/esx.json" -except=shell-local packer/ova/packer.json
-.PHONY: $(OVA_BUILD_TARGETS_ESX)
-
+.PHONY: $(AZURE_BUILD_TARGETS)
 $(AZURE_BUILD_TARGETS):
 	. $(abspath packer/azure/scripts/init-$(subst build-azure-,,$@).sh) && packer build $(PACKER_FLAGS) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/$(subst build-,,$@).json)" -only="$(subst build-azure-,,$@)" packer/azure/packer.json
-.PHONY: $(AZURE_BUILD_TARGETS)
 
-CLEAN_TARGETS := $(addprefix clean-,$(OVA_BUILD_NAMES))
-$(CLEAN_TARGETS):
+## --------------------------------------
+## Dynamic clean targets
+## --------------------------------------
+OVA_CLEAN_TARGETS := $(subst build-,clean-,$(OVA_BUILD_TARGETS))
+.PHONY: $(OVA_CLEAN_TARGETS)
+$(OVA_CLEAN_TARGETS):
 	rm -fr output/$(subst clean-ova-,,$@)*
-.PHONY: $(CLEAN_TARGETS)
 
-build: $(OVA_BUILD_TARGETS) $(AMI_BUILD_TARGETS) $(GCE_BUILD_TARGETS) $(AZURE_BUILD_TARGETS)
-clean: $(CLEAN_TARGETS)
-.PHONY: build clean
+## --------------------------------------
+## Documented targets
+## --------------------------------------
+build-ova-centos-7: ## Builds CentOS 7 OVA w local hypervisor
+build-ova-photon-3: ## Builds Photon 3 OVA w local hypervisor
+build-ova-ubuntu-1804: ## Builds Ubuntu 18.04 OVA w local hypervisor
+build-ova-ubuntu-2004: ## Builds Ubuntu 20.04 OVA w local hypervisor
+
+build-esx-centos-7: ## Builds CentOS 7 OVA w remote hypervisor
+build-esx-photon-3: ## Builds Photon 3 OVA w remote hypervisor
+build-esx-ubuntu-1804: ## Builds Ubuntu 18.04 OVA w remote hypervisor
+build-esx-ubuntu-2004: ## Builds Ubuntu 20.04 OVA w remote hypervisor
+
+build-ami-default: ## Builds the AMI default image
+build-gce-default: ## Builds the GCE default image
+
+build-azure-ubuntu-1804: $(AZURE_BUILD_TARGETS)
+build-azure-ubuntu-1804: ## Builds Ubuntu 18.04 for Azure
+
+## --------------------------------------
+## Global targets
+## --------------------------------------
+.PHONY: build
+build:	$(OVA_BUILD_TARGETS) \
+		$(AMI_BUILD_TARGETS) \
+		$(GCE_BUILD_TARGETS) \
+		$(AZURE_BUILD_TARGETS)
+build: ## Builds all images
+
+.PHONY: clean
+clean: $(OVA_CLEAN_TARGETS)
+clean: ## Cleans all local image caches

--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -18,13 +18,19 @@ common_rpms:
 - curl
 - ebtables
 - nfs-utils
-- ntp
 - open-vm-tools
+- socat
+- yum-utils
+common_7_rpms:
+- ntp
 - python2-pip
 - python-netifaces
 - python-requests
-- socat
-- yum-utils
+common_8_rpms:
+- chrony
+- python3-pip
+- python3-netifaces
+- python3-requests
 common_extra_rpms: []
 common_debs:
 - openssh-client
@@ -38,7 +44,8 @@ common_debs:
 
 common_pinned_debs: []
 common_extra_debs: []
-common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+common_redhat_7_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+common_redhat_8_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
 disable_public_repos: false
 extra_repos: ""
 common_photon_rpms: "python3-pip python-requests ebtables socat ntp jq nfs-utils net-tools conntrack-tools distrib-compat openssl-c_rehash"

--- a/images/capi/ansible/roles/common/tasks/redhat.yml
+++ b/images/capi/ansible/roles/common/tasks/redhat.yml
@@ -12,11 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: add epel repo
+- name: Add EPEL repository (7)
   yum:
-    name: "{{ common_redhat_epel_rpm }}"
+    name: "{{ common_redhat_7_epel_rpm }}"
     state: present
     lock_timeout: 60
+  when: ansible_facts['distribution_major_version'] == "7"
+
+- name: Add EPEL repository (8)
+  yum:
+    name: "{{ common_redhat_8_epel_rpm }}"
+    state: present
+    lock_timeout: 60
+  when: ansible_facts['distribution_major_version'] == "8"
 
 - name: Find existing repo files
   find:
@@ -44,11 +52,25 @@
     state: latest
     lock_timeout: 60
 
-- name: install baseline dependencies
+- name: Install baseline dependencies
   yum:
     name: "{{ common_rpms }}"
     state: present
     lock_timeout: 60
+
+- name: Install baseline dependencies (7)
+  yum:
+    name: "{{ common_7_rpms }}"
+    state: present
+    lock_timeout: 60
+  when: ansible_facts['distribution_major_version'] == "7"
+
+- name: Install baseline dependencies (8)
+  yum:
+    name: "{{ common_8_rpms }}"
+    state: present
+    lock_timeout: 60
+  when: ansible_facts['distribution_major_version'] == "8"
 
 - name: install extra rpms
   yum:

--- a/images/capi/packer/ova/linux/centos/http/8/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/8/ks.cfg
@@ -1,0 +1,120 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The install command is deprecated in CentOS 8.
+#install
+
+# Use the boot ISO as an installation source.
+cdrom
+
+# There was an attempt in 2037e4f3b0e272883c64102ca47f175fc8faf71a to no longer
+# install packages from the internet during the kickstart of CentOS 7.
+#
+# However, CentOS 8 no longer provides a minimal ISO, only the full DVD or the
+# network boot ISOs. This means either a +7GiB DVD ISO is required to build 
+# CentOS 8, or a 500MiB-ish ISO that requires network access may be used.
+#
+# The initial work to support CentOS 8 has opted to use the network boot ISO as
+# the ESX builder fails when using large ISOs as learned while attempting to
+# support Photon 3 Rev2.
+url --url=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
+
+# Perform a text installation
+text
+
+# Do not install an X server
+skipx
+
+# Configure the locale/keyboard
+lang en_US.UTF-8
+keyboard us
+
+# Configure networking
+network --onboot yes --bootproto dhcp --hostname centos.vm
+firewall --disabled
+selinux --permissive
+timezone UTC
+
+# This no longer seems to be a supported kickstart option in CentOS 8:
+#
+# * https://github.com/geerlingguy/packer-centos-8/issues/1#issuecomment-535033562
+# * https://github.com/geerlingguy/packer-boxes/blob/master/centos8/http/ks.cfg
+#
+# Don't flip out if unsupported hardware is detected
+# unsupported_hardware
+
+# The following command is deprecated in CentOS 8 and shadowing passwords is
+# now enabled by default.
+# 
+#auth --enableshadow --passalgo=sha512 --kickstart
+
+# Add a user.
+user --name=centos --plaintext --password centos --groups=wheel
+
+# Disable general install minutia
+firstboot --disabled
+eula --agreed
+
+# Create a single partition with no swap space
+bootloader --location=mbr
+zerombr
+clearpart --all --initlabel
+part / --grow --asprimary --fstype=ext4 --label=slash
+
+%packages --ignoremissing --excludedocs
+openssh-server
+sed
+sudo
+
+# The following removal no longer works in CentOS 8 as it causes the removal of
+# firmware required to do the installation.
+#
+# TODO(akutz) Figure out how to removal unnecessary firmware
+#
+# Remove unnecessary firmware
+#-*-firmware
+
+# Remove other unnecessary packages
+-postfix
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+# Perform a reboot once the installation has completed
+reboot
+
+# The %post section is essentially a shell script
+%post --erroronfail
+
+# Update the root certificates
+update-ca-trust force-enable
+
+# Ensure that the "centos" user doesn't require a password to use sudo,
+# or else Ansible will fail
+echo 'centos ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/centos
+chmod 440 /etc/sudoers.d/centos
+
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+# Ensure on next boot that network devices get assigned unique IDs.
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/ova/ova-centos-8.json
+++ b/images/capi/packer/ova/ova-centos-8.json
@@ -1,0 +1,14 @@
+{
+    "build_name": "centos-8",
+    "distro_name": "centos",
+    "os_display_name": "CentOS 8",
+    "guest_os_type": "centos-64",
+    "iso_url": "https://mirrors.edge.kernel.org/centos/8.0.1905/isos/x86_64/CentOS-8-x86_64-1905-boot.iso",
+    "iso_checksum": "a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc",
+    "iso_checksum_type": "sha256",
+    "ssh_username": "centos",
+    "ssh_password": "centos",
+    "boot_command_prefix": "<tab> text ks=",
+    "boot_command_suffix": "/8/ks.cfg<enter><wait>",
+    "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
This patch introduces initial support for building OVAs with CentOS 8.

Hi @codenrhoden @figo @ppadmavilasom,

Please see the following comment in the kickstart file:

> There was an attempt in 2037e4f3b0e272883c64102ca47f175fc8faf71a to no longer install packages from the internet during the kickstart of CentOS 7.
>
> However, CentOS 8 no longer provides a minimal ISO, only the full DVD or the network boot ISOs. This means either a +7GiB DVD ISO is required to build  CentOS 8, or a 500MiB-ish ISO that requires network access may be used.
>
> The initial work to support CentOS 8 has opted to use the network boot ISO as the ESX builder fails when using large ISOs as learned while attempting to support Photon 3 Rev2.

This patch will be rebased once #121 is merged.