### PR TITLE
Minimize packages installed during Photon kickstart

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -25,7 +25,6 @@ common_rpms:
 - python-requests
 - socat
 - yum-utils
-common_extra_rpms: []
 common_debs:
 - openssh-client
 - openssh-server
@@ -35,13 +34,25 @@ common_debs:
 - ntp
 - jq
 - nfs-client
+common_photon_rpms:
+- conntrack-tools
+- distrib-compat
+- ebtables
+- jq
+- net-tools
+- ntp
+- nfs-utils
+- openssl-c_rehash
+- python3-pip
+- python-requests
+- socat
 
 common_pinned_debs: []
 common_extra_debs: []
+common_extra_rpms: []
 common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 disable_public_repos: false
 extra_repos: ""
-common_photon_rpms: "python3-pip python-requests ebtables socat ntp jq nfs-utils net-tools conntrack-tools distrib-compat openssl-c_rehash"
 #photon does not have backward compatibility for legacy distro behavior for sysctl.conf by default
 #as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.
 sysctl_conf_file: "{{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family == 'VMware Photon OS' else '/etc/sysctl.conf' }}"

--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -43,9 +43,12 @@ common_photon_rpms:
 - ntp
 - nfs-utils
 - openssl-c_rehash
+- python-netifaces
 - python3-pip
 - python-requests
 - socat
+- tar
+- unzip
 
 common_pinned_debs: []
 common_extra_debs: []

--- a/images/capi/ansible/roles/common/tasks/photon.yml
+++ b/images/capi/ansible/roles/common/tasks/photon.yml
@@ -27,8 +27,12 @@
     owner: photon
     group: photon
 
+- name: Concatenate the Photon RPMs
+  set_fact:
+    photon_rpms: "{{ common_photon_rpms | join(' ') }}"
+
 - name: install baseline dependencies
-  command: tdnf install {{ common_photon_rpms }} -y --refresh
+  command: tdnf install {{ photon_rpms }} -y --refresh
 
 - name: disable service docker and ensure it is masked (installed via 'minimal' package)
   systemd:

--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -11,29 +11,12 @@
         "initramfs"
     ],
     "additional_packages": [
-        "conntrack-tools",
-        "ebtables",
-        "jq",
-        "libnetfilter_conntrack",
-        "libnetfilter_cthelper",
-        "libnetfilter_cttimeout",
-        "libnetfilter_queue",
-        "nfs-utils",
-        "ntp",
-        "openssh-clients",
         "openssh-server",
-        "python-netifaces",
-        "python-requests",
-        "python-pip",
-        "sed",
-        "socat",
-        "sudo",
-        "tar",
-        "unzip"
+        "sudo"
     ],
     "postinstall": [
         "#!/bin/sh",
-        "tdnf install -y conntrack-tools ebtables jq libnetfilter_conntrack libnetfilter_cthelper libnetfilter_cttimeout libnetfilter_queue nfs-utils ntp openssh-clients openssh-server python-netifaces python-requests python-pip sed socat sudo tar unzip",
+        "tdnf install -y openssh-server sudo",
         "useradd -U -d /home/photon -m --groups wheel photon && echo 'photon:photon' | chpasswd",
         "echo 'photon ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/photon",
         "chmod 440 /etc/sudoers.d/photon",


### PR DESCRIPTION
This PR has two commits.

1.  Enable the Photon RPMs to be in a list, just like the other distros
2. Minimize the packages that are installed during the kickstart, just like the other distros.

/assign @akutz