### PR TITLE
Fix imagebuilder docker build failure

### DIFF
--- a/images/kube-deploy/imagebuilder/Dockerfile
+++ b/images/kube-deploy/imagebuilder/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.11 AS build
+FROM golang:1.13 AS build
 
 WORKDIR /go/src/sigs.k8s.io/image-builder/images/kube-deploy/imagebuilder
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:3.8
+FROM alpine:3.11
 WORKDIR /imagebuilder
 RUN apk add --no-cache ca-certificates
 COPY --from=build /go/src/sigs.k8s.io/image-builder/images/kube-deploy/imagebuilder/imagebuilder imagebuilder


### PR DESCRIPTION
To avoid build failure with modules, use a newer version which use go.mod

Without this, the docker build fails with "cannot find package" msgs.

See https://blog.golang.org/go1.13 for reference.