### PR TITLE
Make sure Ubuntu images remain immutable

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -63,7 +63,7 @@
     path: /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
     state: absent
   when: ansible_os_family == "VMware Photon OS"
-  
+
 #- name: Unlock password
 #  replace:
 #    path: /etc/cloud/cloud.cfg
@@ -76,3 +76,9 @@
     dest:  /usr/lib/cloud-init
     state: link
   when: ansible_os_family == "RedHat"
+
+- name: Disable Hyper-V KVP protocol daemon
+  systemd:
+    name: hv-kvp-daemon
+    state: stopped
+    enabled: false

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -61,6 +61,18 @@
   - { path: /var/lib/apt/lists, state: absent,    mode: "0755" }
   - { path: /var/lib/apt/lists, state: directory, mode: "0755" }
 
+- name: Disable unwanted systemd services
+  systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop:
+  - apt-daily
+  - apt-daily.timer
+  - apt-daily-upgrade
+  - apt-daily-upgrade.timer
+  - unattended-upgrades
+
 - name: Reset network interface IDs
   file:
     state: absent


### PR DESCRIPTION
A key tenet of the CAPI images are that they are immutable. Unfortunately, the Ubuntu image is being created with the default settings of having a few services enabled, namely `apt-daily`, `apt-daily-upgrade`, and `unattended-upgrades` enabled. Each of these is unnecessary in an immutable image.

For the `apt-daily*` services and timers, they just added unnecessary time to the boot process. For the `unattended-upgrades` service, that can actually upgrade/modify packages, and we do not want it enabled.

Furthermore, during investigating this issue, it was noticed that there was a consistent 90-second pause during the boot time waiting for the "Hyper-V KVP Protocol Daemon" to startup. This boot would [consistently fail](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1820063). I see no reason to run a Hyper-V specific daemon for OVA images running on ESXi, so disabling this service speeds boot times up by 90 seconds.

For full disclosure, there is one weird thing... According the bug linked above, the issue should have been fixed for Bionic with Linux kernel `4.15.0-74.84`. When I build a new image from scratch today (without this fix) we end up with kernel `4.15.0-76-generic`, which seems to me it should include the fix. But the problem persists, but disabling this services solves the problems. It takes VM boot time on my laptop with Fusion workstation from
```sh
$ systemd-analyze
Startup finished in 2.010s (kernel) + 1min 36.354s (userspace) = 1min 38.365s
```
to
```sh
$ systemd-analyze
Startup finished in 1.715s (kernel) + 6.638s (userspace) = 8.354s
```
Which I think is pretty great. Exactly 90 seconds less in userspace. 💪 

fixes: #90 
/assign @detiber @akutz 