### PR TITLE
No longer call post-create script during OVA build

### DIFF
--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -128,10 +128,6 @@
     {
       "type": "shell-local",
       "command": "./hack/image-build-ova.py --vmx {{user `vmx_version`}} {{user `output_dir`}}"
-    },
-    {
-      "type": "shell-local",
-      "command": "./hack/image-post-create-config.sh {{user `output_dir`}}"
     }
   ]
 }


### PR DESCRIPTION
> When building OVA images, after the OVA is packaged up, a call to
> images/capi/hack/image-post-create-config.sh is made. This convenience
> script modifies the VM size and sets up with some useful cloud-init data
> for developer debugging.
> 
> However, this assumes that the VM (VMX file) that it operates on is
> loaded/imported to your VM managment software. If you are using VMW
> Workstation, this may work well for you. If you are using VMW Fusion, it
> does not. The VM created does not show up automatically in Fusion. I end
> up having to import teh disk to FUsion, and then run this script
> manually to set it up.
> 
> My point is that the Packer config is optimized for the 5% case, I
> think. I pretty much never use this setup. When I do, I end up having to
> run it manually anyways, so I think it is a wasted step.

quoted text is from the commit message. But basically, my thinking here is that there is a step in the process I don't think gets used very often. And when *I* need it, I end up running a step manually anyways, so the fact that is is part of every build doesn't help me. It may be a difference between building images locally on Fusion vs someone using Workstation. But when I build community images, this extra step is also not really needed.

But that's my dev workflow, and others might rely on it. So I'd like to get more input. Does anyone else build images with the tool, and immediately boot the VM from the existing VMX and are able to SSH into it with the given dummy keys?

low priority

/assign @akutz @figo @jiatongw 
/hold
^ for discussion.