### PR TITLE
capi: remove NFS by default

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -17,7 +17,6 @@ common_rpms:
 - conntrack-tools
 - curl
 - ebtables
-- nfs-utils
 - ntp
 - open-vm-tools
 - python2-pip
@@ -39,7 +38,6 @@ common_debs:
 - libnetfilter-log1
 - linux-cloud-tools-virtual
 - linux-tools-virtual
-- nfs-common
 - ntp
 - open-vm-tools
 - python3-distutils
@@ -54,7 +52,6 @@ common_photon_rpms:
 - jq
 - net-tools
 - ntp
-- nfs-utils
 - openssl-c_rehash
 - python-netifaces
 - python3-pip


### PR DESCRIPTION
No longer install NFS utilities by default. This reduces the number of
open ports in the default image. If a user needs NFS capabilities, they
can add it back in when builing their own image.

fixes: #95 
supersedes: #64 

The ability for a user to easily list additional packages (without modifying the base YAML) is coming this week. There is not an issue filed for it, though.

With these changes, I verified that `systemctl list-units --all` did not list either of `rpcbind.service` or `rcpbind.socket`. Addtionally, port 111 was not open:

```sh
$ netstat -atln | grep 111
$ exit
```

/assign @detiber 
/cc @dennisme