### PR TITLE
Only disable Hyper-V protocol daemon on Ubuntu

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -77,8 +77,9 @@
     state: link
   when: ansible_os_family == "RedHat"
 
-- name: Disable Hyper-V KVP protocol daemon
+- name: Disable Hyper-V KVP protocol daemon on Ubuntu
   systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
In a previous commit, disabling the Hyper-V protocol daemon was
accidentally done for all OVA builds. The intent was to only apply it to
Ubuntu.

I verified that all OVA builds (photon3, centos 7, ubuntu 1804 and 2004) complete successfully now.

/assign @figo 