### PR TITLE
Use a single user/pass across multiple distros

### DIFF
--- a/images/capi/ansible/roles/common/tasks/photon.yml
+++ b/images/capi/ansible/roles/common/tasks/photon.yml
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: add home dir for photon user
+- name: add home dir for builder user
   file:
     state: directory
-    path: /home/photon
+    path: /home/builder
     mode: 0755
-    owner: photon
-    group: photon
+    owner: builder
+    group: builder
 
 - name: add bash_profile
   template:
-    dest: /home/photon/.bash_profile
+    dest: /home/builder/.bash_profile
     src: photon_bash_profile
-    owner: photon
-    group: photon
+    owner: builder
+    group: builder
 
 - name: Concatenate the Photon RPMs
   set_fact:

--- a/images/capi/hack/image-ssh.sh
+++ b/images/capi/hack/image-ssh.sh
@@ -43,11 +43,7 @@ VMX_FILE=$(/bin/ls "${1-}"/*.vmx)
 # Get the SSH user.
 SSH_USER="${SSH_USER:-${2-}}"
 if [ -z "${SSH_USER}" ]; then
-  if [[ ${VMX_FILE} = *centos* ]]; then
-    SSH_USER=centos
-  elif [[ ${VMX_FILE} = *ubuntu* ]]; then
-    SSH_USER=ubuntu
-  fi
+  SSH_USER=builder
 fi
 if [ -z "${SSH_USER}" ]; then
   echo "SSH_USER is required" 1>&2

--- a/images/capi/packer/ova/linux/centos/http/7/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/7/ks.cfg
@@ -37,7 +37,7 @@ unsupported_hardware
 
 # Configure the user(s)
 auth --enableshadow --passalgo=sha512 --kickstart
-user --name=centos --plaintext --password centos --groups=centos,wheel
+user --name=builder --plaintext --password builder --groups=builder,wheel
 
 # Disable general install minutia
 firstboot --disabled
@@ -73,10 +73,10 @@ reboot
 # Update the root certificates
 update-ca-trust force-enable
 
-# Ensure that the "centos" user doesn't require a password to use sudo,
+# Ensure that the "builder" user doesn't require a password to use sudo,
 # or else Ansible will fail
-echo 'centos ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/centos
-chmod 440 /etc/sudoers.d/centos
+echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+chmod 440 /etc/sudoers.d/builder
 
 # Remove the package cache
 yum -y clean all

--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -2,7 +2,7 @@
     "hostname": "localhost",
     "password": {
         "crypted": false,
-        "text": "photon"
+        "text": "builder"
     },
     "disk": "/dev/sda",
     "packages": [
@@ -17,9 +17,9 @@
     "postinstall": [
         "#!/bin/sh",
         "tdnf install -y openssh-server sudo",
-        "useradd -U -d /home/photon -m --groups wheel photon && echo 'photon:photon' | chpasswd",
-        "echo 'photon ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/photon",
-        "chmod 440 /etc/sudoers.d/photon",
+        "useradd -U -d /home/builder -m --groups wheel builder && echo 'builder:builder' | chpasswd",
+        "echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder",
+        "chmod 440 /etc/sudoers.d/builder",
         "systemctl enable sshd",
         "systemctl disable docker.service",
         "systemctl mask docker.service",

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -76,10 +76,10 @@ d-i partman-partitioning/no_bootable_gpt_efi boolean false
 d-i partman-efi/non_efi_system boolean false
 
 # Create the default user.
-d-i passwd/user-fullname string ubuntu
-d-i passwd/username string ubuntu
-d-i passwd/user-password password ubuntu
-d-i passwd/user-password-again password ubuntu
+d-i passwd/user-fullname string builder
+d-i passwd/username string builder
+d-i passwd/user-password password builder
+d-i passwd/user-password-again password builder
 d-i user-setup/encrypt-home boolean false
 d-i user-setup/allow-password-weak boolean true
 
@@ -109,7 +109,7 @@ libssl1.1:amd64 libssl1.1/restart-services string
 
 
 # This command runs after all other steps; it:
-# 1. Ensures the "ubuntu" user doesn't require a password to use sudo
+# 1. Ensures the "builder" user doesn't require a password to use sudo
 # 2. Cleans up any packages that are no longer required
 # 3. Cleans the package cache
 # 4. Removes the cached list of packages
@@ -117,8 +117,8 @@ libssl1.1:amd64 libssl1.1/restart-services string
 # 6. Removes the existing swapfile
 # 7. Removes the swapfile entry from /etc/fstab
 d-i preseed/late_command string \
-    echo 'ubuntu ALL=(ALL) NOPASSWD: ALL' >/target/etc/sudoers.d/ubuntu ; \
-    in-target chmod 440 /etc/sudoers.d/ubuntu ; \
+    echo 'builder ALL=(ALL) NOPASSWD: ALL' >/target/etc/sudoers.d/builder ; \
+    in-target chmod 440 /etc/sudoers.d/builder ; \
     in-target swapoff -a ; \
     in-target rm -f /swapfile ; \
     in-target sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab ; \

--- a/images/capi/packer/ova/ova-centos-7.json
+++ b/images/capi/packer/ova/ova-centos-7.json
@@ -6,8 +6,6 @@
   "iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-Minimal-1908.iso",
   "iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
   "iso_checksum_type": "sha256",
-  "ssh_username": "centos",
-  "ssh_password": "centos",
   "boot_command_prefix": "<tab> text ks=",
   "boot_command_suffix": "/7/ks.cfg<enter><wait>",
   "shutdown_command": "sys-unconfig"

--- a/images/capi/packer/ova/ova-photon-3.json
+++ b/images/capi/packer/ova/ova-photon-3.json
@@ -6,8 +6,6 @@
   "iso_url": "http://dl.bintray.com/vmware/photon/3.0/Rev2/iso/photon-minimal-3.0-58f9c74.iso",
   "iso_checksum": "ae28558e57f5d8aefb8b479c9fac7473079156e1",
   "iso_checksum_type": "sha1",
-  "ssh_username": "photon",
-  "ssh_password": "photon",
   "boot_command_prefix": "<esc><wait> vmlinuz initrd=initrd.img root/dev/ram0 loglevel=3 photon.media=cdrom ks=",
   "boot_command_suffix": "/3/ks.json<enter><wait>",
   "shutdown_command": "shutdown now"

--- a/images/capi/packer/ova/ova-ubuntu-1804.json
+++ b/images/capi/packer/ova/ova-ubuntu-1804.json
@@ -6,8 +6,6 @@
   "iso_url": "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-server-amd64.iso",
   "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
   "iso_checksum_type": "sha256",
-  "ssh_username": "ubuntu",
-  "ssh_password": "ubuntu",
   "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
   "boot_command_suffix": "/18.04/preseed.cfg -- <wait><enter><wait>",
   "shutdown_command": "shutdown -P now"

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -42,6 +42,8 @@
     "remote_username": "",
     "remote_password": "",
     "skip_compaction": "false",
+    "ssh_username": "builder",
+    "ssh_password": "builder",
     "vmx_version": "13",
     "vnc_bind_address": "127.0.0.1",
     "vnc_disable_password": "false",


### PR DESCRIPTION
When building the OVA images, a user and password is establed as part of
the kickstart/preseed. This user is then used for Ansible to provision
the node, and that user is locked out at the very end. It's never used
again. As we expand the number of supported distros, it seems like
extraneous effort to set a different user/pass for each distro. It also
makes re-use of kickstart files produce odd circumstances, such as
creating a "centos" user on a rhel machine, for example.

This patch standardizes the user to a non-distro specific one, and
instead just uses builder/builder.

This patch was originally part of #129, but since that is still being debugged, I'd like to see this go in sooner rather than later. I verified that all the OVA images build successfully.

/assign @detiber 