### PR TITLE
photon: add support for repo management

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -40,7 +40,7 @@ Several variables can be used to customize the image build.
 |----------|-------------|---------|
 | `disable_public_repos` | If set to `"true"`, this will disable all existing package repositories defined in the OS before doing any package installs. The `extra_repos` variable *must* be set for package installs to succeed. | `"false"` |
 | `extra_debs` | This can be set to a space delimited string containing the names of additional deb packages to install | `""` |
-| `extra_repos` | A comma-separated list of files to add to the image containing repository definitions. The files should be given as absolute paths. | `""` |
+| `extra_repos` | A space delimited string containing the names of files to add to the image containing repository definitions. The files should be given as absolute paths. | `""` |
 | `extra_rpms` | This can be set to a space delimited string containing the names of additional RPM packages to install | `""` |
 | `reenable_public_repos` | If set to `"false"`, the package repositories disabled by setting `disable_public_repos` will remain disabled at the end of the build. | `"true"` |
 | `remove_extra_repos` | If set to `"true"`, the package repositories added to the OS through the use of `extra_repos` will be removed at the end of the build. | `"false"` |
@@ -89,7 +89,7 @@ For example, to build an image using only an internal mirror, create a file call
 ```json
 {
   "disable_public_repos": "true",
-  "extra_repos": "/home/<user>/repo.list",
+  "extra_repos": "/home/<user>/mirror.repo",
   "remove_extra_repos": "true"
 }
 ```

--- a/images/capi/ansible/roles/common/tasks/debian.yml
+++ b/images/capi/ansible/roles/common/tasks/debian.yml
@@ -36,7 +36,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/apt/sources.list.d/{{ item | basename }}"
-  loop: "{{ extra_repos.split(',') }}"
+  loop: "{{ extra_repos.split() }}"
   when: extra_repos != ""
 
 - name: update apt cache

--- a/images/capi/ansible/roles/common/tasks/photon.yml
+++ b/images/capi/ansible/roles/common/tasks/photon.yml
@@ -27,6 +27,8 @@
     owner: builder
     group: builder
 
+- import_tasks: rpm_repos.yml
+
 - name: Concatenate the Photon RPMs
   set_fact:
     photon_rpms: "{{ common_photon_rpms | join(' ') }}"

--- a/images/capi/ansible/roles/common/tasks/redhat.yml
+++ b/images/capi/ansible/roles/common/tasks/redhat.yml
@@ -18,25 +18,7 @@
     state: present
     lock_timeout: 60
 
-- name: Find existing repo files
-  find:
-    depth: 1
-    paths: /etc/yum.repos.d
-    patterns: '*.repo'
-  register: repo_files
-  when: disable_public_repos|bool
-
-- name: Disable repos
-  command: "mv {{ item.path }} {{ item.path }}.disabled"
-  loop: "{{ repo_files.files }}"
-  when: disable_public_repos|bool
-
-- name: Install extra repos
-  copy:
-    src: "{{ item }}"
-    dest: "/etc/yum.repos.d/{{ item | basename }}"
-  loop: "{{ extra_repos.split(',') }}"
-  when: extra_repos != ""
+- import_tasks: rpm_repos.yml
 
 - name: perform a yum update
   yum:

--- a/images/capi/ansible/roles/common/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/common/tasks/rpm_repos.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,25 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Define file modes
-  set_fact:
-    last_log_mode:   "0644"
-    machine_id_mode: "0444"
+- name: Find existing repo files
+  find:
+    depth: 1
+    paths: /etc/yum.repos.d
+    patterns: '*.repo'
+  register: repo_files
+  when: disable_public_repos|bool
 
-- import_tasks: rpm_repos.yml
+- name: Disable repos
+  command: "mv {{ item.path }} {{ item.path }}.disabled"
+  loop: "{{ repo_files.files }}"
+  when: disable_public_repos|bool
 
-- name: Remove yum package caches
-  yum:
-    autoremove: yes
-    lock_timeout: 60
-
-- name: Remove yum package lists
-  command: /usr/bin/yum -y clean all
-
-- name: Reset network interface IDs
-  shell: sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
-
-- name: Remove the kickstart log
-  file:
-    state: absent
-    path: /root/anaconda-ks.cfg
+- name: Install extra repos
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/yum.repos.d/{{ item | basename }}"
+  loop: "{{ extra_repos.split(',') }}"
+  when: extra_repos != ""

--- a/images/capi/ansible/roles/common/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/common/tasks/rpm_repos.yml
@@ -29,5 +29,5 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/yum.repos.d/{{ item | basename }}"
-  loop: "{{ extra_repos.split(',') }}"
+  loop: "{{ extra_repos.split() }}"
   when: extra_repos != ""

--- a/images/capi/ansible/roles/sysprep/tasks/photon.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/photon.yml
@@ -37,6 +37,8 @@
     state: absent
     path: /root/anaconda-ks.cfg
 
+- import_tasks: rpm_repos.yml
+
 - name: Remove tdnf package caches
   command: /usr/bin/tdnf -y clean all
 

--- a/images/capi/ansible/roles/sysprep/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/rpm_repos.yml
@@ -1,0 +1,33 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Remove extra repos
+  file:
+    path: "/etc/yum.repos.d/{{ item | basename }}"
+    state: absent
+  loop: "{{ extra_repos.split() }}"
+  when: remove_extra_repos and extra_repos != ""
+
+- name: Find disabled repo files
+  find:
+    depth: 1
+    paths: /etc/yum.repos.d
+    patterns: '*.repo.disabled'
+  register: repo_files
+  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+
+- name: Enable repos
+  command: "mv {{ item.path }} {{ item.path | regex_replace('.disabled') }}"
+  loop: "{{ repo_files.files }}"
+  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool


### PR DESCRIPTION
This patch updates the Photon OVA build to accept the extra repo
definitions and repo management flags that the other builds support.

/hold
^ because I need to add docs clearly showing how to do all the repo management stuff, and because I want to get other PRs in first. But wanted to show where this is going already.

fixes #149

/assign @detiber 