### PR TITLE
Use SHA for cri-containerd NOT upstream containerd tar.gz

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,4 +1,4 @@
 {
     "containerd_version": "1.3.3",
-    "containerd_sha256": "b76d54ca86b69871266c29d0f1ad56f37892ab4879b82d34909ab94918b83d16"
+    "containerd_sha256": "24ce7ad6b489fb25d07d2a3bb50e443fcce1ac3318f8cc0831e00668c2c9fd86"
 }


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/87960

We are using tar.gz(s) from:
https://storage.googleapis.com/cri-containerd-release

So we should use the SHA for:
https://storage.googleapis.com/cri-containerd-release/cri-containerd-1.3.3.linux-amd64.tar.gz