### PR TITLE
capi: define containerd_url in single place

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -15,7 +15,7 @@
     "extra_rpms": "",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": null,
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -13,7 +13,7 @@
     "build_timestamp": "{{timestamp}}",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": null,
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,4 +1,5 @@
 {
     "containerd_version": "1.3.3",
-    "containerd_sha256": "24ce7ad6b489fb25d07d2a3bb50e443fcce1ac3318f8cc0831e00668c2c9fd86"
+    "containerd_sha256": "24ce7ad6b489fb25d07d2a3bb50e443fcce1ac3318f8cc0831e00668c2c9fd86",
+    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz"
 }

--- a/images/capi/packer/digitalocean/packer.json
+++ b/images/capi/packer/digitalocean/packer.json
@@ -9,7 +9,7 @@
     "image_name": "cluster-api-ubuntu-1804",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": null,
     "extra_debs": "",
     "extra_repos": "",
     "kubernetes_cni_rpm_version": null,

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -11,7 +11,7 @@
     "zone": null,
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": null,
     "extra_debs": "",
     "extra_repos": "",
     "kubernetes_cni_rpm_version": null,

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -7,7 +7,7 @@
     "capi_version": "v1alpha2",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": null,
     "disable_public_repos": "false",
     "disk_type_id": "0",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",


### PR DESCRIPTION
Each provider was providing the exact same defintion for
`containerd_url`. There is no reason this shouldn't instead be defined
in packer/config/containerd.json, where it is common. We still specify
`containerd_url` as `null` in each provider's packer.json file to
indicate it is a required variable.

/assign @detiber 