### PR TITLE
Revert "capi: define containerd_url in single place"

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -15,7 +15,7 @@
     "extra_rpms": "",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": null,
+    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -13,7 +13,7 @@
     "build_timestamp": "{{timestamp}}",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": null,
+    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,5 +1,4 @@
 {
     "containerd_version": "1.3.3",
-    "containerd_sha256": "24ce7ad6b489fb25d07d2a3bb50e443fcce1ac3318f8cc0831e00668c2c9fd86",
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz"
+    "containerd_sha256": "24ce7ad6b489fb25d07d2a3bb50e443fcce1ac3318f8cc0831e00668c2c9fd86"
 }

--- a/images/capi/packer/digitalocean/packer.json
+++ b/images/capi/packer/digitalocean/packer.json
@@ -9,7 +9,7 @@
     "image_name": "cluster-api-ubuntu-1804",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": null,
+    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
     "extra_debs": "",
     "extra_repos": "",
     "kubernetes_cni_rpm_version": null,

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -11,7 +11,7 @@
     "zone": null,
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": null,
+    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
     "extra_debs": "",
     "extra_repos": "",
     "kubernetes_cni_rpm_version": null,

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -7,7 +7,7 @@
     "capi_version": "v1alpha2",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": null,
+    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
     "disable_public_repos": "false",
     "disk_type_id": "0",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",


### PR DESCRIPTION
This reverts commit dbf0a435d47db129ef54c736f76219708f8a6648.

I broke `master` again. I failed to realize that you cannot call templating functions (i.e. `{{user}}` from within user var files -- only the main template. Sigh. I've been trying to find better ways to organize all the vars files, but I think it's a losing effort until we just built a pre-processor/template-generator into a CLI.

/cc @figo 
/assign @detiber 

I really was sure I had tested this before submitting the PR, but clearly I did not as any build would have caught it. I must have been bouncing between too many different branches.