### PR TITLE
Update README and update CAPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Image Builder
 
-Cross provider Kubernetes virtual machine image building utility.
+## Please see our [Book](https://image-builder.sigs.k8s.io) for more in-depth documentation.
+
+## What is the Image Builder?
+
+The Image Builder is a collection of cross-provider Kubernetes virtual machine image building utilities.
+
+There are currently 3 distinct tools in this repo:
+
+- [Image builder for Cluster API](https://github.com/kubernetes-sigs/image-builder/tree/master/images/capi)
+- [kube-deploy/imagebuilder](https://github.com/kubernetes-sigs/image-builder/tree/master/images/kube-deploy/imagebuilder)
+- [konfigadm](https://github.com/kubernetes-sigs/image-builder/tree/master/images/konfigadm)
+
+Each project is independent from each other, with the goal of eventually merging into a single tool.
+
+The `konfigadm` directory contains manifests for use with the `konfigadm CLI`.
+
+### Useful links
+- [Quick Start for Cluster API Image Builder](https://image-builder.sigs.k8s.io/capi/quickstart.html)
+- [konfigadm CLI](https://github.com/flanksource/konfigadm)
 
 ## Community, discussion, contribution, and support
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,7 +1,8 @@
 # Summary
 
 [Introduction](./introduction.md)
-- [CAPI Providers](./capi/capi.md)
+- [CAPI](./capi/capi.md)
+  - [Quick Start](./capi/quickstart.md)
   - [AWS](./capi/providers/aws.md)
   - [Azure](./capi/providers/azure.md)
   - [DigitalOcean](./capi/providers/digitalocean.md)

--- a/docs/book/src/capi/quickstart.md
+++ b/docs/book/src/capi/quickstart.md
@@ -1,0 +1,31 @@
+# Quick Start
+
+In this tutorial we will cover the basics of how to download and execute the Image Builder.
+
+## Installation
+
+As a set of scripts and Makefiles that rely on Packer and Ansible, there is image builder binary/application to install. Rather we need to download the tooling from the GitHub repo and make sure that the Packer and Ansible are installed.
+
+To get the latest image-builder source on your machine, execute the following:
+
+```sh
+curl -L https://github.com/kubernetes-sigs/image-builder/tarball/master -o image-builder.tgz
+tar xzf image-builder.tgz
+cd image-builder/images/capi
+```
+
+## Dependencies
+
+Once you are within the `capi` directory, you can execute `make` or `make help` to see all the possible make targets. Before we can build an image, we need to make sure that Packer and Ansible are installed on your system. You may already have them, Mac users may have them installed via `brew`, or you may have downloaded them directly.
+
+If you want the image-builder to install these tools for you, they can be installed by executing `make deps`. This will install dependencies into `image-builder/images/capi/.bin` **if they are not already on your system**. `make deps` will first check if Ansible and Packer are available and if they are, will use the existing installations.
+
+Looking at the output from `make deps`, if Ansible or Packer were installed into the `.bin` directory, you'll need to add that to your `PATH` environment variable before they can be used. Assuming you are still in `images/capi`, you can do that with the following:
+
+```sh
+export PATH=$PWD/.bin:$PATH
+```
+
+## Builds
+
+With the CAPI image builder installed and dependencies satisfied, you are now ready to build an image. In general, this is done via `make` targets, and each provider (e.g. AWS, GCE, etc.) will have different requirements for what information needs to be provided (such as cloud provider authentication credentials). Certain providers may have dependencies that are not satisfied by `make deps`, for example the vSphere provider needs access to a hypervisor (VMware Fusion on macOS, VMware Workstation on Linux). See the [specific documentation](./capi.md#providers) for your desired provider for more details.

--- a/images/capi/README.md
+++ b/images/capi/README.md
@@ -1,0 +1,5 @@
+# Image Builder for Cluster API
+
+The Image Builder can be used to build images intended for use with Kubernetes [CAPI](https://cluster-api.sigs.k8s.io/) providers. Each provider has its own format of images that it can work with. For example, AWS instances use AMIs, and vSphere uses OVAs.
+
+For detailed documentation, see https://image-builder.sigs.k8s.io/capi/capi.html.


### PR DESCRIPTION
This patch updates the top-level README to list the projects within the
repo, and link to the published documentation. A README specifically for
the CAPI builder is added, and the mdbook now contains a CAPI quick
start.

I think this will address the CAPI portions of #148, but does not do anything to help out with the kube-deploy stuff.

/assign @moshloop @detiber 
/cc @timothysc 