### PR TITLE
[capi/azure] add skuLongSummary to SKU template

### DIFF
--- a/images/capi/packer/azure/ubuntu-sku-template.json
+++ b/images/capi/packer/azure/ubuntu-sku-template.json
@@ -2,6 +2,7 @@
     "planId": "{{ID}}",
     "microsoft-azure-corevm.skuTitle": "Kubernetes {{K8S_VERSION}} Ubuntu 18.04",
     "microsoft-azure-corevm.skuSummary": "Cluster API Kubernetes {{K8S_VERSION}} Ubuntu 18.04 Base Image",
+    "microsoft-azure-corevm.skuLongSummary": "Cluster API Kubernetes {{K8S_VERSION}} Ubuntu 18.04 Base Image",
     "microsoft-azure-corevm.hideSKUForSolutionTemplate": true,
     "microsoft-azure-corevm.hardened": false,
     "microsoft-azure-corevm.deploymentModels": [


### PR DESCRIPTION
Add skuLongSummary field to the Azure create SKU template since it is now required.