### PR TITLE
Move "Wants=" under Unit rather than Install

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
+++ b/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
@@ -18,8 +18,8 @@
 # https://cloudinit.readthedocs.io/en/latest/topics/boot.html#final
 After=cloud-init.service
 Before=cloud-config.service
+Wants=cloud-init.service
 
 [Install]
-Wants=cloud-init.service
 WantedBy=cloud-config.service
 


### PR DESCRIPTION
option `Wants=` should be under Unit. See: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
Upon daemon-reload and restart, it would cause this issue: systemd unknown lvalue wants in section 'install'