### PR TITLE
Add containerd systemd drop-in for max tasks

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -48,11 +48,16 @@
   template:
     dest: /etc/systemd/system/containerd.service.d/boot-order.conf
     src: etc/systemd/system/containerd.service.d/boot-order.conf
-    
+
 - name: Create containerd memory pressure drop in file
   template:
     dest: /etc/systemd/system/containerd.service.d/memory-pressure.conf
     src: etc/systemd/system/containerd.service.d/memory-pressure.conf
+
+- name: Create containerd max tasks drop in file
+  template:
+    dest: /etc/systemd/system/containerd.service.d/max-tasks.conf
+    src: etc/systemd/system/containerd.service.d/max-tasks.conf
 
 - name: start containerd service
   systemd:

--- a/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/max-tasks.conf
+++ b/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/max-tasks.conf
@@ -1,0 +1,3 @@
+[Service]
+# Do not limit the number of tasks that can be spawned by containerd
+TasksMax=infinity


### PR DESCRIPTION
The default `TasksMax` setting is 512, which has a practical effect of
limiting the number of pods on a node to ~225. In other implementations,
especially for k/k docker, this restriction has been removed. Do the
same thing here.

For reference, here is what is mainline k/k for docker on GCE: https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh#L1363

/assign @detiber 