### PR TITLE
Perform tdnf distro-sync for photon build

### DIFF
--- a/images/capi/ansible/roles/common/tasks/photon.yml
+++ b/images/capi/ansible/roles/common/tasks/photon.yml
@@ -29,15 +29,29 @@
 
 - import_tasks: rpm_repos.yml
 
+- name: Perform a tdnf distro-sync
+  command: tdnf distro-sync -y --refresh
+  register: distro
+  changed_when: '"Nothing to do" not in distro.stderr'
+
+  # When the linux package is upgraded on Photon, the current /lib/modules
+  # folder is removed, causing future package installs to file if they involve
+  # kmods, which a lot of our future packages do. A reboot fixes this. In the
+  # future it might be nice to only reboot if that package was upgraded, but
+  # a reboot of Photon is generally very fast so this is fine for now.
+- name: Reboot after distro sync
+  reboot:
+  when: distro.changed
+
 - name: Concatenate the Photon RPMs
   set_fact:
     photon_rpms: "{{ common_photon_rpms | join(' ') }}"
 
 - name: install baseline dependencies
-  command: tdnf install {{ photon_rpms }} -y --refresh
+  command: tdnf install {{ photon_rpms }} -y
 
 - name: install extra RPMs
-  command: tdnf install {{ extra_rpms }} -y --refresh
+  command: tdnf install {{ extra_rpms }} -y
   when: extra_rpms != ""
 
 - name: disable service docker and ensure it is masked (installed via 'minimal' package)

--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -327,9 +327,9 @@ ${EULA}
       <Info>Information about the installed software</Info>
       <Product>${OS_NAME} and Kubernetes ${KUBERNETES_SEMVER}</Product>
       <Vendor>VMware Inc.</Vendor>
-      <VendorUrl>https://vmware.com</VendorUrl>
       <Version>kube-${KUBERNETES_SEMVER}</Version>
       <FullVersion>kube-${KUBERNETES_SEMVER}</FullVersion>
+      <VendorUrl>https://vmware.com</VendorUrl>
       <Property ovf:userConfigurable="false" ovf:value="${BUILD_TIMESTAMP}" ovf:type="string" ovf:key="BUILD_TIMESTAMP"/>
       <Property ovf:userConfigurable="false" ovf:value="${BUILD_DATE}" ovf:type="string" ovf:key="BUILD_DATE"/>
       <Property ovf:userConfigurable="false" ovf:value="${CNI_VERSION}" ovf:type="string" ovf:key="CNI_VERSION"/>


### PR DESCRIPTION
The photon ansible steps were not doing a tdnf distro-sync -- meaning
that basic OS packages were not being upgraded to the latest version,
missing possibly critical security and bug fixes.

However, when Photon upgrades the "linux" package, it removes the
existing /lib/modules dir instead of waiting until the next reboot,
causing future package installs that involve kmods to fail. So we also
need to reboot the node after the distro-sync.

fixes #162 

This PR also includes a needed fix to the OVF metadata. In 01f50634d1e2a2d1a2c774ba3e66adb18a81089f, I removed the `ProductURL` and `Category` fields, as they are not needed. I also *moved* the `VendorURL` property to be next to `Vendor` (I thought it looked nicer). However, moving that property **breaks** the importing of the OVA. Why?? I have no idea... But apparently ordering matters. :/

/assign @detiber 
/cc @figo 