### PR TITLE
Force cri-tools symlink

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -17,6 +17,7 @@
     src:   "/usr/local/bin/{{ item }}"
     dest:  "/usr/bin/{{ item }}"
     state: link
+    force: yes
   loop:
   - ctr
   - crictl


### PR DESCRIPTION
When Kubernetes is not installed via package, there is an Ansible
snippet that symlinks cri-tools from /usr/local/bin to /usr/bin. With
the latest Photon packages installed, a newer version of Docker is
pulled in, which now requires containerd. This puts a binary at
/usr/bin/ctr, and when we try installing the *newer* containerd and
symlink from /usr/local/bin, Ansible refuses to overwrite it. This patch
forces the overwrite.

/assign @detiber 
/cc @dims @figo 