### PR TITLE
ova: fix type of open-vm-tools for Photon

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -53,6 +53,7 @@ common_photon_rpms:
 - net-tools
 - ntp
 - openssl-c_rehash
+- open-vm-tools
 - python-netifaces
 - python3-pip
 - python-requests

--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -16,7 +16,7 @@
         "libtool", "linux",
         "motd",
         "net-tools",
-        "openssh", "openvm-tools",
+        "openssh", "open-vm-tools",
         "pkg-config", "photon-release", "photon-repos", "procps-ng",
         "rpm",
         "sed",


### PR DESCRIPTION
With the recent change to not use the 'minimal' package, a typo was made
that listed open-vmtools instead of open-vm-tools. This patch fixes
that, and also lists the package in the Ansible scripts just for
consistency with the other OS's.

/assign @dims @figo 
/cc @frapposelli @ppadmavilasom 