### PR TITLE
Add vsphere builder

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -125,6 +125,7 @@ PLATFORMS_AND_VERSIONS	:=	$(CENTOS_VERSIONS) \
 							$(UBUNTU_VERSIONS)
 
 OVA_BUILD_NAMES			:=	$(addprefix ova-,$(PLATFORMS_AND_VERSIONS))
+VSPHERE_BUILD_NAMES		:=	$(addprefix vsphere-,$(OVA_BUILD_NAMES))
 ESX_BUILD_NAMES			:=	$(addprefix esx-,$(OVA_BUILD_NAMES))
 
 AMI_BUILD_NAMES			?=	ami-default
@@ -138,6 +139,7 @@ QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804
 ## --------------------------------------
 ## Dynamic build targets
 ## --------------------------------------
+VSPHERE_BUILD_TARGETS	:= $(addprefix build-,$(VSPHERE_BUILD_NAMES))
 OVA_BUILD_TARGETS	:= $(addprefix build-,$(OVA_BUILD_NAMES))
 ESX_BUILD_TARGETS	:= $(addprefix build-,$(ESX_BUILD_NAMES))
 AMI_BUILD_TARGETS	:= $(addprefix build-,$(AMI_BUILD_NAMES))
@@ -146,13 +148,17 @@ AZURE_BUILD_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_NAMES))
 DO_BUILD_TARGETS 	:= $(addprefix build-,$(DO_BUILD_NAMES))
 QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 
+.PHONY: $(VSPHERE_BUILD_TARGETS)
+$(VSPHERE_BUILD_TARGETS):
+	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json"  -except=esx -except=local $(PACKER_VAR_FILES) -only=vsphere -force packer/ova/packer.json
+
 .PHONY: $(OVA_BUILD_TARGETS)
 $(OVA_BUILD_TARGETS):
-	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-,,$@).json)" -except=esx $(PACKER_VAR_FILES) packer/ova/packer.json
+	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-,,$@).json)" -except=esx -except=vsphere $(PACKER_VAR_FILES) -only=vmware-iso packer/ova/packer.json
 
 .PHONY: $(ESX_BUILD_TARGETS)
 $(ESX_BUILD_TARGETS):
-	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-esx-,,$@).json)" -var-file="packer/ova/esx.json" -except=local $(PACKER_VAR_FILES) packer/ova/packer.json
+	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-esx-,,$@).json)" -var-file="packer/ova/esx.json" -except=vsphere -except=local $(PACKER_VAR_FILES) -only=vmware-iso packer/ova/packer.json
 
 .PHONY: $(AMI_BUILD_TARGETS)
 $(AMI_BUILD_TARGETS):
@@ -200,6 +206,11 @@ build-azure-vhd-ubuntu-1804: ## Builds Ubuntu 18.04 VHD image for Azure
 build-do-default: ## Builds the DigitalOcean snapshot default image
 
 build-gce-default: ## Builds the GCE default image
+
+build-vsphere-ova-centos-7: ## Builds CentOS 7 template on vSphere
+build-vsphere-ova-photon-3: ## Builds Photon 3 template on vSphere
+build-vsphere-ova-ubuntu-1804: ## Builds Ubuntu 18.04 template on vSphere
+build-vsphere-ova-ubuntu-2004: ## Builds Ubuntu 20.04 template on vSphere
 
 build-ova-centos-7: ## Builds CentOS 7 OVA w local hypervisor
 build-ova-photon-3: ## Builds Photon 3 OVA w local hypervisor

--- a/images/capi/packer/ova/linux/centos/http/7/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/7/ks.cfg
@@ -53,6 +53,7 @@ part / --grow --asprimary --fstype=ext4 --label=slash
 openssh-server
 sed
 sudo
+open-vm-tools
 
 # Remove unnecessary firmware
 -*-firmware

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -98,7 +98,7 @@ d-i apt-setup/use_mirror boolean false
 d-i apt-setup/services-select multiselect none
 
 # Customize the list of packages installed.
-d-i pkgsel/include string openssh-server
+d-i pkgsel/include string openssh-server open-vm-tools unattended-upgrades
 
 
 # Ensure questions about these packages do not bother the installer.

--- a/images/capi/packer/ova/ova-centos-7.json
+++ b/images/capi/packer/ova/ova-centos-7.json
@@ -3,6 +3,7 @@
   "distro_name": "centos",
   "os_display_name": "CentOS 7",
   "guest_os_type": "centos7-64",
+  "vsphere_guest_os_type": "centos7_64Guest",
   "iso_url": "https://mirrors.edge.kernel.org/centos/7.7.1908/isos/x86_64/CentOS-7-x86_64-Minimal-1908.iso",
   "iso_checksum": "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d",
   "iso_checksum_type": "sha256",

--- a/images/capi/packer/ova/ova-photon-3.json
+++ b/images/capi/packer/ova/ova-photon-3.json
@@ -3,6 +3,7 @@
   "distro_name": "photon",
   "os_display_name": "VMware Photon OS 64-bit",
   "guest_os_type": "vmware-photon-64",
+  "vsphere_guest_os_type": "vmwarePhoton64Guest",
   "iso_url": "https://dl.bintray.com/vmware/photon/3.0/Rev2/iso/Update1/photon-minimal-3.0-a0f216d.iso",
   "iso_checksum": "090f5c98b6b8406dbc3ad856aa1ed23bad1ce5b0",
   "iso_checksum_type": "sha1",

--- a/images/capi/packer/ova/ova-ubuntu-1804.json
+++ b/images/capi/packer/ova/ova-ubuntu-1804.json
@@ -3,6 +3,7 @@
   "distro_name": "ubuntu",
   "os_display_name": "Ubuntu 18.04",
   "guest_os_type": "ubuntu-64",
+  "vsphere_guest_os_type": "ubuntu64Guest",
   "iso_url": "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-server-amd64.iso",
   "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
   "iso_checksum_type": "sha256",

--- a/images/capi/packer/ova/ova-ubuntu-2004.json
+++ b/images/capi/packer/ova/ova-ubuntu-2004.json
@@ -3,6 +3,7 @@
   "distro_name": "ubuntu",
   "os_display_name": "Ubuntu 20.04",
   "guest_os_type": "ubuntu-64",
+  "vsphere_guest_os_type": "ubuntu64Guest",
   "iso_url": "http://cdimage.ubuntu.com/ubuntu-server/daily/20200107/focal-server-amd64.iso",
   "iso_checksum": "4901eeba3ffaa56b9356bb496d161ade5bd1e2df579552aa6c40f33984a34614",
   "iso_checksum_type": "sha256",

--- a/images/capi/packer/ova/packer.json
+++ b/images/capi/packer/ova/packer.json
@@ -5,20 +5,28 @@
     "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",
     "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+    "cluster": "",
     "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "convert_to_template": "false",
+    "datastore": "",
     "disable_public_repos": "false",
     "disk_type_id": "0",
+    "disk_controller_type": "pvscsi",
+    "disk_thin_provisioned": "true",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "extra_debs": "",
     "extra_repos": "",
     "extra_rpms": "",
+    "folder": "",
     "format": "",
     "guestinfo_datasource_slug": "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo",
     "guestinfo_datasource_ref": "v1.3.0",
     "guest_os_type": null,
+    "vsphere_guest_os_type": null,
     "headless": "true",
+    "insecure_connection": "false",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,
@@ -36,6 +44,7 @@
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
     "network": "",
+    "network_card": "vmxnet3",
     "output_dir": "./output/{{user `build_version`}}",
     "reenable_public_repos": "true",
     "remove_extra_repos": "false",
@@ -48,6 +57,8 @@
     "ssh_username": "builder",
     "ssh_password": "builder",
     "vmx_version": "13",
+    "username": "",
+    "vcenter_server": "",
     "vnc_bind_address": "127.0.0.1",
     "vnc_disable_password": "false",
     "vnc_port_min": "5900",
@@ -55,7 +66,7 @@
   },
   "builders": [
     {
-      "name": "{{user `build_name`}}",
+      "name": "vmware-iso",
       "vm_name": "{{user `build_version`}}",
       "vmdk_name": "{{build_name}}",
       "output_directory": "{{user `output_dir`}}",
@@ -98,6 +109,57 @@
       "vmx_data": {
         "ethernet0.networkName": "{{user `network`}}"
       }
+    },
+    {
+      "type": "vsphere-iso",
+      "name": "vsphere",
+
+      "vcenter_server":      "{{user `vcenter_server`}}",
+      "username":            "{{user `username`}}",
+      "password":            "{{user `password`}}",
+      "insecure_connection": "{{user `insecure_connection`}}",
+
+      "vm_name": "{{user `build_version`}}",
+      "datastore": "{{user `datastore`}}",
+      "folder": "{{user `folder`}}",
+      "host":     "{{user `host`}}",
+      "convert_to_template": "{{user `convert_to_template`}}",
+      "cluster": "{{user `cluster`}}",
+      "network": "{{user `network`}}",
+
+
+
+      "vm_version": "{{user `vmx_version`}}",
+      "CPUs": 1,
+      "cpu_cores": 1,
+      "RAM": 2048,
+      "disk_size": 20480,
+      "disk_controller_type": "{{user `disk_controller_type`}}",
+      "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}",
+      "network_card": "{{user `network_card`}}",
+      "guest_os_type": "{{user `vsphere_guest_os_type`}}",
+
+      "boot_wait": "{{user `boot_wait`}}",
+      "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
+      "iso_urls": "{{user `iso_url`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+
+      "communicator": "ssh",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_timeout": "4h",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_command_suffix`}}"
+      ],
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+
+      "export": {
+        "force": true,
+        "output_directory": "{{user `output_dir`}}"
+      }
     }
   ],
   "provisioners": [
@@ -122,10 +184,12 @@
       "output": "{{user `output_dir`}}/packer-manifest.json",
       "strip_path": true,
       "custom_data": {
+        "build_name": "{{user `build_name`}}",
         "build_timestamp": "{{user `build_timestamp`}}",
         "build_date": "{{isotime}}",
         "containerd_version": "{{user `containerd_version`}}",
         "guest_os_type": "{{user `guest_os_type`}}",
+        "vsphere_guest_os_type": "{{user `vsphere_guest_os_type`}}",
         "kubernetes_cni_semver": "{{user `kubernetes_cni_semver`}}",
         "kubernetes_semver": "{{user `kubernetes_semver`}}",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
@@ -139,14 +203,22 @@
         "cd {{user `output_dir`}}",
         "tar xf {{user `build_version`}}.ova",
         "rm {{user `build_version`}}.ova",
-        "GIT_VERSION=`git describe --dirty` ../../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk1.vmdk"
+        "GIT_VERSION=`git describe --dirty` ../../hack/image-build-ova.py --stream_vmdk --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk1.vmdk"
+      ]
+    },
+    {
+      "name": "vsphere",
+      "type": "shell-local",
+      "inline": [
+        "cd {{user `output_dir`}}",
+        "GIT_VERSION=`git describe --dirty` ../../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk-0.vmdk"
       ]
     },
     {
       "name": "local",
       "type": "shell-local",
       "inline": [
-        "GIT_VERSION=`git describe --dirty` ./hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt {{user `output_dir`}}",
+        "GIT_VERSION=`git describe --dirty` ./hack/image-build-ova.py --stream_vmdk --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt {{user `output_dir`}}",
         "./hack/image-post-create-config.sh {{user `output_dir`}}"
       ]
     }

--- a/images/capi/packer/ova/vsphere.json
+++ b/images/capi/packer/ova/vsphere.json
@@ -1,0 +1,11 @@
+{
+    "vcenter_server":"",
+    "username":"",
+    "password":"",
+    "datastore":"",
+    "folder": "",
+    "cluster": "",
+    "network": "",
+    "convert_to_template": "false",
+    "insecure_connection": "false"
+}


### PR DESCRIPTION
Since Packer has integrated a way to create image using vSphere API (and not a hack using ssh on esxi), I've created a vsphere builder to allow the creation of template directly on the vSphere.

Documentation is missing from the PR because the ova provisionner is refered as vSphere in it, in which way you prefer me to add this provisionner: a new section of vsphere or an other chapter but with which name ?