### PR TITLE
Add nfs utils so NFS mounting works in photon3

### DIFF
--- a/images/capi/ansible/roles/common/defaults/main.yml
+++ b/images/capi/ansible/roles/common/defaults/main.yml
@@ -60,6 +60,7 @@ common_photon_rpms:
 - socat
 - tar
 - unzip
+- nfs-utils
 
 common_pinned_debs: []
 common_redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"


### PR DESCRIPTION
This package was missing, so you're unable to do NFS mounts properly.  This PR just adds it.