### PR TITLE
ova: set PhotonOS password expiry to never

### DIFF
--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -1,8 +1,9 @@
 {
     "hostname": "localhost",
     "password": {
-        "crypted": false,
-        "text": "builder"
+        "crypted": true,
+        "text": "*",
+        "age": -1
     },
     "disk": "/dev/sda",
     "packages": [


### PR DESCRIPTION
This patch sets the default password expiry to `-1`, which makes it be equivalent to never. The default in PhotonOS is 90 days, which would lead to long-term issues with both the root account and the capv account created by CAPV. Even though passwords are not used anywhere with CAPV, an expired password means that admins logging in (even via SSH keypair, the only way) are prompted to change a password. Both CentOS and Ubuntu already default to never.

We also set the PhotonOS root account back to its [default](https://github.com/vmware/photon/blob/7b2f140e6496c7baaae4c99df9c1c9fdadabb9d3/installer/ks_config.txt#L156-L175). Though it's kind of a funny "default" -- if you don't set `text` or `crypted` fields in the kickstart, the installer aborts as they are required fields. 🤷‍♂ 
There is no reason to set an actual password for the root account here since it is never used. `sudo` from the `capv` user works as intended here.

Note that setting `age: -1` also [changes the default value](https://github.com/vmware/photon/blob/3.0/installer/modules/m_updaterootpassword.py#L36-L38) in `/etc/login.defs`, meaning that it applies to the `capv` user when it is created during initial boot via `cloud-init`.

Here are the relevant account details with this patch:

```sh
root@capi [ ~ ]# chage -l capv
Last password change					: Mar 30, 2020
Password expires					: never
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 0
Maximum number of days between password change		: 99999
Number of days of warning before password expires	: 7
root@capi [ ~ ]# chage -l root
Last password change					: Mar 30, 2020
Password expires					: never
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 0
Maximum number of days between password change		: 99999
Number of days of warning before password expires	: 7
```

Before this patch:

```sh
root@capi [ ~ ]# chage -l capv
Last password change					: Mar 30, 2020
Password expires					: Jun 28, 2020
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 0
Maximum number of days between password change		: 90
Number of days of warning before password expires	: 7
root@capi [ ~ ]# chage -l root
Last password change					: Mar 23, 2020
Password expires					: Jun 21, 2020
Password inactive					: never
Account expires						: never
Minimum number of days between password change		: 0
Maximum number of days between password change		: 90
Number of days of warning before password expires	: 7
```

/assign @dims @frapposelli @detiber 