### PR TITLE
Deploy haveged as part of base image to prevent low-entropy situations

### DIFF
--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -13,6 +13,7 @@
         "e2fsprogs",
         "file", "filesystem", "findutils",
         "gdbm", "grep", "gzip",
+        "haveged",
         "iana-etc", "initramfs", "iptables", "iproute2", "iputils",
         "libtool", "linux",
         "motd",


### PR DESCRIPTION
Pick up some proactive recommendation from https://github.com/kubernetes/kubernetes/issues/60751