### PR TITLE
Explicit installation of the latest SSMAgent

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -19,3 +19,29 @@
     packages:
       - https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
       - awscli
+
+- name: install aws agents RPM
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  when: ansible_os_family == "RedHat"
+
+- name: Ensure ssm agent is running RPM
+  service:
+    name: amazon-ssm-agent
+    state: started
+    enabled: yes
+  when: ansible_os_family == "RedHat"
+
+- name: install aws agents Ubuntu
+  shell: snap install amazon-ssm-agent --classic
+  when: ansible_distribution == "Ubuntu"
+
+- name: Ensure ssm agent is running Ubuntu
+  service:
+    name: snap.amazon-ssm-agent.amazon-ssm-agent.service
+    state: started
+    enabled: yes
+  when: ansible_distribution == "Ubuntu"


### PR DESCRIPTION
This enables SSM capabilities on CentOS and Ubuntu flavors of AMI images, allowing easier troubleshooting and accessibility when the proper SSM IAM permissions are applied to the image.

The Amazon Linux 2 flavor already had this turned on by default, but would sometimes not have the latest version of the agent, so this also conveniently upgrades that agent as well.

Fixes: https://github.com/kubernetes-sigs/image-builder/issues/158