### PR TITLE
[capi/Azure] Use pip3 to install Azure CLI

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -14,6 +14,7 @@
 ---
 - name: install Azure clients
   pip:
+    executable: pip3
     name: "{{ packages }}"
   vars:
     packages:


### PR DESCRIPTION
Installing the Azure CLI now requires using `pip3`. Prior to this change, installing az-cli 2.3.x fails with 

```
Collecting mock~=4.0 (from azure-cli)
  Could not find a version that satisfies the requirement mock~=4.0 (from azure-cli) (from versions: 0.5.0, 0.6.0, 0.7.0b1, 0.7.0b2, 0.7.0b3, 0.7.0b4, 0.7.0rc1, 0.7.0, 0.7.1, 0.7.2, 0.8.0, 1.0b1, 1.0.0, 1.0.1, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.2.0, 1.3.0, 2.0.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5)
No matching distribution found for mock~=4.0 (from azure-cli)
```

According to https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?view=azure-cli-latest#prerequisites, "The CLI has dropped support for Python 2.7 since version 2.1.0. New versions no longer guarantee to run with Python 2.7 correctly."