### PR TITLE
Enable rng-tools as default entropy gather in Photon images

### DIFF
--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -17,18 +17,14 @@
         "libtool", "linux",
         "motd",
         "net-tools",
-        "openssh", "open-vm-tools",
+        "openssh-server", "open-vm-tools",
         "pkg-config", "photon-release", "photon-repos", "procps-ng",
         "rng-tools", "rpm",
-        "sed",
+        "sed", "sudo",
         "tdnf", "tzdata",
         "util-linux",
         "vim",
         "which"
-    ],
-    "additional_packages": [
-        "openssh-server",
-        "sudo"
     ],
     "postinstall": [
         "#!/bin/sh",

--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -19,7 +19,7 @@
         "net-tools",
         "openssh", "open-vm-tools",
         "pkg-config", "photon-release", "photon-repos", "procps-ng",
-        "rpm",
+        "rng-tools", "rpm",
         "sed",
         "tdnf", "tzdata",
         "util-linux",


### PR DESCRIPTION
Part of #194 - while we are waiting to see what needs to be done on Ubuntu, enable this on Photon, just like was done https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/880.

This is partly in prep for #197 .

While we are modifying the Kickstart file anyways, make an additional cleanup (which is in a separate commit) that removes the use of `additional_packages`. There is no reason to specify two packages there instead of just listing them in `packages`.

/assign @randomvariable @detiber 