### PR TITLE
Add Buster images for k8s 1.17

### DIFF
--- a/images/kube-deploy/imagebuilder/aws-1.17-buster.yaml
+++ b/images/kube-deploy/imagebuilder/aws-1.17-buster.yaml
@@ -1,0 +1,11 @@
+Cloud: aws
+TemplatePath: templates/1.17-buster.yml
+Tags:
+  k8s.io/kernel: "4.19"
+  k8s.io/version: "1.17"
+  k8s.io/family: "default"
+  k8s.io/distro: "debian"
+  k8s.io/ssh-user: "admin"
+# Ensure the image is repeatable - really we should be locking to a tag
+BootstrapVZRepo: https://github.com/justinsb/bootstrap-vz.git
+BootstrapVZBranch: image18

--- a/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
+++ b/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
@@ -58,7 +58,7 @@ type AWSConfig struct {
 
 func (c *AWSConfig) InitDefaults(region string) {
 	c.Config.InitDefaults()
-	c.InstanceType = "m3.medium"
+	c.InstanceType = "c4.large"
 
 	if region == "" {
 		region = "us-east-1"
@@ -71,52 +71,46 @@ func (c *AWSConfig) InitDefaults(region string) {
 		// A slightly older image, but the newest one we have
 		c.ImageID = "ami-da69a1b7"
 
-	// Debian 9.10 images from https://wiki.debian.org/Cloud/AmazonEC2Image/Stretch
+	// Debian 10.3 images from https://wiki.debian.org/Cloud/AmazonEC2Image/Buster
 	case "ap-east-1":
-		c.ImageID = "ami-0a81e23ced9c32d26"
+		c.ImageID = "ami-f9c58188"
 	case "ap-northeast-1":
-		c.ImageID = "ami-0aad015f7b135e198"
+		c.ImageID = "ami-0fae5501ae428f9d7"
 	case "ap-northeast-2":
-		c.ImageID = "ami-00a96e50f990be54c"
+		c.ImageID = "ami-0522874b039290246"
 	case "ap-south-1":
-		c.ImageID = "ami-0c7bd0941d9b93c88"
+		c.ImageID = "ami-03b4e18f70aca8973"
 	case "ap-southeast-1":
-		c.ImageID = "ami-0cca8bafd3ad1ad08"
+		c.ImageID = "ami-0852293c17f5240b3"
 	case "ap-southeast-2":
-		c.ImageID = "ami-0c6d33437a8337f6e"
+		c.ImageID = "ami-03ea2db714f1f6acf"
 	case "ca-central-1":
-		c.ImageID = "ami-001c474f9452c7d93"
+		c.ImageID = "ami-094511e5020cdea18"
 	case "eu-central-1":
-		c.ImageID = "ami-04dd896c9036d974b"
+		c.ImageID = "ami-0394acab8c5063f6f"
 	case "eu-north-1":
-		c.ImageID = "ami-04cc93d303a4dd18c"
+		c.ImageID = "ami-0c82d9a7f5674320a"
 	case "eu-west-1":
-		c.ImageID = "ami-08d95e3db80c57a5e"
+		c.ImageID = "ami-006d280940ad4a96c"
 	case "eu-west-2":
-		c.ImageID = "ami-04129aa76aebf3aa2"
+		c.ImageID = "ami-08fe9ea08db6f1258"
 	case "eu-west-3":
-		c.ImageID = "ami-024a4edbad921fd5c"
+		c.ImageID = "ami-04563f5eab11f2b87"
 	case "me-south-1":
-		c.ImageID = "ami-0e8670e0374463e7b"
+		c.ImageID = "ami-0492a01b319d1f052"
 	case "sa-east-1":
-		c.ImageID = "ami-082e93a75a7f2ba1d"
+		c.ImageID = "ami-05e16feea94258a69"
 	case "us-east-1":
-		c.ImageID = "ami-02c3fa55e499f1fb3"
+		c.ImageID = "ami-04d70e069399af2e9"
 	case "us-east-2":
-		c.ImageID = "ami-06858f33bbe384bbb"
+		c.ImageID = "ami-04100f1cdba76b497"
 	case "us-west-1":
-		c.ImageID = "ami-0dd6bad099b8b3889"
+		c.ImageID = "ami-014c78f266c5b7163"
 	case "us-west-2":
-		c.ImageID = "ami-0964442b6f325859a"
+		c.ImageID = "ami-023b7a69b9328e1f9"
 
 	default:
 		klog.Warningf("Building in unknown region %q - will require specifying an image, may not work correctly")
-	}
-
-	// Not all regions support m3.medium
-	switch c.Region {
-	case "us-east-2":
-		c.InstanceType = "m4.large"
 	}
 }
 

--- a/images/kube-deploy/imagebuilder/templates/1.17-buster.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.17-buster.yml
@@ -1,0 +1,205 @@
+---
+{{ if eq .Cloud "aws" }}
+name: k8s-1.17-debian-{system.release}-{system.architecture}-{provider.virtualization}-ebs-{%Y}-{%m}-{%d}
+{{ else }}
+name: k8s-1.17-debian-{system.release}-{system.architecture}-{%Y}-{%m}-{%d}
+{{ end }}
+provider:
+{{ if eq .Cloud "aws" }}
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+{{ else if eq .Cloud "gce" }}
+  name: gce
+  gcs_destination: {{ .GCSDestination }}
+  gce_project: {{ .Project }}
+{{ else }}
+  name: {{ .Cloud }}
+{{ end }}
+  description: Kubernetes 1.17 Base Image - Debian {system.release} {system.architecture}
+bootstrapper:
+  workspace: /target
+  # tarball speeds up development, but for prod builds we want to be 100% sure...
+  # tarball: true
+  # todo: switch to variant: minbase
+system:
+  release: buster
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+{{ if eq .Cloud "aws" }}
+  backing: ebs
+{{ else if eq .Cloud "gce" }}
+  backing: raw
+{{ end }}
+  partitions:
+    type: gpt
+    root:
+      filesystem: ext4
+      # We create the FS with more inodes... docker is pretty inode hungry
+      format_command: [ 'mkfs.{fs}', '-i', '4096', '{device_path}' ]
+      size: 8GiB
+packages:
+{{ if eq .Cloud "aws" }}
+  mirror: http://cloudfront.debian.net/debian
+{{ end }}
+  install:
+    # Important utils for administration
+    # if minbase - openssh-server
+
+    # Ensure systemd scripts run on shutdown
+    - acpi-support
+
+    # these packages are generally useful
+    # (and are the ones from the GCE image)
+    - rsync
+    - screen
+    - vim
+
+    # needed for docker
+    - arptables
+    - ebtables
+    - iptables
+    - libapparmor1
+    - libltdl7
+
+    # Handy utilities
+    - htop
+    - tcpdump
+    - iotop
+    - ethtool
+    - sysstat
+
+    # needed for setfacl below
+    - acl
+
+{{ if eq .Cloud "aws" }}
+    # these packages are included in the official AWS image
+    - python-boto
+    - python3-boto
+    - apt-transport-https
+    - lvm2
+    - ncurses-term
+    - parted
+    - cloud-init
+    - cloud-utils
+    - gdisk
+    - systemd
+    - systemd-sysv
+
+    # these packages are included in the official image, but we remove them
+    # awscli : we install from pip instead
+{{ end }}
+
+    # These packages would otherwise be installed during first boot
+    - aufs-tools
+    - curl
+    - python-yaml
+    - git
+    - nfs-common
+    - bridge-utils
+    - logrotate
+    - socat
+    - python-apt
+    - apt-transport-https
+    - unattended-upgrades
+    - lvm2
+    - btrfs-tools
+
+{{ if eq .Cloud "aws" }}
+    # So we can install the latest awscli
+    - python-pip
+{{ end }}
+
+plugins:
+{{ if eq .Cloud "gce" }}
+  ntp:
+    servers:
+    - metadata.google.internal
+{{ else }}
+  ntp: {}
+{{ end }}
+
+{{ if eq .Cloud "aws" }}
+  cloud_init:
+    metadata_sources: Ec2
+    username: admin
+    enable_modules:
+      cloud_init_modules:
+        - {module: growpart, position: 4}
+{{ end }}
+
+  commands:
+    commands:
+{{ if eq .Cloud "aws" }}
+       # Install awscli through python-pip
+       - [ 'chroot', '{root}', 'pip', 'install', 'awscli' ]
+{{ end }}
+
+       # We don't enable unattended upgrades - nodeup can always add it
+       # but if we add it now, there's a race to turn it off
+       # cloud-init depends on unattended-upgrades, so we can't just remove it
+       # Instead we turn them off; we turn them on later
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Update-Package-Lists \"0\";" > /etc/apt/apt.conf.d/20auto-upgrades' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
+       # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
+
+       # Install Docker
+       - [ 'mkdir', '-p', '{root}/var/cache/nodeup/packages' ]
+       - [ 'wget', 'https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb', '-O', '{root}/var/cache/nodeup/packages/containerd.io.deb' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/packages; echo "365e4a7541ce2cf3c3036ea2a9bf6b40a50893a8  containerd.io.deb" | shasum -c -' ]
+       - [ 'wget', 'https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce-cli_19.03.4~3-0~debian-buster_amd64.deb', '-O', '{root}/var/cache/nodeup/packages/docker-ce-cli.deb' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/packages; echo "2549a364f0e5ce489c79b292b78e349751385dd5  docker-ce-cli.deb" | shasum -c -' ]
+       - [ 'wget', 'https://download.docker.com/linux/debian/dists/buster/pool/stable/amd64/docker-ce_19.03.4~3-0~debian-buster_amd64.deb', '-O', '{root}/var/cache/nodeup/packages/docker-ce.deb' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/packages; echo "492a70f29ceffd315ee9712b33004491c6f59e49  docker-ce.deb" | shasum -c -' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /var/cache/nodeup/packages/containerd.io.deb' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /var/cache/nodeup/packages/docker-ce-cli.deb' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /var/cache/nodeup/packages/docker-ce.deb' ]
+       - [ 'chroot', '{root}', 'systemctl', 'disable', 'containerd.service', 'docker.service', 'docker.socket' ]
+
+       # We perform a full replacement of some grub conf variables:
+       #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)
+       #   GRUB_TIMEOUT (remove boot delay)
+       # (but leave the old versions commented out for people to see)
+       - [ 'chroot', '{root}', 'touch', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_CMDLINE_LINUX_DEFAULT=/#GRUB_CMDLINE_LINUX_DEFAULT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0 nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', 'update-grub2' ]
+
+       # Update everything to latest versions
+       - [ 'chroot', '{root}', 'apt-get', 'update' ]
+       - [ 'chroot', '{root}', 'apt-get', 'dist-upgrade', '--yes' ]
+
+       # Cleanup packages
+       - [ 'chroot', '{root}', 'apt-get', 'autoremove', '--yes' ]
+
+       # Remove machine-id, so that we regenerate next boot
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "" > /etc/machine-id' ]
+
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
+       # journald requires machine-id, so add a PreStart
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "ExecStartPre=/bin/systemd-machine-id-setup" >> /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]
+
+       # Make sure journald is persistent
+       # From /usr/share/doc/systemd/README.Debian
+       - [ 'chroot', '{root}', 'install', '-d', '-g', 'systemd-journal', '/var/log/journal' ]
+       - [ 'chroot', '{root}', 'setfacl', '-R', '-nm', 'g:adm:rx,d:g:adm:rx', '/var/log/journal' ]
+
+       # Use iptables-legacy by default
+       - [ 'chroot', '{root}', 'update-alternatives', '--set', 'iptables', '/usr/sbin/iptables-legacy' ]
+       - [ 'chroot', '{root}', 'update-alternatives', '--set', 'ip6tables', '/usr/sbin/ip6tables-legacy' ]
+       - [ 'chroot', '{root}', 'update-alternatives', '--set', 'arptables', '/usr/sbin/arptables-legacy' ]
+       - [ 'chroot', '{root}', 'update-alternatives', '--set', 'ebtables', '/usr/sbin/ebtables-legacy' ]


### PR DESCRIPTION
This PR should make it possible to use Debian Buster by default in Kops 1.17 if we want to.
It has the optimisations from https://github.com/kubernetes-sigs/image-builder/pull/199 and also set the iptables mode to *legacy* by default, making it compatible with all the CNI plugins. 

Requires also a small patch in https://github.com/justinsb/bootstrap-vz:
```diff
diff --git a/bootstrapvz/plugins/cloud_init/manifest-schema.yml b/bootstrapvz/plugins/cloud_init/manifest-schema.yml
index 0f2a706..dde0974 100644
--- a/bootstrapvz/plugins/cloud_init/manifest-schema.yml
+++ b/bootstrapvz/plugins/cloud_init/manifest-schema.yml
@@ -14,6 +14,7 @@ properties:
         - jessie
         - stable
         - stretch
+        - buster
         - testing
         - sid
         - unstable
diff --git a/bootstrapvz/providers/ec2/tasks/packages-kernels.yml b/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
index 4f9679f..0e90e1a 100644
--- a/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
+++ b/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
@@ -12,6 +12,9 @@ jessie:
 stretch:
   amd64: linux-image-amd64
   i386: linux-image-686-pae
+buster:
+  amd64: linux-image-amd64
+  i386: linux-image-686-pae
 sid:
   amd64: linux-image-amd64
   i386: linux-image-686-pae
```