### PR TITLE
Update version of containerd to latest v1.3.4

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,5 +1,5 @@
 {
-    "containerd_version": "1.3.3",
-    "containerd_sha256": "24ce7ad6b489fb25d07d2a3bb50e443fcce1ac3318f8cc0831e00668c2c9fd86",
+    "containerd_version": "1.3.4",
+    "containerd_sha256": "4616971c3ad21c24f2f2320fa1c085577a91032a068dd56a41c7c4b71a458087",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2"
 }


### PR DESCRIPTION
- Updates the version of containerd we use by default to the latest v1.3.4 release: https://github.com/containerd/containerd/releases/tag/v1.3.4