### PR TITLE
Fix vsphere build still having the old naming scheme

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -158,7 +158,7 @@ $(NODE_OVA_ESX_BUILD_TARGETS):
 
 .PHONY: $(NODE_OVA_VSPHERE_BUILD_TARGETS)
 $(NODE_OVA_VSPHERE_BUILD_TARGETS):
-	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-ova-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json"  -except=esx -except=local $(PACKER_VAR_FILES) -only=vsphere -force packer/ova/packer.json
+	packer build $(PACKER_FLAGS) -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json"  -except=esx -except=local $(PACKER_VAR_FILES) -only=vsphere -force packer/ova/packer.json
 
 .PHONY: $(AMI_BUILD_TARGETS)
 $(AMI_BUILD_TARGETS):


### PR DESCRIPTION
This fixes what https://github.com/kubernetes-sigs/image-builder/commit/16812dec801c311a692685b36e9ac5d2b25ca3cb forgot and gets vsphere builds working again