### PR TITLE
For vsphere-iso the minimum packer version is 1.5.2

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-_version="1.4.1"
+_version="1.5.2"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
Reported by @MaxRink  in #186 , I've forgot to bump the packer version in the ensure-packer.sh script at the same level than documentation.
See:
https://github.com/kubernetes-sigs/image-builder/pull/186#issuecomment-616807402