### PR TITLE
Precreate `kube-apiserver` audit log

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -131,6 +131,18 @@
   - { path: /var/log, state: absent }
   - { path: /var/log, state: directory }
 
+- name: Create a log directory for kube-apiserver audit logs
+  file:
+    path: "{{ item.path }}"
+    state: "{{ item.state }}"
+    mode: "{{ item.mode }}"
+    owner: root
+    group: root
+  loop:
+  - { path: /var/log/kubernetes, state: directory, mode: "0755" }
+  - { path: /var/log/kubernetes/audit.log, state: touch, mode: "0600" }
+  when: kubernetes_semver != '' # Ensure audit log is not created for HA Proxy images, since this task is shared amongst build targets
+
 - name: Truncate shell history
   file:
     state: absent


### PR DESCRIPTION
- Because the default permission of audit log created by kubeadm is
too unrestrictive, i.e. read for all users, an audit log file is
pre-precreated with appropriate permission. See issue https://github.com/kubernetes-sigs/image-builder/issues/191

Build an AMI image and verified that the appropriate directory and file have been created:

```
[ec2-user@ip-172-31-19-152 ~]$ ll /var/log/kubernetes/
total 0
-rw------- 1 root root 0 Apr 22 00:06 audit.log
[ec2-user@ip-172-31-19-152 ~]$ ll /var/log/
total 356
drwxr--r-x 3 root   root       17 Apr 22 00:18 amazon
-rw------- 1 root   root    14970 Apr 22 00:18 boot.log
-rw------- 1 root   utmp        0 Apr 22 00:17 btmp
drwxr-xr-x 2 chrony chrony      6 Apr 22 00:17 chrony
-rw-r--r-- 1 root   root    99716 Apr 22 00:18 cloud-init.log
-rw-r--r-- 1 root   root     3321 Apr 22 00:18 cloud-init-output.log
-rw------- 1 root   root      283 Apr 22 00:20 cron
-rw-r--r-- 1 root   root    27124 Apr 22 00:17 dmesg
drwxr-xr-x 2 root   root       23 Apr 22 00:06 kubernetes
-rw------- 1 root   root      906 Apr 22 00:20 maillog
-rw------- 1 root   root   120478 Apr 22 00:25 messages
-rw------- 1 root   root     1191 Apr 22 00:25 secure
-rw-rw-r-- 1 root   utmp     2688 Apr 22 00:25 wtmp
-rw------- 1 root   root        0 Apr 22 00:18 yum.log
```
