### PR TITLE
Adds Buster image for k8s 1.15

### DIFF
--- a/images/kube-deploy/imagebuilder/aws-1.15-buster.yaml
+++ b/images/kube-deploy/imagebuilder/aws-1.15-buster.yaml
@@ -1,0 +1,11 @@
+Cloud: aws
+TemplatePath: templates/1.15-buster.yml
+Tags:
+  k8s.io/kernel: "4.19"
+  k8s.io/version: "1.15"
+  k8s.io/family: "default"
+  k8s.io/distro: "debian"
+  k8s.io/ssh-user: "admin"
+# Ensure the image is repeatable - really we should be locking to a tag
+BootstrapVZRepo: https://github.com/justinsb/bootstrap-vz.git
+BootstrapVZBranch: image18

--- a/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
+++ b/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
@@ -117,6 +117,8 @@ func (c *AWSConfig) InitDefaults(region string) {
 	switch c.Region {
 	case "us-east-2":
 		c.InstanceType = "m4.large"
+	case "ap-south-1":
+		c.InstanceType = "m4.large"
 	}
 }
 

--- a/images/kube-deploy/imagebuilder/templates/1.15-buster.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.15-buster.yml
@@ -1,0 +1,190 @@
+---
+{{ if eq .Cloud "aws" }}
+name: k8s-1.15-debian-{system.release}-{system.architecture}-{provider.virtualization}-ebs-{%Y}-{%m}-{%d}
+{{ else }}
+name: k8s-1.15-debian-{system.release}-{system.architecture}-{%Y}-{%m}-{%d}
+{{ end }}
+provider:
+{{ if eq .Cloud "aws" }}
+  name: ec2
+  virtualization: hvm
+  enhanced_networking: simple
+{{ else if eq .Cloud "gce" }}
+  name: gce
+  gcs_destination: {{ .GCSDestination }}
+  gce_project: {{ .Project }}
+{{ else }}
+  name: {{ .Cloud }}
+{{ end }}
+  description: Kubernetes 1.15 Base Image - Debian {system.release} {system.architecture}
+bootstrapper:
+  workspace: /target
+  # tarball speeds up development, but for prod builds we want to be 100% sure...
+  # tarball: true
+  # todo: switch to variant: minbase
+system:
+  release: buster
+  architecture: amd64
+  bootloader: grub
+  charmap: UTF-8
+  locale: en_US
+  timezone: UTC
+volume:
+{{ if eq .Cloud "aws" }}
+  backing: ebs
+{{ else if eq .Cloud "gce" }}
+  backing: raw
+{{ end }}
+  partitions:
+    type: gpt
+    root:
+      filesystem: ext4
+      # We create the FS with more inodes... docker is pretty inode hungry
+      format_command: [ 'mkfs.{fs}', '-i', '4096', '{device_path}' ]
+      size: 8GiB
+packages:
+{{ if eq .Cloud "aws" }}
+  mirror: http://cloudfront.debian.net/debian
+{{ end }}
+  install:
+    # Important utils for administration
+    # if minbase - openssh-server
+
+    # Ensure systemd scripts run on shutdown
+    - acpi-support
+
+    # these packages are generally useful
+    # (and are the ones from the GCE image)
+    - rsync
+    - screen
+    - vim
+
+    # needed for docker
+    - iptables
+    - libapparmor1
+    - libltdl7
+
+    # Handy utilities
+    - htop
+    - tcpdump
+    - iotop
+    - ethtool
+    - sysstat
+
+    # needed for setfacl below
+    - acl
+
+{{ if eq .Cloud "aws" }}
+    # these packages are included in the official AWS image
+    - python-boto
+    - python3-boto
+    - apt-transport-https
+    - lvm2
+    - ncurses-term
+    - parted
+    - cloud-init
+    - cloud-utils
+    - gdisk
+    - systemd
+    - systemd-sysv
+
+    # these packages are included in the official image, but we remove them
+    # awscli : we install from pip instead
+{{ end }}
+
+    # These packages would otherwise be installed during first boot
+    - aufs-tools
+    - curl
+    - python-yaml
+    - git
+    - nfs-common
+    - bridge-utils
+    - logrotate
+    - socat
+    - python-apt
+    - apt-transport-https
+    - unattended-upgrades
+    - lvm2
+    - btrfs-tools
+
+{{ if eq .Cloud "aws" }}
+    # So we can install the latest awscli
+    - python-pip
+{{ end }}
+
+plugins:
+{{ if eq .Cloud "gce" }}
+  ntp:
+    servers:
+    - metadata.google.internal
+{{ else }}
+  ntp: {}
+{{ end }}
+
+{{ if eq .Cloud "aws" }}
+  cloud_init:
+    metadata_sources: Ec2
+    username: admin
+    enable_modules:
+      cloud_init_modules:
+        - {module: growpart, position: 4}
+{{ end }}
+
+  commands:
+    commands:
+{{ if eq .Cloud "aws" }}
+       # Install awscli through python-pip
+       - [ 'chroot', '{root}', 'pip', 'install', 'awscli' ]
+{{ end }}
+
+       # We don't enable unattended upgrades - nodeup can always add it
+       # but if we add it now, there's a race to turn it off
+       # cloud-init depends on unattended-upgrades, so we can't just remove it
+       # Instead we turn them off; we turn them on later
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Update-Package-Lists \"0\";" > /etc/apt/apt.conf.d/20auto-upgrades' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
+       # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
+
+       # Install docker
+       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~debian_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
+       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "93b5a055a39462867d79109b00db1367e3d9e32f  docker.deb" | shasum -c -' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
+       - [ 'rm', '{root}/tmp/docker.deb' ]
+
+       # We perform a full replacement of some grub conf variables:
+       #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)
+       #   GRUB_TIMEOUT (remove boot delay)
+       # (but leave the old versions commented out for people to see)
+       - [ 'chroot', '{root}', 'touch', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_CMDLINE_LINUX_DEFAULT=/#GRUB_CMDLINE_LINUX_DEFAULT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', 'sed', '-i', 's/^GRUB_TIMEOUT=/#GRUB_TIMEOUT=/g', '/etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "# kubernetes image changes" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_CMDLINE_LINUX_DEFAULT=\"cgroup_enable=memory oops=panic panic=10 console=ttyS0 nvme_core.io_timeout=255\"" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "GRUB_TIMEOUT=0" >> /etc/default/grub' ]
+       - [ 'chroot', '{root}', 'update-grub2' ]
+
+       # Update everything to latest versions
+       - [ 'chroot', '{root}', 'apt-get', 'update' ]
+       - [ 'chroot', '{root}', 'apt-get', 'dist-upgrade', '--yes' ]
+
+       # Cleanup packages
+       - [ 'chroot', '{root}', 'apt-get', 'autoremove', '--yes' ]
+
+       # Remove machine-id, so that we regenerate next boot
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "" > /etc/machine-id' ]
+
+       # Ensure we have cleaned up all our SSH keys
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key' ]
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'shred --remove /etc/ssh/ssh_host_*_key.pub' ]
+       # Workaround bootstrap-vz bug where it errors if all keys are removed
+       - [ 'chroot', '{root}', 'bin/sh', '-c', 'touch /etc/ssh/ssh_host_rsa_key.pub' ]
+
+       # journald requires machine-id, so add a PreStart
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/etc/systemd/system/debian-fixup.service.d/' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "[Service]" > /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]
+       - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "ExecStartPre=/bin/systemd-machine-id-setup" >> /etc/systemd/system/debian-fixup.service.d/10-machineid.conf' ]
+
+       # Make sure journald is persistent
+       # From /usr/share/doc/systemd/README.Debian
+       - [ 'chroot', '{root}', 'install', '-d', '-g', 'systemd-journal', '/var/log/journal' ]
+       - [ 'chroot', '{root}', 'setfacl', '-R', '-nm', 'g:adm:rx,d:g:adm:rx', '/var/log/journal' ]


### PR DESCRIPTION
This PR adds a Debian Buster image which has the kernel `4.19.0-8-amd64` which has the patch for the [Kernel Throttling Bug]( https://bugzilla.kernel.org/show_bug.cgi?id=198197)
```
$ uname -a
Linux ip-172-31-102-226 4.19.0-8-amd64 #1 SMP Debian 4.19.98-1 (2020-01-26) x86_64 GNU/Linux
```
Fixes https://github.com/kubernetes/kops/issues/8954
Kubernetes Issue: kubernetes/kubernetes#67577
Kops Issue:  https://github.com/kubernetes/kops/issues/8954
Related: https://github.com/kubernetes-sigs/image-builder/pull/205

## Results of the Throttling Test
Source: https://gist.github.com/bobrik/2030ff040fad360327a5fab7a09c4ff1

No throttling is happening now. Burn always take 5ms.

<details>
  <summary>docker run --rm -it --cpu-quota 20000 --cpu-period 100000 -v $(pwd):$(pwd) -w $(pwd) golang:1.9.2 go run cfs.go -iterations 100 -sleep 1000ms</summary>

```
2020/04/23 12:09:26 [0] burn took 5ms, real time so far: 5ms, cpu time so far: 7ms
2020/04/23 12:09:27 [1] burn took 5ms, real time so far: 1010ms, cpu time so far: 13ms
2020/04/23 12:09:28 [2] burn took 5ms, real time so far: 2015ms, cpu time so far: 20ms
2020/04/23 12:09:29 [3] burn took 5ms, real time so far: 3020ms, cpu time so far: 26ms
2020/04/23 12:09:30 [4] burn took 5ms, real time so far: 4025ms, cpu time so far: 32ms
2020/04/23 12:09:31 [5] burn took 5ms, real time so far: 5031ms, cpu time so far: 39ms
2020/04/23 12:09:32 [6] burn took 5ms, real time so far: 6036ms, cpu time so far: 44ms
2020/04/23 12:09:33 [7] burn took 5ms, real time so far: 7041ms, cpu time so far: 51ms
2020/04/23 12:09:34 [8] burn took 5ms, real time so far: 8046ms, cpu time so far: 58ms
2020/04/23 12:09:35 [9] burn took 5ms, real time so far: 9051ms, cpu time so far: 63ms
2020/04/23 12:09:36 [10] burn took 5ms, real time so far: 10056ms, cpu time so far: 70ms
2020/04/23 12:09:37 [11] burn took 5ms, real time so far: 11061ms, cpu time so far: 76ms
2020/04/23 12:09:38 [12] burn took 5ms, real time so far: 12066ms, cpu time so far: 82ms
2020/04/23 12:09:39 [13] burn took 5ms, real time so far: 13072ms, cpu time so far: 88ms
2020/04/23 12:09:40 [14] burn took 5ms, real time so far: 14077ms, cpu time so far: 94ms
2020/04/23 12:09:41 [15] burn took 5ms, real time so far: 15082ms, cpu time so far: 101ms
2020/04/23 12:09:42 [16] burn took 5ms, real time so far: 16087ms, cpu time so far: 107ms
```
</details>

## Small patch in bootstap-vz is required
Requires also a small patch in https://github.com/justinsb/bootstrap-vz:
```diff
diff --git a/bootstrapvz/plugins/cloud_init/manifest-schema.yml b/bootstrapvz/plugins/cloud_init/manifest-schema.yml
index 0f2a706..dde0974 100644
--- a/bootstrapvz/plugins/cloud_init/manifest-schema.yml
+++ b/bootstrapvz/plugins/cloud_init/manifest-schema.yml
@@ -14,6 +14,7 @@ properties:
         - jessie
         - stable
         - stretch
+        - buster
         - testing
         - sid
         - unstable
diff --git a/bootstrapvz/providers/ec2/tasks/packages-kernels.yml b/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
index 4f9679f..0e90e1a 100644
--- a/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
+++ b/bootstrapvz/providers/ec2/tasks/packages-kernels.yml
@@ -12,6 +12,9 @@ jessie:
 stretch:
   amd64: linux-image-amd64
   i386: linux-image-686-pae
+buster:
+  amd64: linux-image-amd64
+  i386: linux-image-686-pae
 sid:
   amd64: linux-image-amd64
   i386: linux-image-686-pae
```
