### PR TITLE
Fix provider role not running on vsphere builds

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -19,7 +19,8 @@
   when: packer_builder_type.startswith('azure') 
 
 - include_tasks: vmware.yml
-  when: packer_builder_type is search('vmware')
+  when: packer_builder_type is search('vmware') or 
+        packer_builder_type is search('vsphere')
 
 - include_tasks: googlecompute.yml
   when: packer_builder_type.startswith('googlecompute')


### PR DESCRIPTION
packer_builder_type is vsphere_iso for vsphere builds, thus cluster init never gets installed.
Thus all images build by vsphere-iso wont work with CAPV.
This fixes that.