### PR TITLE
ova: no need to symlink cloud-init in CentOS

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -70,13 +70,6 @@
 #    regexp: '(?i)lock_passwd: True'
 #    replace: 'lock_passwd: False'
 
-- name: Symlink /usr/libexec/cloud-init to /usr/lib/cloud-init
-  file:
-    src:   /usr/libexec/cloud-init
-    dest:  /usr/lib/cloud-init
-    state: link
-  when: ansible_os_family == "RedHat"
-
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   systemd:
     name: hv-kvp-daemon


### PR DESCRIPTION
With the latest CentOS 7 builds, the step to symlink cloud-init was
failing because the symlink target already existed. It already existed
because it is put there by the cloud-init package itself. I can only
guess this was a packaging change at some point, but this step is no
longer needed.

/assign @detiber 

I confirmed that an image built with this change booted up and ran cloud-init just as expected. I also could see that the symlink target (the existing one that made the symlink fail) was owned by the cloud-init RPM itself:

```sh
# rpm -qf /usr/libexec/cloud-init/
cloud-init-18.5-6.el7.centos.x86_64
# rpm -qf /usr/bin/cloud-init
cloud-init-18.5-6.el7.centos.x86_64
```

I really don't think we want to be symlinking over files/directories owned by RPMs. I'm sure there was some historical context for this, but this step is no longer needed and is in fact currently breaking the build.

We could use the `force` option to override like we did in https://github.com/kubernetes-sigs/image-builder/pull/177/files#diff-2d3ed05212ae755af2225edeb728462fR20, but again, that's not needed here. cloud-init is already working fine. And the change I just linked to can safely be removed, because it was a work around needed because PhotonOS was installing docker (and we're doing that anymore by virtue of not installing the `minimal` package).