### PR TITLE
apparmor: Install a default apparmor profile

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/apparmor.yml
+++ b/images/capi/ansible/roles/containerd/tasks/apparmor.yml
@@ -1,0 +1,12 @@
+- name: Copy in apparmor profile
+  template:
+    dest: /etc/apparmor.d/container-default
+    src: etc/apparmor.d/container-default
+  when: ansible_os_family == "Debian" || ansible_os_family == "VMware Photon OS"
+
+- name: start apparmor service
+  systemd:
+    name: apparmor
+    daemon_reload: yes
+    enabled: True
+    state: started

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -69,6 +69,9 @@
     dest: /etc/containerd/config.toml
     src: etc/containerd/config.toml
 
+- import_tasks: apparmor.yml
+  when: ansible_os_family == "VMware Photon OS" || ansible_os_family == "Debian"
+
 - name: start containerd service
   systemd:
     name: containerd

--- a/images/capi/ansible/roles/containerd/templates/etc/apparmor.d/container-default
+++ b/images/capi/ansible/roles/containerd/templates/etc/apparmor.d/container-default
@@ -1,0 +1,33 @@
+#include <tunables/global>
+
+profile container-default flags=(attach_disconnected,mediate_deleted) {
+
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+
+  signal (send,receive) peer=container-default,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/kcore rwklx,
+  deny mount,
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read,tracedby,readby) peer=container-default,
+
+}

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -46,6 +46,8 @@ common_debs:
 - socat
 
 common_photon_rpms:
+- apparmor-profiles
+- apparmor-utils
 - conntrack-tools
 - distrib-compat
 - ebtables


### PR DESCRIPTION
Part of #231 

Should install a profile you can use in Kubernetes, as well as ensuring the right  binaries exist on PhotonOS.

Been unable to get Packer to run on vSphere though.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>