### PR TITLE
chore: more strict logrotate on conntrackd

### DIFF
--- a/images/capi/ansible/roles/node/files/conntrackd
+++ b/images/capi/ansible/roles/node/files/conntrackd
@@ -1,0 +1,14 @@
+/var/log/conntrackd-stats.log {
+    su root syslog
+    compress
+    dateext
+    notifempty
+    missingok
+    nocreate
+    weekly
+    rotate 2
+    copytruncate
+    postrotate
+        invoke-rc.d conntrackd restart > /dev/null
+    endscript
+}

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -73,3 +73,12 @@
     sysctl_set: yes
     reload: yes
     sysctl_file: "{{ sysctl_conf_file }}"
+
+- name: Ensure conntrackd logrotate is present
+  copy:
+    src: conntrackd
+    dest: /etc/logrotate.d/conntrackd
+    owner: root
+    group: root
+    mode: 0644
+    


### PR DESCRIPTION
conntrackd logs is taking up a lot of disk space. Logrotate needs to compress the logs.  
Before:
```
-rw-------  1 root   root    28G May  8 17:15 conntrackd-stats.log
-rw-------  1 root   root    31G May  3 06:25 conntrackd-stats.log.1
-rw-------  1 root   root   3.6G Apr 27 06:25 conntrackd-stats.log.2
```

After:
```
-rw-------  1 root   root    17M May  8 18:16 conntrackd-stats.log
-rw-------  1 root   root   2.5G May  8 17:48 conntrackd-stats.log-20200508.gz
```