### PR TITLE
Bump Ubuntu ISO 18.04.4 in OpenStack provider

### DIFF
--- a/images/capi/packer/qemu/qemu-ubuntu-1804.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-1804.json
@@ -3,10 +3,10 @@
   "distro_name": "ubuntu",
   "os_display_name": "Ubuntu 18.04",
   "guest_os_type": "ubuntu-64",
-  "iso_url": "http://old-releases.ubuntu.com/releases/18.04.2/ubuntu-18.04.2-server-amd64.iso",
-  "iso_checksum": "a2cb36dc010d98ad9253ea5ad5a07fd6b409e3412c48f1860536970b073c98f5",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-amd64.iso",
+  "iso_checksum": "e2ecdace33c939527cbc9e8d23576381c493b071107207d2040af72595f8990b",
   "iso_checksum_type": "sha256",
   "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
-  "boot_command_suffix": "/18.04/preseed.cfg -- <wait><enter><wait>",
+  "boot_command_suffix": "/18.04/preseed.cfg -- <enter>",
   "shutdown_command": "shutdown -P now"
 }


### PR DESCRIPTION
This PR is followup PR of #225, updates the ubuntu ISO to 18.04.4 in OpenStack provider.