### PR TITLE
Add chrony for time sync for Azure image

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -19,3 +19,31 @@
   vars:
     packages:
       - azure-cli
+
+- name: Ansible apt install chrony
+  apt:
+    name: chrony
+    state: present
+  when: ansible_distribution == "Ubuntu"
+  
+- name: Configure PTP
+  lineinfile:
+    path: /etc/chrony/chrony.conf
+    create: yes
+    line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+  when: ansible_distribution == "Ubuntu"  
+
+- name: Ensure makestep parameter set as per Azure recommendation
+  lineinfile:
+    path: /etc/chrony/chrony.conf
+    regexp: '^makestep'
+    line: makestep 1.0 -1
+  when: ansible_distribution == "Ubuntu"  
+
+- name: Enable chrony.service
+  systemd:
+    enabled: yes
+    state: started
+    daemon_reload: yes
+    name: chrony.service
+  when: ansible_distribution == "Ubuntu"  


### PR DESCRIPTION
Chrony is the only way to sync time from host using PTP source according to the azure team

Related to issue [539](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/539) in cluster-api-provider-azure 