### PR TITLE
Add ethtool to photon ova(s)

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -49,6 +49,7 @@ common_photon_rpms:
 - conntrack-tools
 - distrib-compat
 - ebtables
+- ethtool
 - jq
 - net-tools
 - ntp


### PR DESCRIPTION
ethtool is handy to have especially to tweak things like say the offload checksum when you can't get networking to work right.