### PR TITLE
container-image-builder: terraform cleanups

### DIFF
--- a/images/kube-deploy/container-image/README.md
+++ b/images/kube-deploy/container-image/README.md
@@ -97,7 +97,12 @@ pushd cloud/aws-test
 terraform init
 terraform apply
 TEST_INSTANCE_PUBLIC_IP=`terraform output test_instance_public_ip`
+TEST_INSTANCE_ID=`terraform output test_instance_id`
+TEST_INSTANCE_REGION=`terraform output test_instance_region`
 popd
+
+# If running in a script, it can be useful to wait for the instance to be ready
+aws ec2 wait instance-status-ok --instance-id ${TEST_INSTANCE_ID} --region ${TEST_INSTANCE_REGION}
 
 # SSH to the instance and test it out
 ssh admin@${TEST_INSTANCE_PUBLIC_IP}

--- a/images/kube-deploy/container-image/cloud/aws-upload/uploader.tf
+++ b/images/kube-deploy/container-image/cloud/aws-upload/uploader.tf
@@ -27,7 +27,7 @@ data "aws_ami" "amazonlinux2" {
 # Allow inbound SSH
 resource "aws_security_group" "allow_ssh" {
   description = "Allow SSH inbound traffic"
-  vpc_id      = "${data.aws_vpc.main.id}"
+  vpc_id      = data.aws_vpc.main.id
 
   ingress {
     description = "Inbound SSH"
@@ -41,16 +41,16 @@ resource "aws_security_group" "allow_ssh" {
 # Upload our ssh key
 resource "aws_key_pair" "default" {
   key_name   = "imagebuilder-aws-upload"
-  public_key = "${file("id_rsa.pub")}"
+  public_key = file("id_rsa.pub")
 }
 
 # Create a worker instance
 resource "aws_instance" "worker" {
   vpc_security_group_ids = ["${aws_security_group.allow_ssh.id}"]
-  key_name               = "${aws_key_pair.default.key_name}"
+  key_name               = aws_key_pair.default.key_name
 
   associate_public_ip_address = true
-  ami                         = "${data.aws_ami.amazonlinux2.id}"
+  ami                         = data.aws_ami.amazonlinux2.id
   instance_type               = "m5a.large"
 
   ebs_block_device {


### PR DESCRIPTION
* Use newer terraform syntax to avoid warnings
* Allow network egress from test instance on AWS
* Wait for instance to be ready in README