### PR TITLE
container-image-builder: fix incorrect string comparison

### DIFF
--- a/images/kube-deploy/container-image/tools/container-to-raw
+++ b/images/kube-deploy/container-image/tools/container-to-raw
@@ -35,7 +35,7 @@ fi
 docker run --name ${EXPORT_NAME} ${IMAGE} /bin/true
 
 SUDO=sudo
-if [[ `whoami` -eq 'root' ]]; then
+if [[ `whoami` == 'root' ]]; then
     echo "Running as root; won't use sudo"
     SUDO=""
 fi


### PR DESCRIPTION
The previous syntax was simply not correct; fixing.