### PR TITLE
container-image: install cloud-init on AWS

### DIFF
--- a/images/kube-deploy/container-image/images/buster-aws/Dockerfile
+++ b/images/kube-deploy/container-image/images/buster-aws/Dockerfile
@@ -9,3 +9,6 @@ RUN apt-get -y install --no-install-recommends cloud-init
 # Configure default user (admin) to match debian default image
 # https://salsa.debian.org/cloud-team/debian-cloud-images/-/blob/master/config_space/files/etc/cloud/cloud.cfg.d/01_debian_cloud.cfg/EC2
 COPY 01_debian_cloud.cfg /etc/cloud/cloud.cfg.d/
+
+RUN echo "cloud-init    cloud-init/datasources    multiselect    Ec2" | debconf-set-selections
+RUN apt-get -y install --no-install-recommends cloud-init


### PR DESCRIPTION
This gets the correct SSH keys onto the instance, via the metadata service.