### PR TITLE
capi: ubuntu-1804: use python3

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "ansible_common_vars": "",
-    "ansible_extra_vars": "",
+    "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
     "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",
     "containerd_version": null,


### PR DESCRIPTION
`make build-qemu-ubuntu-1804` was failing on ansible with `/bin/sh: 1: /usr/bin/python`, adding the python package to `preseed.cfg` seems to help