### PR TITLE
Use specific Ansible provisioner user for qemu build

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -76,6 +76,7 @@
     {
       "type": "ansible",
       "playbook_file": "./ansible/node.yml",
+      "user": "builder",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
         "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"


### PR DESCRIPTION
Fixes an issue were Ansible would skip privilege escalation if
Ansible/Packer are running as root and Ansible "thinks" it is connecting
to the target as root.