### PR TITLE
Fix default EPEL location for CentOS 7.

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -39,6 +39,7 @@
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "ami_groups": "all",
     "ami_users": "",
+    "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
     "reenable_public_repos": "true",
     "remove_extra_repos": "false",
     "snapshot_groups": "all",

--- a/images/capi/packer/ova/centos-7.json
+++ b/images/capi/packer/ova/centos-7.json
@@ -1,6 +1,7 @@
 {
   "build_name": "centos-7",
   "distro_name": "centos",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
   "os_display_name": "CentOS 7",
   "guest_os_type": "centos7-64",
   "vsphere_guest_os_type": "centos7_64Guest",


### PR DESCRIPTION
A recent change (#218) made it possible to set the EPEL location to an empty
string to skip installing EPEL. Since this var is now always set by
Packer, not setting it makes it be an empty string, and since extra-vars
take precedence in Ansible, the net effect is that the var was *always*
set to an empty string, even though a default is set in the Ansible
role.

This patch sets the default value for CentOS 7 back as it was. The
addition is only the CentOS 7 file for OVAs, so it does not effect AL2,
and if needed in a future CentOS 8 distro, a release specific version
can be set there as well.

/assign @detiber 
/cc @voor 