### PR TITLE
Replace deprecated configuration keys for Packer 1.6

### DIFF
--- a/images/capi/packer/ova/packer-haproxy.json
+++ b/images/capi/packer/ova/packer-haproxy.json
@@ -33,8 +33,7 @@
       "guest_os_type": "{{user `guest_os_type`}}",
       "headless": "{{user `headless`}}",
       "iso_url": "{{user `iso_url`}}",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "{{user `ssh_timeout`}}",
@@ -74,28 +73,38 @@
       "host":     "{{user `host`}}",
       "convert_to_template": "{{user `convert_to_template`}}",
       "cluster": "{{user `cluster`}}",
-      "network": "{{user `network`}}",
+
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "{{user `network_card`}}"
+        }
+      ],
 
       "vm_version": "{{user `vmx_version`}}",
       "CPUs": 1,
       "cpu_cores": 1,
       "RAM": 2048,
-      "disk_size": 20480,
       "disk_controller_type": "{{user `disk_controller_type`}}",
-      "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}",
-      "network_card": "{{user `network_card`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
 
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "iso_urls": "{{user `iso_url`}}",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
-
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+            
       "communicator": "ssh",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
+
+      "storage": [
+        {
+          "disk_size": 20480,
+          "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
+        }
+      ],
+
       "boot_command": [
         "{{user `boot_command_prefix`}}",
         "http://{{ .HTTPIP }}:{{ .HTTPPort }}",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -53,8 +53,7 @@
       "guest_os_type": "{{user `guest_os_type`}}",
       "headless": "{{user `headless`}}",
       "iso_url": "{{user `iso_url`}}",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
       "communicator": "ssh",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
@@ -95,30 +94,38 @@
       "host":     "{{user `host`}}",
       "convert_to_template": "{{user `convert_to_template`}}",
       "cluster": "{{user `cluster`}}",
-      "network": "{{user `network`}}",
 
-
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "{{user `network_card`}}"
+        }
+      ],
 
       "vm_version": "{{user `vmx_version`}}",
       "CPUs": 1,
       "cpu_cores": 1,
       "RAM": 2048,
-      "disk_size": 20480,
       "disk_controller_type": "{{user `disk_controller_type`}}",
-      "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}",
-      "network_card": "{{user `network_card`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
 
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "iso_urls": "{{user `iso_url`}}",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
 
       "communicator": "ssh",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
+
+      "storage": [
+        {
+          "disk_size": 20480,
+          "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
+        }
+      ],
+
       "boot_command": [
         "{{user `boot_command_prefix`}}",
         "http://{{ .HTTPIP }}:{{ .HTTPPort }}",


### PR DESCRIPTION
Packer version needs to upgrade to v1.6.0+ in order to use the building from remote vSphere option. This PR replaced some deprecated configuration keys for `builder type: vsphere-iso`

Fixes: #253 
