### PR TITLE
CAPI: Bump kubernetes-cni version to v0.8.6

### DIFF
--- a/docs/book/src/capi/providers/aws.md
+++ b/docs/book/src/capi/providers/aws.md
@@ -33,7 +33,7 @@ The following variables can be overriden when building images using the `-var` o
 | Variable               | Default   | Description                   |
 | ---------------------- | --------- | ----------------------------- |
 | kubernetes_version     | 1.13.6-00 | Kubernetes Version to install |
-| kubernetes_cni_version | 0.7.5-00  | CNI Version to install        |
+| kubernetes_cni_version | 0.8.6-00  | CNI Version to install        |
 
 For example, to build all images for use with Kubernetes 1.14.0 for build version 1:
 

--- a/docs/book/src/capi/providers/aws.md
+++ b/docs/book/src/capi/providers/aws.md
@@ -26,23 +26,6 @@ make deps-ami
 
 ## Building Images
 
-### Build Variables
-
-The following variables can be overriden when building images using the `-var` option when calling `packer build`:
-
-| Variable               | Default   | Description                   |
-| ---------------------- | --------- | ----------------------------- |
-| kubernetes_version     | 1.13.6-00 | Kubernetes Version to install |
-| kubernetes_cni_version | 0.8.6-00  | CNI Version to install        |
-
-For example, to build all images for use with Kubernetes 1.14.0 for build version 1:
-
-```sh
-packer build -var kubernetes_version=1.14.0-00
-```
-
-There are additional variables that may be set that affect the behavior of specific builds or packer post-processors. `packer inspect packer.json` will list all available variables and their default values.
-
 ### Building private AMIs
 
 Pass in the `-var ami_groups=""` and `-var snapshot_groups=""` parameters to

--- a/images/capi/cloudinit/user-data
+++ b/images/capi/cloudinit/user-data
@@ -230,7 +230,7 @@ write_files:
       etcd: {}
       imageRepository: k8s.gcr.io
       kind: ClusterConfiguration
-      kubernetesVersion: 1.16.2
+      kubernetesVersion: 1.16.11
       networking:
         dnsDomain: cluster.local
         podSubnet: 100.96.0.0/11

--- a/images/capi/packer/azure/.pipelines/build-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/build-vhd.yaml
@@ -23,8 +23,13 @@ jobs:
       KUBERNETES_RELEASE=$(echo ${KUBERNETES_VERSION} | cut -d "." -f -2)
       sed -i "s/.*kubernetes_series.*/  \"kubernetes_series\": \"v${KUBERNETES_RELEASE}\",/g" kubernetes.json
       sed -i "s/.*kubernetes_semver.*/  \"kubernetes_semver\": \"v${KUBERNETES_VERSION}\",/g" kubernetes.json
-      sed -i "s/.*kubernetes_rpm_version.*/  \"kubernetes_rpm_version\": \"${KUBERNETES_VERSION}-0\",/g" kubernetes.json
-      sed -i "s/.*kubernetes_deb_version.*/  \"kubernetes_deb_version\": \"${KUBERNETES_VERSION}-00\",/g" kubernetes.json
+      if [[ "${KUBERNETES_VERSION:-}" == "1.16.11" || "${KUBERNETES_VERSION:-}" == "1.17.7" || "${KUBERNETES_VERSION:-}" == "1.18.4" ]]; then
+        sed -i "s/.*kubernetes_rpm_version.*/  \"kubernetes_rpm_version\": \"${KUBERNETES_VERSION}-1\",/g" kubernetes.json
+        sed -i "s/.*kubernetes_deb_version.*/  \"kubernetes_deb_version\": \"${KUBERNETES_VERSION}-01\",/g" kubernetes.json
+      else
+        sed -i "s/.*kubernetes_rpm_version.*/  \"kubernetes_rpm_version\": \"${KUBERNETES_VERSION}-0\",/g" kubernetes.json
+        sed -i "s/.*kubernetes_deb_version.*/  \"kubernetes_deb_version\": \"${KUBERNETES_VERSION}-00\",/g" kubernetes.json
+      fi
       cat kubernetes.json
     displayName: Write configuration files
     workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/config'

--- a/images/capi/packer/config/cni.json
+++ b/images/capi/packer/config/cni.json
@@ -1,8 +1,8 @@
 {
-    "kubernetes_cni_semver": "v0.7.5",
-    "kubernetes_cni_rpm_version": "0.7.5-0",
-    "kubernetes_cni_deb_version": "0.7.5-00",
+    "kubernetes_cni_semver": "v0.8.6",
+    "kubernetes_cni_rpm_version": "0.8.6-0",
+    "kubernetes_cni_deb_version": "0.8.6-00",
     "kubernetes_cni_source_type": "pkg",
     "kubernetes_cni_http_source": "https://github.com/containernetworking/plugins/releases/download",
-    "kubernetes_cni_http_checksum": "sha256:https://github.com/containernetworking/plugins/releases/download/v0.7.5/cni-plugins-amd64-v0.7.5.tgz.sha256"
+    "kubernetes_cni_http_checksum": "sha256:https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz.sha256"
 }

--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
   "kubernetes_series": "v1.16",
-  "kubernetes_semver": "v1.16.2",
-  "kubernetes_rpm_version": "1.16.2-0",
-  "kubernetes_deb_version": "1.16.2-00",
+  "kubernetes_semver": "v1.16.11",
+  "kubernetes_rpm_version": "1.16.11-1",
+  "kubernetes_deb_version": "1.16.11-01",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",


### PR DESCRIPTION
v0.7.5 is incompatible with the latest k8s patches (v1.16.11, v1.17.7, v1.18.4), bumping to v0.8.6.

Also updated the default k8s version to 1.16.11 to be coherent with the default cni version.

https://github.com/kubernetes/kubernetes/pull/91387
https://github.com/kubernetes/kubernetes/issues/92242

/assign @detiber 