### PR TITLE
[capi] fix binary name for cni-plugins when installing from URL

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -33,7 +33,7 @@
 
 - name: Download CNI tarball
   get_url:
-    url: "{{ kubernetes_cni_http_source }}/{{ kubernetes_cni_semver }}/cni-plugins-{{ kubernetes_goarch }}-{{ kubernetes_cni_semver }}.tgz"
+    url: "{{ kubernetes_cni_http_source }}/{{ kubernetes_cni_semver }}/cni-plugins-linux-{{ kubernetes_goarch }}-{{ kubernetes_cni_semver }}.tgz"
     checksum: "{{ kubernetes_cni_http_checksum }}"
     dest: /tmp/cni.tar.gz
     mode: 0755


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/92511