### PR TITLE
Add VC Datacenter as input var to Packer

### DIFF
--- a/images/capi/packer/ova/packer-haproxy.json
+++ b/images/capi/packer/ova/packer-haproxy.json
@@ -68,6 +68,7 @@
       "insecure_connection": "{{user `insecure_connection`}}",
 
       "vm_name": "{{user `build_version`}}",
+      "datacenter": "{{user `datacenter`}}",
       "datastore": "{{user `datastore`}}",
       "folder": "{{user `folder`}}",
       "host":     "{{user `host`}}",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -90,6 +90,7 @@
 
       "vm_name": "{{user `build_version`}}",
       "datastore": "{{user `datastore`}}",
+      "datacenter": "{{user `datacenter`}}",
       "folder": "{{user `folder`}}",
       "host":     "{{user `host`}}",
       "convert_to_template": "{{user `convert_to_template`}}",

--- a/images/capi/packer/ova/vsphere.json
+++ b/images/capi/packer/ova/vsphere.json
@@ -3,6 +3,7 @@
     "username":"",
     "password":"",
     "datastore":"",
+    "datacenter":"",
     "folder": "",
     "cluster": "",
     "network": "",


### PR DESCRIPTION
If a VC has multiple datacenters, VC OVA builder will fail.

Add new var to accommodate above case 

/kind bug