### PR TITLE
Adding PhotonOS to Azure.

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -13,7 +13,7 @@ The `make deps-azure` target will test that Ansible, Packer, and `jq` are instal
 
 - An Azure account
 - The Azure CLI installed and configured
-- Set environment variables for `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
+- Set environment variables for `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_LOCATION`
 
 ## Building Images
 

--- a/images/capi/.gitignore
+++ b/images/capi/.gitignore
@@ -5,3 +5,4 @@
 /output/
 /.bin/
 manifest.json
+packer-manifest.json

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -144,7 +144,7 @@ HAPROXY_OVA_VSPHERE_BUILD_NAMES		:=	$(addprefix haproxy-ova-vsphere-,$(PHOTON_VE
 
 AMI_BUILD_NAMES			?=	ami-centos-7 ami-ubuntu-1804 ami-amazon-2
 GCE_BUILD_NAMES			?=	gce-default
-AZURE_BUILD_NAMES		?=	azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804
+AZURE_BUILD_NAMES		?=	azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804 azure-vhd-photon-3
 
 DO_BUILD_NAMES 			?=	do-default
 
@@ -239,6 +239,7 @@ build-ami-all: $(AMI_BUILD_TARGETS) ## Builds all AMIs
 
 build-azure-sig-ubuntu-1804: ## Builds Ubuntu 18.04 Azure managed image in Shared Image Gallery
 build-azure-vhd-ubuntu-1804: ## Builds Ubuntu 18.04 VHD image for Azure
+build-azure-vhd-photon-3: ## Builds Photon 3 VHD image for Azure
 
 build-do-default: ## Builds the DigitalOcean snapshot default image
 

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -12,13 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: install Azure clients
+- name: Install Azure client RPM packages on PhotonOS
+  command: tdnf install {{ packages }} --nogpgcheck -y
+  vars:
+    packages: "python-pyasn1 WALinuxAgent"
+  when: ansible_os_family == "VMware Photon OS"
+
+- name: install Azure clients through pip3
   pip:
     executable: pip3
     name: "{{ packages }}"
   vars:
     packages:
       - azure-cli
+  when: ansible_distribution == "Ubuntu" or ansible_os_family == "VMware Photon OS"
+
+- name: Add Microsoft signing key for RPM
+  rpm_key:
+    state: present
+    key: https://packages.microsoft.com/keys/microsoft.asc
+  when: ansible_os_family == "RedHat"
+
+- name: Add Azure CLI repository for RPM
+  yum_repository:
+    name: azure-cli
+    description: azure-cli
+    file: azure-cli
+    enabled: true
+    baseurl: https://packages.microsoft.com/yumrepos/azure-cli
+    gpgcheck: "{{ ansible_os_family == 'RedHat'|bool }}"
+    gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+  when: ansible_os_family == "RedHat"
+
+- name: Refresh yum after repo addition since new repository is added
+  shell: 
+    cmd: yum updateinfo --enablerepo=azure-cli
+    warn: false
+  when: ansible_os_family == "RedHat"
+
+- name: Ansible yum install azure-cli, python-pyasn1, and WALinuxAgent
+  yum:
+    name:
+    - python-pyasn1
+    - WALinuxAgent
+    - azure-cli
+    enablerepo: azure-cli
+    update_cache: yes
+    state: latest
+  when: ansible_os_family == "RedHat"
 
 - name: Ansible apt install chrony
   apt:
@@ -31,14 +72,14 @@
     path: /etc/chrony/chrony.conf
     create: yes
     line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
-  when: ansible_distribution == "Ubuntu"  
+  when: ansible_distribution == "Ubuntu"
 
 - name: Ensure makestep parameter set as per Azure recommendation
   lineinfile:
     path: /etc/chrony/chrony.conf
     regexp: '^makestep'
     line: makestep 1.0 -1
-  when: ansible_distribution == "Ubuntu"  
+  when: ansible_distribution == "Ubuntu"
 
 - name: Enable chrony.service
   systemd:
@@ -46,4 +87,20 @@
     state: started
     daemon_reload: yes
     name: chrony.service
-  when: ansible_distribution == "Ubuntu"  
+  when: ansible_distribution == "Ubuntu"
+
+- name: Make sure device file exists
+  template:
+    src: etc/systemd/network/10-eth0.network.manual
+    dest: /etc/systemd/network/10-eth0.network.manual
+    owner: systemd-network
+    group: systemd-network
+    mode: '0644'
+  when: ansible_os_family == "VMware Photon OS"
+
+- name: enable waagent service
+  systemd:
+    name: waagent
+    enabled: yes
+    state: started
+  when: ansible_os_family == "RedHat" or ansible_os_family == "VMware Photon OS"

--- a/images/capi/ansible/roles/providers/templates/etc/systemd/network/10-eth0.network.manual
+++ b/images/capi/ansible/roles/providers/templates/etc/systemd/network/10-eth0.network.manual
@@ -1,0 +1,8 @@
+[Match]
+Name=eth0
+[Network]
+LinkLocalAddressing=no
+DHCP=ipv4
+[DHCP]
+UseDomains=true
+ClientIdentifier=mac

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -22,3 +22,5 @@ extra_rpms: ""
 
 disable_public_repos: false
 extra_repos: ""
+
+post_reboot_delay: 30

--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -33,6 +33,7 @@
   # a reboot of Photon is generally very fast so this is fine for now.
 - name: Reboot after distro sync
   reboot:
+    post_reboot_delay: "{{ post_reboot_delay }}"
   when: distro.changed
 
 - name: Concatenate the Photon RPMs

--- a/images/capi/packer/azure/azure-vhd-photon-3.json
+++ b/images/capi/packer/azure/azure-vhd-photon-3.json
@@ -1,0 +1,5 @@
+{
+  "resource_group_name": "{{env `RESOURCE_GROUP_NAME`}}",
+  "storage_account_name": "{{env `STORAGE_ACCOUNT_NAME`}}",
+  "capture_container_name": "photon3"
+}

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -8,6 +8,7 @@
     "disable_public_repos": "false",
     "extra_debs": "",
     "extra_repos": "",
+    "extra_rpms": "",
     "azure_location": null,
     "vm_size": "",
     "build_timestamp": "{{timestamp}}",
@@ -33,8 +34,17 @@
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "cloud_environment_name": "Public",
     "reenable_public_repos": "true",
-    "remove_extra_repos": "false"
+    "remove_extra_repos": "false",
+    "photon_image_url": "https://photon3.blob.core.windows.net/vhds/photon-azure-3.0-a9bc127.vhd",
+    "custom_role": "",
+    "custom_role_name": "",
+    "http_proxy": "",
+    "https_proxy": "",
+    "headless": "true",
+    "no_proxy": "",
+    "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
   },
   "builders": [
     {
@@ -53,6 +63,7 @@
       "capture_name_prefix": "capi-{{user `build_timestamp`}}",
       "storage_account": "{{user `storage_account_name`}}",
       "location": "{{user `azure_location`}}",
+      "cloud_environment_name": "{{user `cloud_environment_name`}}",
       "ssh_username": "packer",
       "azure_tags": {
         "build_timestamp": "{{user `build_timestamp`}}",
@@ -85,12 +96,38 @@
         ]
       },
       "location": "{{user `azure_location`}}",
+      "cloud_environment_name": "{{user `cloud_environment_name`}}",
       "ssh_username": "packer",
       "azure_tags": {
         "build_timestamp": "{{user `build_timestamp`}}",
         "distribution": "ubuntu",
         "distribution_release": "bionic",
         "distribution_version": "1804",
+        "kubernetes_version": "{{user `kubernetes_semver`}}"
+      }
+    },
+    {
+      "name": "vhd-photon-3",
+      "type": "azure-arm",
+      "os_type": "Linux",
+      "os_disk_size_gb": "5",
+      "image_url": "{{user `photon_image_url`}}",
+      "subscription_id": "{{user `subscription_id`}}",
+      "client_id": "{{user `client_id`}}",
+      "client_secret": "{{user `client_secret`}}",
+      "vm_size": "{{user `vm_size`}}",
+      "resource_group_name": "{{user `resource_group_name`}}",
+      "build_resource_group_name": "{{user `resource_group_name`}}",
+      "capture_container_name": "{{user `capture_container_name`}}",
+      "capture_name_prefix": "capi-{{user `build_timestamp`}}",
+      "storage_account": "{{user `storage_account_name`}}",
+      "cloud_environment_name": "{{user `cloud_environment_name`}}",
+      "ssh_username": "builder",
+      "azure_tags": {
+        "build_timestamp": "{{user `build_timestamp`}}",
+        "distribution": "photon",
+        "distribution_release": "3",
+        "distribution_version": "3",
         "kubernetes_version": "{{user `kubernetes_semver`}}"
       }
     }
@@ -101,7 +138,8 @@
       "inline": [
         "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
         "sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install python python-pip"
-      ]
+      ],
+      "only": ["sig-ubuntu-1804", "vhd-ubuntu-1804"]
     },
     {
       "type": "ansible",
@@ -115,8 +153,29 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "azure_local=True"
       ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "./packer-manifest.json",
+      "strip_path": true,
+      "custom_data": {
+        "build_name": "{{user `build_name`}}",
+        "build_timestamp": "{{user `build_timestamp`}}",
+        "build_date": "{{isotime}}",
+        "build_type": "node",
+        "containerd_version": "{{user `containerd_version`}}",
+        "custom_role": "{{user `custom_role`}}",
+        "kubernetes_cni_semver": "{{user `kubernetes_cni_semver`}}",
+        "kubernetes_semver": "{{user `kubernetes_semver`}}",
+        "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
+        "os_name": "{{user `distro_name`}}"
+      }
     }
   ]
 }

--- a/images/capi/packer/azure/scripts/init-vhd-photon-3.sh
+++ b/images/capi/packer/azure/scripts/init-vhd-photon-3.sh
@@ -10,6 +10,4 @@ export AZURE_LOCATION="${AZURE_LOCATION:-southcentralus}"
 az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION}
 echo "resource group name: ${RESOURCE_GROUP_NAME}"
 CREATE_TIME="$(date +%s)"
-export STORAGE_ACCOUNT_NAME="capi${CREATE_TIME}"
-az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME}
-echo "storage name: ${STORAGE_ACCOUNT_NAME}"
+export STORAGE_ACCOUNT_NAME="photon3"


### PR DESCRIPTION
This adds Photon 3 as an option for creating VHD output images in Azure.  I wanted to see how we could incorporate an uploaded ISO that could then turn into a VHD, since the current examples leveraged only shared gallery images as sources.

Also adds in other sovereign clouds to the VHD scripts by calling `az cloud set --name` (this defaults to `AzurePublicCloud` for backwards compatibility)

Really interested in some feedback, and completely open to further discussion on if this is the best approach.  I want to possible tackling publishing to a shared image gallery afterwards, since I know VHD is supposed to be deprecated.

/assign @CecileRobertMichon 
/cc @codenrhoden @nader-ziada 