### PR TITLE
Add 'exclude-nics' filter in vmtools configuration file in Ansible

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/vmware-tools/tools.conf
+++ b/images/capi/ansible/roles/providers/files/etc/vmware-tools/tools.conf
@@ -1,0 +1,3 @@
+[guestinfo]
+exclude-nics=antrea-*,ovs-system,br*,flannel*,veth*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????
+

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -76,3 +76,11 @@
     state: stopped
     enabled: false
   when: ansible_os_family == "Debian"
+ 
+- name: Create provider vmtools config drop-in file
+  copy:
+    src: files/etc/vmware-tools/tools.conf
+    dest: /etc/vmware-tools/tools.conf
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
Adding an `exclude-nics` filter can solve the current problem where no NICs are returned for a VM when the NIC limit is reached (vmtools has a 16 NIC limit).