### PR TITLE
[WIP] Add standardised data for OS distributions

### DIFF
--- a/v1/resources/defaults.yml
+++ b/v1/resources/defaults.yml
@@ -1,8 +1,13 @@
 amazon-ebs:
   instance_type: t3.small
   region: us-east-1
+  ami_regions: ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2
 gce:
-  zone: us-central-1
+  zone: us-central-1-a
+  project_id: "{{env `GCP_PROJECT_ID`}}"
+  machine_type: n1-standard-1
+  # image_family:
+  # image_name
 vmware-iso:
   version: 13
   disk_adapter_type: scsi
@@ -17,3 +22,18 @@ vmware-vmx:
   cpus: "2"
   disk_size: "20480"
   memory: "2048"
+
+azure:
+  azure_location: "{{env `AZURE_LOCATION`}}"
+  vm_size: "Standard_B2ms"
+  subscription_id: "{{env `AZURE_SUBSCRIPTION_ID`}}"
+  client_id: "{{env `AZURE_CLIENT_ID`}}"
+  client_secret: "{{env `AZURE_CLIENT_SECRET`}}"
+
+digitalocean:
+  type: digitalocean
+  region: nyc1
+  size: s-1vcpu-1gb
+  api_token: "{{env `DIGITALOCEAN_ACCESS_TOKEN`}}"
+  snapshot_regions:
+    ["nyc1", "sgp1", "lon1", "nyc3", "ams3", "fra1", "tor1", "sfo2", "blr1"]

--- a/v1/resources/distros/centos.yml
+++ b/v1/resources/distros/centos.yml
@@ -1,11 +1,48 @@
-centos7:
+centos76: &centos76
   os: centos
   distribution: CentOS
   distribution_release: Core
   distribution_version: 7
-  iso: &iso
+  docker:
+    image: centos
+    tag: 7.6.1810
+  iso: &isocentos76
     url: https://mirrors.edge.kernel.org/centos/7.6.1810/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso
     checksum: 38d5d51d9d100fd73df031ffd6bd8b1297ce24660dc8c13a3b8b4534a4bd291c
+  boot_command: <tab> text ks=/7/ks.cfg<enter><wait>
+  shutdown_command: sys-unconfig
+  os_display_name: CentOS 7
+  guest_os_type: centos-64
+  ami:
+    filters:
+      virtualization-type: hvm
+      name: CentOS Linux 7 x86_64 HVM EBS ENA*
+      root-device-type: ebs
+      architecture: x86_64
+    owners:
+      - "410186602215"
+    most_recent: true
+  vmware-iso:
+    <<: *isocentos76
+  vmware-vmx:
+    <<: *isocentos76
+  amazon-ebs:
+    <<: *isocentos76
+
+centos78: &centos78
+  os: centos
+  distribution: CentOS
+  distribution_release: Core
+  distribution_version: 7
+  docker:
+    image: centos
+    tag: 7.8.2003
+  qemu:
+    url: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2003.qcow2
+    checksum: 1db30c9c272fb37b00111b93dcebff16c278384755bdbe158559e9c240b73b80
+  iso: &isocentos78
+    url: https://mirrors.edge.kernel.org/centos/7.8.2003/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso
+    checksum: 659691c28a0e672558b003d223f83938f254b39875ee7559d1a4a14c79173193
   boot_command: <tab> text ks=/7/ks.cfg<enter><wait>
   shutdown_command: sys-unconfig
   os_display_name: CentOS 7
@@ -20,8 +57,48 @@ centos7:
       - "410186602215"
     most_recent: true
   vmware-iso:
-    <<: *iso
+    <<: *centos78
   vmware-vmx:
-    <<: *iso
+    <<: *centos78
   amazon-ebs:
-    <<: *ami
+    <<: *centos78
+
+centos:
+  <<: *centos78
+
+centos82: &centos82
+  os: centos
+  distribution: CentOS
+  distribution_release: Core
+  distribution_version: 8
+  docker:
+    image: centos
+    tag: 8.2.2004
+  qemu:
+    url: https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2
+    checksum: d8984b9baee57b127abce310def0f4c3c9d5b3cea7ea8451fc4ffcbc9935b640
+  iso: &isocentos82
+    url: https://mirrors.edge.kernel.org/centos/8/isos/x86_64/CentOS-8.2.2004-x86_64-minimal.iso
+    checksum: 47ab14778c823acae2ee6d365d76a9aed3f95bb8d0add23a06536b58bb5293c0
+    checksumType: sha256
+  boot_command: <tab> text ks=/7/ks.cfg<enter><wait>
+  shutdown_command: sys-unconfig
+  os_display_name: CentOS 8
+  guest_os_type: centos-64
+  ami: &ami
+    filters:
+      virtualization-type: hvm
+      name: CentOS Linux 8 x86_64 HVM EBS ENA*
+      root-device-type: ebs
+      architecture: x86_64
+    owners:
+      - "410186602215"
+    most_recent: true
+  vmware-iso:
+    <<: *isocentos82
+  vmware-vmx:
+    <<: *isocentos82
+  amazon-ebs:
+    <<: *isocentos82
+
+centos8: *centos82

--- a/v1/resources/distros/photon.yml
+++ b/v1/resources/distros/photon.yml
@@ -1,0 +1,23 @@
+photon3:
+  distro_name: photon
+
+  vmx:
+    os_display_name: VMware Photon OS 64-bit
+    guest_os_type: vmware-photon-64
+    vsphere_guest_os_type: vmwarePhoton64Guest
+
+  docker:
+    image: photon
+    tag: 3.0-20200626
+
+  ova:
+    url: http://dl.bintray.com/vmware/photon/3.0/GA/ova/photon-hw11-3.0-26156e2.ova
+    checksum: 5394b482ef10261d5bb732601572539c2ddba3ed
+    checksumType: sha1
+
+  iso: &iso
+    url: https://packages.vmware.com/photon/3.0/Rev2/iso/Update2/photon-minimal-3.0-a0f216d.iso
+    checksum: a5acf94d564f63a174a9de200e04ab6cfe2451f2
+    checksumType: sha1
+    shutdown_command: shutdown  now
+    boot_command: <esc><wait> vmlinuz initrd=initrd.img root/dev/ram0 loglevel=3 photon.media=cdrom ks=/3/ks.json<enter><wait>

--- a/v1/resources/distros/ubuntu.yml
+++ b/v1/resources/distros/ubuntu.yml
@@ -3,6 +3,10 @@ ubuntu1804:
   distribution: Ubuntu
   distribution_release: bionic
   distribution_version: 18.04
+  digitalocean:
+    image: ubuntu-18-04-x64
+  gce:
+    source_image_family: ubuntu-1804-lts
   docker:
     image: ubuntu
     tag: 18.04
@@ -35,3 +39,54 @@ ubuntu1804:
     image_publisher: Canonical
     image_offer: UbuntuServer
     image_sku: 18.04-LTS
+
+ubuntu2004:
+  ubuntu1804:
+  os: ubuntu
+  distribution: Ubuntu
+  distribution_release: focal fossa
+  distribution_version: 20.04
+  digitalocean:
+    image: ubuntu-20-04-x64
+  gce:
+    source_image_family: ubuntu-2004-lts
+  docker:
+    image: ubuntu
+    tag: 20.04
+  qemu:
+    url: https://cloud-images.ubuntu.com/releases/focal/release-20200625/ubuntu-20.04-server-cloudimg-amd64.img
+    checksum: d75d900f406d073205eff1b3711ea4a9f5cf8a46f9c714e41ce7c8b28ec5fc06
+  iso: &iso
+    url: http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04-legacy-server-amd64.iso
+    checksum: 36f15879bd9dfd061cd588620a164a82972663fdd148cce1f70d57d314c21b73
+    checksumType: sha256
+    ssh_username: ubuntu
+    ssh_password: ubuntu
+    shutdown_command: shutdown -P now
+    os_display_name: Ubuntu 20.04
+    boot_command: <esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg  -- <wait><enter><wait>
+  ami: &ami
+    ssh_username: ubuntu
+    source_ami_filter:
+      filters:
+        "virtualization-type": hvm
+        "name": ubuntu/images/*ubuntu-focal-20.04-amd64-server-*
+        "root-device-type": ebs
+        "architecture": x86_64
+      owners:
+        - "099720109477"
+      most_recent: true
+  vmware-iso:
+    <<: *iso
+    os_display_name: Ubuntu 20.04
+    guest_os_type: ubuntu-64
+  vmware-vmx:
+    <<: *iso
+    os_display_name: Ubuntu 20.04
+    guest_os_type: ubuntu-64
+  amazon-ebs:
+    <<: *ami
+  azure:
+    image_publisher: Canonical
+    image_offer: UbuntuServer
+    image_sku: 20.04-LTS


### PR DESCRIPTION
This PR updates the data definition files for the various operating systems - this is the first step in getting rid of all the various packer.json files and configuration values that only get passed through to packer builders

Using these definitions the CLI can generate packer configurations based on the OS/Cloud combination available:

`cd v1 && make pack && go run main.go images` will display the current matrix configured:

```
ALIAS          OS            DISTRO         RELEASE          VERSION   AMI   QEMU   GCE   AZURE   DOCKER   ISO   OVA
ubuntu1804     ubuntu        Ubuntu         bionic           18.04     ✓     ✓      ✓     ✓       ✓        ✓
ubuntu2004     ubuntu        Ubuntu         focal fossa      20.04     ✓     ✓      ✓     ✓       ✓        ✓
centos76       centos        CentOS         Core             7         ✓                          ✓        ✓
centos78       centos        CentOS         Core             7         ✓     ✓                    ✓        ✓
centos82       centos        CentOS         Core             8         ✓     ✓                    ✓        ✓
debian8        debian                                                                                      ✓
debian9        debian                                                                                      ✓
photon3                                                                                           ✓        ✓     ✓
amazonLinux2   amazonLinux   Amazon Linux   Amazon Linux 2   2         ✓
centos         centos        CentOS         Core             7         ✓     ✓                    ✓        ✓
centos8        centos        CentOS         Core             8         ✓     ✓                    ✓        ✓
```

/cc @codenrhoden @detiber @voor 