### PR TITLE
Add auditd to photon OS

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -46,6 +46,7 @@ common_debs:
 - socat
 
 common_photon_rpms:
+- audit
 - conntrack-tools
 - distrib-compat
 - ebtables

--- a/images/capi/ansible/roles/node/files/photon-os/etc/audit/rules.d/containerd.rules
+++ b/images/capi/ansible/roles/node/files/photon-os/etc/audit/rules.d/containerd.rules
@@ -1,0 +1,10 @@
+-w /var/lib/containerd/ -p rwxa -k containerd
+-w /etc/containerd/ -p rwxa -k containerd
+-w /etc/systemd/system/containerd.service -p rwxa -k containerd
+-w /etc/systemd/system/containerd.service.d/ -p rwxa -k containerd
+-w /run/containerd/ -p rwxa -k containerd
+-w /usr/local/bin/containerd-shim -p rwxa -k containerd
+-w /usr/local/bin/containerd-shim-runc-v1 -p rwxa -k containerd
+-w /usr/local/bin/containerd-shim-runc-v2 -p rwxa -k containerd
+-w /usr/local/sbin/runc -p rwxa -k containerd
+-w /usr/local/bin/containerd -p rwxa -k containerd

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+- import_tasks: photon.yml
+  when: ansible_os_family == "VMware Photon OS"
+
 - name: Ensure overlay module is present
   modprobe:
     name: overlay

--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -1,0 +1,28 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Ensure auditd is running and comes on at reboot
+  service:
+    name: auditd
+    state: started
+    enabled: yes
+
+- name: configure auditd rules for containerd
+  copy:
+    src: photon-os/etc/audit/rules.d/containerd.rules
+    dest: /etc/audit/rules.d/containerd.rules
+    owner: root
+    group: root
+    mode: 0644

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -132,7 +132,7 @@
   - { path: /var/log, state: directory }
   - { path: /var/log/sa, state: directory }
 
-- name: Create a log directory for kube-apiserver audit logs
+- name: Create log directories for k8s
   file:
     path: "{{ item.path }}"
     state: "{{ item.state }}"
@@ -143,6 +143,16 @@
   - { path: /var/log/kubernetes, state: directory, mode: "0755" }
   - { path: /var/log/kubernetes/audit.log, state: touch, mode: "0600" }
   when: kubernetes_semver != '' # Ensure audit log is not created for HA Proxy images, since this task is shared amongst build targets
+
+- name: Create a log directory for auditd in Photon OS
+  file:
+    path: "/var/log/audit"
+    state: directory
+    mode: "0640"
+    owner: root
+    group: root
+  when: kubernetes_semver != '' and ansible_os_family == "VMware Photon OS" # Ensure audit log is not created for HA Proxy images, since this task is shared amongst build targets
+
 
 - name: Truncate shell history
   file:


### PR DESCRIPTION
Add auditd to Node image for photon OS

  - Add auditd service
  - Enable on boot
  - Recreate log dir once sysprep cleans log dirs
  - Add containerd audit rules
  - Make sure all auditd customizations happen for photon OS only

  SYSPREP ROLE
  - Include Photon OS tasks at end.
  - Move machine mode fact out of OS specific sysprep role to set
  at begining of role execution.