### PR TITLE
Add Photon 3 AMI build

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -142,7 +142,7 @@ HAPROXY_OVA_LOCAL_BUILD_NAMES			:=	$(addprefix haproxy-ova-local-,$(PHOTON_VERSI
 HAPROXY_OVA_ESX_BUILD_NAMES			:=	$(addprefix haproxy-ova-esx-,$(PHOTON_VERSIONS))
 HAPROXY_OVA_VSPHERE_BUILD_NAMES		:=	$(addprefix haproxy-ova-vsphere-,$(PHOTON_VERSIONS))
 
-AMI_BUILD_NAMES			?=	ami-centos-7 ami-ubuntu-1804 ami-amazon-2
+AMI_BUILD_NAMES			?=	ami-centos-7 ami-ubuntu-1804 ami-amazon-2 ami-photon-3
 GCE_BUILD_NAMES			?=	gce-default
 AZURE_BUILD_NAMES		?=	azure-sig-ubuntu-1804 azure-vhd-ubuntu-1804
 
@@ -235,6 +235,7 @@ $(QEMU_CLEAN_TARGETS):
 build-ami-amazon-2: ## Builds Amazon-2 Linux AMI
 build-ami-centos-7: ## Builds CentOS 7 AMI
 build-ami-ubuntu-1804: ## Builds Ubuntu 18.04 AMI
+build-ami-photon-3: ## Builds Photon 3 AMI
 build-ami-all: $(AMI_BUILD_TARGETS) ## Builds all AMIs
 
 build-azure-sig-ubuntu-1804: ## Builds Ubuntu 18.04 Azure managed image in Shared Image Gallery

--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -18,7 +18,18 @@
   vars:
     packages:
       - awscli
-  when: ansible_distribution != "Amazon"
+  when: 
+    - ansible_os_family == "RedHat"
+    - ansible_distribution != "Amazon"
+
+- name: install AWS clients through pip3
+  pip:
+    executable: pip3
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - awscli
+  when: ansible_distribution == "Ubuntu" or ansible_os_family == "VMware Photon OS"
 
 - name: install aws agents RPM
   package:
@@ -29,6 +40,12 @@
   when: 
     - ansible_os_family == "RedHat" 
     - ansible_distribution != "Amazon"
+
+- name: Install AWS Agent for Photon directly using the rpm command
+  shell: 
+    cmd: rpm -i https://s3.us-west-1.amazonaws.com/amazon-ssm-us-west-1/latest/linux_amd64/amazon-ssm-agent.rpm
+    warn: no
+  when: ansible_os_family == "VMware Photon OS"
 
 - name: install aws agents RPM
   package:
@@ -44,7 +61,7 @@
     name: amazon-ssm-agent
     state: started
     enabled: yes
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" or ansible_os_family == "VMware Photon OS"
 
 - name: install aws agents Ubuntu
   shell: snap install amazon-ssm-agent --classic

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -113,6 +113,17 @@
       ]
     },
     {
+      "type": "shell",
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "inline": [
+        "if [ $BUILD_NAME != \"photon-3\" ]; then exit 0; fi",
+        "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+        "useradd -U -d /home/builder -m --groups wheel builder # photon3 expects builder user to be present"
+      ]
+    },
+    {
       "type": "ansible",
       "playbook_file": "./ansible/node.yml",
       "ansible_env_vars": [

--- a/images/capi/packer/ami/photon-3.json
+++ b/images/capi/packer/ami/photon-3.json
@@ -1,0 +1,10 @@
+{
+  "ami_filter_name": "photon-ami-*",
+  "ami_filter_owners": "798022768933",
+  "build_name": "photon-3",
+  "distribution": "Photon",
+  "distribution_release": "Core",
+  "distribution_version": "3",
+  "source_ami": "",
+  "ssh_username": "root"
+}


### PR DESCRIPTION
This adds Photon 3 to AWS.

I noticed the AWS CLI was being installed with pip rather than pip3, so switched that when I moved Ubuntu to its own definition for installing the AWS CLI.

There's a remediation that adds a `builder` account since some of the tasks expect that username and the photon AMI only has root normally.