### PR TITLE
Add GOSS provisioner to node OVA builder

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -108,7 +108,8 @@ endif
 COMMON_NODE_VAR_FILES :=	packer/config/kubernetes.json \
 					packer/config/cni.json \
 					packer/config/containerd.json \
-					packer/config/ansible-args.json
+					packer/config/ansible-args.json \
+					packer/config/goss-args.json
 
 COMMON_HAPROXY_VAR_FILES := packer/ova/packer-common.json \
 					packer/config/ansible-args.json

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -20,7 +20,6 @@
     "extra_debs": "",
     "extra_repos": "",
     "extra_rpms": "",
-    "goss_url": "https://github.com/aelsabbahy/goss/releases/download/v0.3.2/goss-linux-amd64",
     "iam_instance_profile": "",
     "ib_version": "{{env `IB_VERSION`}}",
     "kms_key_id": "",
@@ -128,9 +127,12 @@
     },
     {
       "type": "goss",
+      "arch": "{{user `goss_arch`}}",
+      "format": "{{user `goss_format`}}",
+      "tests": ["packer/goss/goss.yaml"],
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
-      "tests": ["packer/goss/goss.yaml"]
+      "version": "{{user `goss_version`}}"
     }
   ],
   "post-processors": [

--- a/images/capi/packer/config/goss-args.json
+++ b/images/capi/packer/config/goss-args.json
@@ -1,0 +1,6 @@
+{
+  "goss_arch": "amd64",
+  "goss_url": "",
+  "goss_version": "0.3.13",
+  "goss_format": "json"
+}

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -155,7 +155,15 @@
         "--extra-vars",
         "{{user `ansible_extra_vars`}}"
       ]
-   }
+   },{
+      "type": "goss",
+      "arch": "{{user `goss_arch`}}",
+      "format": "{{user `goss_format`}}",
+      "tests": ["packer/goss/goss.yaml"],
+      "url": "{{user `goss_url`}}",
+      "use_sudo": true,
+      "version": "{{user `goss_version`}}"
+    }
   ],
   "post-processors": [
     {


### PR DESCRIPTION
  - Runs goss verifier on node OVA
  - Extract out goss args in common config
  - Update GOSS version to 0.3.13

Fixes #278 #279 #280 