### PR TITLE
capi: remove iso_checksum_type in qemu for packer 1.6

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -56,8 +56,7 @@
       "format": "{{user `format`}}",
       "headless": "{{user `headless`}}",
       "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
-      "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
       "iso_url": "{{user `iso_url`}}",
       "boot_command": [
         "{{user `boot_command_prefix`}}",


### PR DESCRIPTION
Packer v1.6.0 or newer does not support the config `iso_checksum_type`.
So it simply fails with the following message:

```
1 error occurred:
        * Deprecated configuration key: 'iso_checksum_type'. Please call `packer fix` against your template to update your template to be compatible with the current version of Packer. Visit https://www.packer.io/docs/commands/fix/ for more detail.
```

It addresses similar issues as https://github.com/kubernetes-sigs/image-builder/pull/255, but this PR is about qemu, not ova.