### PR TITLE
Move rng-tools package to Ansible from photon kickstart

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -58,6 +58,7 @@ common_photon_rpms:
 - python-netifaces
 - python3-pip
 - python-requests
+- rng-tools
 - socat
 - tar
 - unzip

--- a/images/capi/packer/ova/linux/photon/http/3/ks.json
+++ b/images/capi/packer/ova/linux/photon/http/3/ks.json
@@ -19,7 +19,7 @@
         "net-tools",
         "openssh-server", "open-vm-tools",
         "pkg-config", "photon-release", "photon-repos", "procps-ng",
-        "rng-tools", "rpm",
+        "rpm",
         "sed", "sudo",
         "tdnf", "tzdata",
         "util-linux",


### PR DESCRIPTION
Photon OS base image does not have `rng-tools` package. Additionally, photon os's kickstart file `ks.json` won't raise an error if package is missing.

Moving installation of `rng-tools` from kickstart to node ansible role