### PR TITLE
Allow customizing volume_size for AWS

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -48,7 +48,8 @@
     "snapshot_groups": "all",
     "snapshot_users": "",
     "subnet_id": "",
-    "vpc_id": ""
+    "vpc_id": "",
+    "volume_size": ""
   },
   "builders": [
     {
@@ -96,7 +97,15 @@
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver`}}",
         "kubernetes_version": "{{user `kubernetes_semver`}}",
         "source_ami": "{{user `source_ami`}}"
-      }
+      },
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_size": "{{ user `volume_size` }}",
+          "volume_type": "gp2",
+          "delete_on_termination": true
+        }
+      ]
     }
   ],
   "provisioners": [


### PR DESCRIPTION
When adding in custom roles or additional tasks you quickly run out of space since most AMI only have 8GB of space.  This just allows a larger volume, which is already supported in Azure and vSphere.

Topic of conversation, Azure changes this with `vm_size`, vSphere changes this with `disk_size` which is a different variable from AWS that is `volume_size`, wondering if it would be confusing or offer better consistency by using the existing variable for `vm_size`?