### PR TITLE
Added cfg file for cloud-init to improve usability

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/05_logging.cfg
+++ b/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/05_logging.cfg
@@ -1,0 +1,67 @@
+## This yaml formated config file handles setting
+## logger information.  The values that are necessary to be set
+## are seen at the bottom.  The top '_log' are only used to remove
+## redundency in a syslog and fallback-to-file case.
+##
+## The 'log_cfgs' entry defines a list of logger configs
+## Each entry in the list is tried, and the first one that
+## works is used.  If a log_cfg list entry is an array, it will
+## be joined with '\n'.
+_log:
+ - &log_base |
+   [loggers]
+   keys=root,cloudinit
+   
+   [handlers]
+   keys=consoleHandler,cloudLogHandler
+   
+   [formatters]
+   keys=simpleFormatter,arg0Formatter
+   
+   [logger_root]
+   level=DEBUG
+   formatter=arg0Formatter
+   handlers=consoleHandler,cloudLogHandler
+   
+   [logger_cloudinit]
+   level=DEBUG
+   qualname=cloudinit
+   handlers=
+   propagate=1
+   
+   [handler_consoleHandler]
+   class=StreamHandler
+   level=WARNING
+   formatter=arg0Formatter
+   args=(sys.stderr,)
+   
+   [formatter_arg0Formatter]
+   format=%(asctime)s - %(filename)s[%(levelname)s]: %(message)s
+   
+   [formatter_simpleFormatter]
+   format=[CLOUDINIT]%(asctime)s - %(filename)s[%(levelname)s]: %(message)s
+ - &log_file |
+   [handler_cloudLogHandler]
+   class=FileHandler
+   level=DEBUG
+   formatter=arg0Formatter
+   args=('/var/log/cloud-init.log',)
+ - &log_syslog |
+   [handler_cloudLogHandler]
+   class=handlers.SysLogHandler
+   level=DEBUG
+   formatter=simpleFormatter
+   args=("/dev/log", handlers.SysLogHandler.LOG_USER)
+
+log_cfgs:
+# These will be joined into a string that defines the configuration
+ - [ *log_base, *log_syslog ]
+# These will be joined into a string that defines the configuration
+ - [ *log_base, *log_file ]
+# A file path can also be used
+# - /etc/log.conf
+
+# this tells cloud-init to redirect its stdout and stderr to
+# 'tee -a /var/log/cloud-init-output.log' so the user can see output
+# there without needing to look on the console.
+output: {all: '| python3 -c ''import sys,time;sys.stdout.write("".join(( " ".join((time.strftime("[%Y-%m-%d %H:%M:%S]", time.localtime()), line)) for line in sys.stdin )))'' | tee -a /var/log/cloud-init-output.log'}

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -68,3 +68,11 @@
     - cloud-config
     - cloud-init
     - cloud-init-local
+
+- name: Create cloud-init config file
+  copy:
+    src: files/etc/cloud/cloud.cfg.d/05_logging.cfg
+    dest: /etc/cloud/cloud.cfg.d/05_logging.cfg
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
- Adds a logging config file for cloud-init data
- Adds timestamp to cloud-init entries
- Outputs data destined for `cloud-init-output.log` to the console too.