### PR TITLE
Add kernel params to GOSS validation spec

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -139,7 +139,8 @@
       "arch": "{{user `goss_arch`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
-      "tests": ["packer/goss/goss.yaml"],
+      "goss_file": "{{user `goss_entry_file`}}",
+      "tests": ["{{user `goss_tests_dir`}}"],
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "version": "{{user `goss_version`}}"

--- a/images/capi/packer/config/goss-args.json
+++ b/images/capi/packer/config/goss-args.json
@@ -1,7 +1,9 @@
 {
   "goss_arch": "amd64",
   "goss_format": "json",
-  "goss_format_options": "pretty",
+  "goss_entry_file": "goss/goss.yaml",
+  "goss_tests_dir": "packer/goss",
   "goss_url": "",
+  "goss_format_options": "pretty",
   "goss_version": "0.3.13"
 }

--- a/images/capi/packer/goss/goss-common.yaml
+++ b/images/capi/packer/goss/goss-common.yaml
@@ -1,0 +1,32 @@
+package:
+  cloud-init:
+    installed: true
+  kubeadm:
+    installed: true
+  kubelet:
+    installed: true
+  kubectl:
+    installed: true
+  kubernetes-cni:
+    installed: true
+service:
+  containerd:
+    enabled: true
+    running: true
+  dockerd:
+    enabled: false
+    running: false
+  kubelet:
+    enabled: true
+    running: false
+command:
+  crictl ps:
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 0
+  crictl images | grep -v 'IMAGE ID' | awk -F' ' '{print $1}' | awk -F'/' '{print $2}' | awk '!seen[$0]++' | sort:
+    exit-status: 0
+    stdout: ["coredns", "etcd", "kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler", "pause"]
+    stderr: []
+    timeout: 0

--- a/images/capi/packer/goss/goss-common.yaml
+++ b/images/capi/packer/goss/goss-common.yaml
@@ -1,3 +1,25 @@
+command:
+  crictl ps:
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 0
+  crictl images | grep -v 'IMAGE ID' | awk -F' ' '{print $1}' | awk -F'/' '{print $2}' | awk '!seen[$0]++' | sort:
+    exit-status: 0
+    stdout: ["coredns", "etcd", "kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler", "pause"]
+    stderr: []
+    timeout: 0
+kernel-param:
+  net.bridge.bridge-nf-call-iptables:
+    value: "1"
+  net.ipv6.conf.all.forwarding:
+    value: "1"
+  net.ipv6.conf.all.disable_ipv6:
+    value: "0"
+  net.ipv4.ip_forward:
+    value: "1"
+  net.bridge.bridge-nf-call-ip6tables:
+    value: "1"
 package:
   cloud-init:
     installed: true

--- a/images/capi/packer/goss/goss.yaml
+++ b/images/capi/packer/goss/goss.yaml
@@ -1,10 +1,2 @@
-package:
-  cloud-init:
-    installed: true
-service:
-  containerd:
-    enabled: true
-    running: true
-command:
-  crictl ps:
-    exit-status: 0
+gossfile:
+  goss-common.yaml: {}

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -160,7 +160,8 @@
       "arch": "{{user `goss_arch`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
-      "tests": ["packer/goss/goss.yaml"],
+      "goss_file": "{{user `goss_entry_file`}}",
+      "tests": ["{{user `goss_tests_dir`}}"],
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "version": "{{user `goss_version`}}"


### PR DESCRIPTION
Add 5 kernel params that should have expected values set in sysctl.conf.

We do not need sysctl conf file location for the different OS as GOSS deals directly with sysctl CLI directly using https://github.com/lorenzosaino/go-sysctl

/hold

Should not be merged before #291 (Needs commits in there)

/assign @codenrhoden 