### PR TITLE
Make ensure-goss replace old goss provisioner version

### DIFF
--- a/images/capi/hack/ensure-goss.sh
+++ b/images/capi/hack/ensure-goss.sh
@@ -20,18 +20,15 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="1.1.0"
 # SHA are for amd64 arch.
+_version="1.1.0"
 darwin_sha256="157b3d281717584ccdb0069e6d5eb90c27d758169960501b2d65902235d215b0"
 linux_sha256="95efb49d7d9434c8aa8deff841ef3d83bd58988f592a72dfce46b684600f8d0a"
 _bin_url="https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${_version}/packer-provisioner-goss-v${_version}-${HOSTOS}-${HOSTARCH}"
 
 _binfile="${HOME}/.packer.d/plugins/packer-provisioner-goss"
-if [ -f "${_binfile}" ]; then
-  { [ -x "${_binfile}" ] && exit 0; } || rm -f "${_binfile}"
-fi
-_bin_dir="$(dirname "${_binfile}")"
-mkdir -p "${_bin_dir}" && cd "${_bin_dir}"
+
+# Get a shasum for right OS's binary
 case "${HOSTOS}" in
 linux)
   _sha256="${linux_sha256}"
@@ -44,6 +41,23 @@ darwin)
   return 1
   ;;
 esac
+
+# Check if current binary is latest
+if [ -f "${_binfile}" ]; then
+  current_shasum=$(get_shasum "${_binfile}")
+  if [ "$current_shasum" != "$_sha256" ]; then
+    echo "Wrong version of binary present."
+  else
+    echo "Right version of binary present"
+    # Check if binary is executable.
+    # If not, delete it and proceed. If it is executable, exit 0
+    { [ -x "${_binfile}" ] && exit 0; } || rm -f "${_binfile}"
+  fi
+fi
+
+# download binary, verify shasum, make it executable and clean up trash files.
+_bin_dir="$(dirname "${_binfile}")"
+mkdir -p "${_bin_dir}" && cd "${_bin_dir}"
 curl -L "${_bin_url}" -o "${_binfile}"
 printf "%s *${_binfile}" "${_sha256}" >"${_binfile}.sha256"
 if ! checksum_sha256 "${_binfile}.sha256"; then

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -54,3 +54,16 @@ checksum_sha256() {
     return 1
   fi
 }
+
+get_shasum() {
+  local present_shasum=''
+  if command -v shasum >/dev/null 2>&1; then
+    present_shasum=$(shasum -a 256 "${1}"| awk -F' ' '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    present_shasum=$(sha256sum -c "${1}" | awk -F' ' '{print $1}')
+  else
+    echo "missing shasum tool" 1>&2
+    return 1
+  fi
+  echo "$present_shasum"
+}


### PR DESCRIPTION
Right now our ensure scripts don't check the version of binary present on the machine.

This change will check the right version's presence by comparing SHASUM and install a newer version of packer provisioner goss if needed.  