### PR TITLE
:bug: Required volume sizes since it's now in a required position.

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -49,7 +49,7 @@
     "snapshot_users": "",
     "subnet_id": "",
     "vpc_id": "",
-    "volume_size": ""
+    "volume_size": "8"
   },
   "builders": [
     {


### PR DESCRIPTION
I broke the build, since volume_size is now required it's prepopulated.  It just so happens that all current supported images use 8 as a default, but it's placed in that file in the event one of them changes.

/assign @detiber 
/cc @codenrhoden 