### PR TITLE
Allow AMI to be private.

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -96,6 +96,15 @@ ifeq (1,$(strip $(FOREGROUND)))
 PACKER_FLAGS += -var="headless=false"
 endif
 
+# If AMI_PRIVATE=1 then AMI_GROUPS will not be set to all, this is to workaround
+# a problem with packer only accepting one variable for ami_groups which makes it
+# impossible to override.
+ifeq (1,$(strip $(AMI_PRIVATE)))
+unexport AMI_GROUPS
+else
+export AMI_GROUPS ?= "all"
+endif
+
 # We want the var files passed to Packer to have a specific order, because the
 # precenence of the variables they contain depends on the order. Files listed
 # later on the CLI have higher precedence. We want the common var files found in

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "ami_description": "Cluster API base image designed for {{user `kubernetes_semver`}}",
-    "ami_groups": "all",
+    "ami_groups": "{{env `AMI_GROUPS`}}",
     "ami_regions": "ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2",
     "ami_users": "",
     "ansible_common_vars": "",

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -45,7 +45,7 @@
     "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
     "remove_extra_repos": "false",
     "skip_profile_validation": "false",
-    "snapshot_groups": "all",
+    "snapshot_groups": "{{env `AMI_GROUPS`}}",
     "snapshot_users": "",
     "subnet_id": "",
     "vpc_id": "",


### PR DESCRIPTION
This is a tricky one that I'd like to discuss further.  There is *only* one valid value for this field, and that's `all`.  That means if you set this to `all` *anywhere* it cannot be overridden, because `all` is the only thing it accepts other than `nil`.  There's no unset in packer, so this is an admitted hack.  Now that we are pushing folks towards the Makefile with migration plans to a CLI, I believe it's acceptable to do something like this, which would allow defaulting an environment variable with an option to override.

Thoughts?

/cc @codenrhoden @detiber @randomvariable 