### PR TITLE
Bump docs and scripts to Packer v1.6.0

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -6,6 +6,11 @@ The Image Builder can be used to build images intended for use with Kubernetes [
 
 [Packer](https://www.packer.io) and [Ansible](https://github.com/ansible/ansible) are used for building these images. This tooling has been forked and extended from the [Wardroom](https://github.com/heptiolabs/wardroom) project.
 
+- [Packer](https://www.packer.io/intro/getting-started/install.html) version >= 1.6.0
+- [Goss plugin for Packer](https://github.com/YaleUniversity/packer-provisioner-goss) version >= 1.1.0
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
+
+If any needed binaries are not present, they can be installed to `images/capi/.bin` with the `make deps` command. This directory will need to be added to your `$PATH`.
 
 ## Providers
 

--- a/docs/book/src/capi/providers/aws.md
+++ b/docs/book/src/capi/providers/aws.md
@@ -1,30 +1,18 @@
 # Building Images for AWS
 
-## Prerequisites
-
-The `make deps-ami` target will test that Ansible, Packer, and Goss are installed and available. If they are not, they will be installed to `images/capi/.bin`. This directory will need to be added to your `$PATH`.
-
-### Prerequisites for all images
-
-- [Packer](https://www.packer.io/intro/getting-started/install.html)
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
-- [goss](https://github.com/YaleUniversity/packer-provisioner-goss)
-
-#### Installing the goss plugin
-
-To install `packer-goss` plugin the following should be executed inside of the
-`images/capi` directory:
-
-```bash
-make deps-ami
-```
-
-### Prerequisites for Amazon Web Services
+## Prerequisites for Amazon Web Services
 
 - An AWS account
 - The AWS CLI installed and configured
 
 ## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building AMIs are managed by running:
+
+```bash
+make deps-ami
+```
 
 From the `images/capi` directory, run `make build-ami-<OS>`, where `<OS>` is
 the desired operating system. The available choices are listed via `make help`.

--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -1,21 +1,19 @@
 # Building Images for Azure
 
-## Prerequisites
-
-The `make deps-azure` target will test that Ansible, Packer, and `jq` are installed and available. If they are not, they will be installed to `images/capi/.bin`. This directory will need to be added to your `$PATH`.
-
-### Prerequisites for all images
-
-- [Packer](https://www.packer.io/intro/getting-started/install.html)
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
-
-### Prerequisites for Azure
+## Prerequisites for Azure
 
 - An Azure account
 - The Azure CLI installed and configured
 - Set environment variables for `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
 
 ## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building Azure images are managed by running:
+
+```bash
+make deps-azure
+```
 
 ### Building Managed Images in Shared Image Galleries
 

--- a/docs/book/src/capi/providers/digitalocean.md
+++ b/docs/book/src/capi/providers/digitalocean.md
@@ -1,21 +1,19 @@
 # Building Images for DigitalOcean
 
-## Prerequisites
-
-The `make deps-do` target will test that Ansible and Packer are installed and available. If they are not, they will be installed to `images/capi/.bin`. This directory will need to be added to your `$PATH`.
-
-### Prerequisites for all images
-
-- [Packer](https://www.packer.io/intro/getting-started/install.html)
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
-
-### Prerequisites for DigitalOcean
+## Prerequisites for DigitalOcean
 
 - A DigitalOcean account
 - The DigitalOcean CLI ([doctl](https://github.com/digitalocean/doctl#installing-doctl)) installed and configured
 - Set environment variables for `DIGITALOCEAN_ACCESS_TOKEN`,
 
 ## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building Digital Ocean images are managed by running:
+
+```bash
+make deps-do
+```
 
 ### Building DigitalOcean Image Snapshots
 

--- a/docs/book/src/capi/providers/openstack.md
+++ b/docs/book/src/capi/providers/openstack.md
@@ -1,17 +1,8 @@
 # Building Images for OpenStack
 
-## Prerequisites
-
-The `make deps-qemu` target will test that Ansible and Packer are installed and available. If they are not, they will be installed to `images/capi/.bin`. This directory will need to be added to your `$PATH`.
-
-### Hypervisor
+## Hypervisor
 
 The image is built using KVM hypervisor.
-
-### Prerequisites for all images
-
-- [Packer](https://www.packer.io/intro/getting-started/install.html)
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
 
 ### Prerequisites for QCOW2
 
@@ -33,6 +24,13 @@ $ sudo chown root:kvm /dev/kvm
 Then exit and log back in to make the change take place.
 
 ## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building qemu images are managed by running:
+
+```bash
+make deps-qemu
+```
 
 ### Building QCOW2 Image
 

--- a/docs/book/src/capi/providers/vsphere.md
+++ b/docs/book/src/capi/providers/vsphere.md
@@ -1,10 +1,6 @@
 # Building Images for vSphere
 
-## Prerequisites
-
-The `make deps-ova` target will test that Ansible and Packer are installed and available. If they are not, they will be installed to `images/capi/.bin`. This directory will need to be added to your `$PATH`.
-
-### Hypervisor
+## Hypervisor
 
 The images may be built using one of the following hypervisors:
 
@@ -20,15 +16,7 @@ The images may be built using one of the following hypervisors:
 The `esxi` builder supports building against a remote VMware ESX server with [specific configuration](https://packer.io/docs/builders/vmware-iso.html#building-on-a-remote-vsphere-hypervisor) (ssh access), but is untested with this project.
 The `vsphere` builder supports building against a remote VMware vSphere using standard API.
 
-
-### Prerequisites for all images
-
-- [Packer](https://www.packer.io/intro/getting-started/install.html) version >= 1.5.5
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
-
 ### Prerequisites for vSphere builder
-
-Packer version >= 1.6.0 is required (older versions still work for building from remote ESXi and locally options).
 
 Complete the `vsphere.json` configuration file with credentials and informations specific to the remote vSphere hypervisor used to build the `ova` file.
 This file must have the following format (`cluster` can be replace by `host`):
@@ -48,6 +36,13 @@ This file must have the following format (`cluster` can be replace by `host`):
 If you prefer to use a different configuration file, you can create it with the same format and export `PACKER_VAR_FILES` environment variable containing the full path to it.
 
 ## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building OVAs are managed by running:
+
+```bash
+make deps-ova
+```
 
 From the `images/capi` directory, run `make build-node-ova-<hypervisor>-<OS>`, where `<hypervisor>` is your target hypervisor (`local`, `vsphere` or `esx`) and `<OS>` is the desired operating system. The available choices are listed via `make help`.
 

--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-_version="1.5.2"
+_version="1.6.0"
 
 # Change directories to the parent directory of the one in which this
 # script is located.

--- a/v1/README.md
+++ b/v1/README.md
@@ -16,7 +16,7 @@ Engines are specified and configured using the `engine` section:
 ```yaml
 engine:
   kind: packer
-  version: 1.5.5
+  version: 1.6.0
   builders:
     amazon-ebs:
       ami_name: !!template image-builder-{{ (time.Now).Format "2006-01-02-150405" }}

--- a/v1/examples/packerAws.yml
+++ b/v1/examples/packerAws.yml
@@ -3,7 +3,7 @@ input:
   kind: ami
 engine:
   kind: packer
-  version: 1.5.5
+  version: 1.6.0
   builders:
     amazon-ebs:
       ami_name: !!template image-builder-{{ (time.Now).Format "2006-01-02-150405" }}


### PR DESCRIPTION
We've merged changes recently that require Packer 1.6.0, so update
scripts and docs to reference that version.

/assign @voor 
/assign @detiber 

fixes #174 