### PR TITLE
explicitly pass user: builder so that ansible does not default to root

### DIFF
--- a/images/capi/packer/ova/packer-haproxy.json
+++ b/images/capi/packer/ova/packer-haproxy.json
@@ -123,6 +123,7 @@
   "provisioners": [
     {
       "type": "ansible",
+      "user": "{{user `ssh_username`}}",
       "playbook_file": "./ansible/haproxy.yml",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -145,6 +145,7 @@
     {
       "type": "ansible",
       "playbook_file": "./ansible/node.yml",
+      "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
         "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"


### PR DESCRIPTION
fixes #263 

Pass the packer var `ssh_username` as the user into ansible so that it does not error out when building the ova as root. 