### PR TITLE
Add OS & provider specific GOSS validations

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -151,7 +151,11 @@
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
+        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
+        "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0 }}",
+        "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+        "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
+        "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "version": "{{user `goss_version`}}"

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -147,6 +147,9 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "vars_inline": {
+        "OS": "{{user `distribution` | lower}}",
+        "ARCH": "amd64",
+        "PROVIDER": "amazon",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version": "{{user `containerd_version`}}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -140,6 +140,9 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "vars_inline": {
+        "OS": "{{user `distribution` | lower}}",
+        "ARCH": "amd64",
+        "PROVIDER": "azure",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version" : "{{user `containerd_version`}}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -144,7 +144,11 @@
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version" : "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
+        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
+        "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+        "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+        "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
+        "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "version": "{{user `goss_version`}}"

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -35,17 +35,17 @@ command:
     stdout: ["coredns", "etcd", "kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler", "pause"]
 {{end}}
 {{if eq .Vars.kubernetes_source_type "http"}}
-  kubectl version --short --client=true -o json | jq .clientVersion.gitVersion | awk -F'[v"]' '{print $3}':
+  kubectl version --short --client=true -o json | jq .clientVersion.gitVersion | tr -d '"' | awk '{print substr($1,2); }':
     exit-status: 0
     stdout: [{{ .Vars.kubernetes_version }}]
     stderr: []
     timeout: 0
-  kubeadm version -o json | jq .clientVersion.gitVersion | awk -F'[v"]' '{print $3}':
+  kubeadm version -o json | jq .clientVersion.gitVersion | tr -d '"' | awk '{print substr($1,2); }':
     exit-status: 0
     stdout: [{{ .Vars.kubernetes_version }}]
     stderr: []
     timeout: 0
-  kubelet --version | awk -F'[ v]' '{print $3}':
+  kubelet --version | awk -F' ' '{print $2}'  | tr -d '"' | awk '{print substr($1,2); }':
     exit-status: 0
     stdout: [{{ .Vars.kubernetes_version }}]
     stderr: []

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -11,7 +11,7 @@ command:
     timeout: 0
 {{if eq .Vars.kubernetes_source_type "pkg"}}
 {{if eq .Vars.kubernetes_cni_source_type "pkg"}}
-  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sort:
+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
     stderr: []
     timeout: 0
@@ -20,7 +20,7 @@ command:
 {{end}}
 {{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (not .Vars.kubernetes_load_additional_imgs)}}
 # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
-  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | awk 'BEGIN{FS=OFS="-"}NF--' | sort:
+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
     stderr: []
     timeout: 0
@@ -28,7 +28,7 @@ command:
 {{end}}
 {{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (.Vars.kubernetes_load_additional_imgs)}}
 # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
-  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | awk 'BEGIN{FS=OFS="-"}NF--' | sort:
+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
     stderr: []
     timeout: 0

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -58,3 +58,15 @@ command:
     stderr: []
     timeout: 0
 {{end}}
+{{range $name, $vers := index .Vars .Vars.OS "common-command"}}
+  {{ $name }}:
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "command"}}
+  {{ $name }}:
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}

--- a/images/capi/packer/goss/goss-kernel-params.yaml
+++ b/images/capi/packer/goss/goss-kernel-params.yaml
@@ -9,3 +9,15 @@ kernel-param:
     value: "1"
   net.bridge.bridge-nf-call-ip6tables:
     value: "1"
+{{range $name, $vers := index .Vars .Vars.OS "common-kernel-param"}}
+  {{ $name }}:
+  {{range $key, $val := $vers}}
+    {{$key}}: "{{$val}}"
+  {{end}}
+{{end}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "kernel-param"}}
+  {{ $name }}:
+  {{range $key, $val := $vers}}
+    {{$key}}: "{{$val}}"
+  {{end}}
+{{end}}

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -34,7 +34,7 @@ package:
     <<: *kubernetes_cni_version
 {{end}}
 # Looping over common packages for an OS
-{{range $name, $vers := index .Vars .Vars.OS "common-packages"}}
+{{range $name, $vers := index .Vars .Vars.OS "common-package"}}
   {{$name}}:
     installed: true
   {{range $key, $val := $vers}}
@@ -42,7 +42,7 @@ package:
   {{end}}
 {{end}}
 # Looping over provider specific packages for an OS
-{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "packages"}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "package"}}
   {{$name}}:
     installed: true
   {{range $key, $val := $vers}}

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -33,3 +33,19 @@ package:
     installed: true
     <<: *kubernetes_cni_version
 {{end}}
+# Looping over common packages for an OS
+{{range $name, $vers := index .Vars .Vars.OS "common-packages"}}
+  {{$name}}:
+    installed: true
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}
+# Looping over provider specific packages for an OS
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "packages"}}
+  {{$name}}:
+    installed: true
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -1,7 +1,18 @@
-x-function: &kubernetes_version
+kubernetes_version: &kubernetes_version
   versions:
-    contain-element:
-      match-regexp: {{ .Vars.kubernetes_version }}
+    or:
+     - contain-element:
+         match-regexp: "^\\Q{{ .Vars.kubernetes_deb_version }}\\E$"
+     - contain-element:
+         match-regexp: "^\\Q{{ .Vars.kubernetes_rpm_version }}\\E$"
+
+kubernetes_cni_version: &kubernetes_cni_version
+  versions:
+    or:
+      - contain-element:
+          match-regexp: "^\\Q{{ .Vars.kubernetes_cni_deb_version }}\\E$"
+      - contain-element:
+          match-regexp: "^\\Q{{ .Vars.kubernetes_cni_rpm_version }}\\E$"
 
 package:
   cloud-init:
@@ -20,7 +31,5 @@ package:
 {{if eq .Vars.kubernetes_cni_source_type "pkg"}}
   kubernetes-cni:
     installed: true
-    versions:
-      contain-element:
-        match-regexp: {{ .Vars.kubernetes_cni_version }}
+    <<: *kubernetes_cni_version
 {{end}}

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -8,3 +8,15 @@ service:
   kubelet:
     enabled: true
     running: false
+{{range $name, $vers := index .Vars .Vars.OS "common-service"}}
+  {{ $name }}:
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "service"}}
+  {{ $name }}:
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -1,4 +1,62 @@
 ---
+common_rpms: &common_rpms
+  ca-certificates:
+  conntrack-tools:
+  curl:
+  ebtables:
+  jq:
+  ntp:
+  open-vm-tools:
+  python-netifaces:
+  python-requests:
+  socat:
+  yum-utils:
+
+common_debs: &common_debs
+  apt-transport-https:
+  conntrack:
+  conntrackd:
+  curl:
+  ebtables:
+  jq:
+  gnupg:
+  libnetfilter-acct1:
+  libnetfilter-cttimeout1:
+  libnetfilter-log1:
+  linux-cloud-tools-virtual:
+  linux-tools-virtual:
+  ntp:
+  open-vm-tools:
+  python3-distutils:
+  python3-netifaces:
+  python3-pip:
+  socat:
+
+chrony_deb: &chrony_deb
+  chrony:
+  ntp:
+    skip: true
+    installed: false
+
+
+common_photon_rpms: &common_photon_rpms
+  audit:
+  conntrack-tools:
+  distrib-compat:
+  ebtables:
+  jq:
+  net-tools:
+  ntp:
+  openssl-c_rehash:
+  open-vm-tools:
+  python-netifaces:
+  python3-pip:
+  python-requests:
+  rng-tools:
+  socat:
+  tar:
+  unzip:
+
 arch: "amd64"
 containerd_version: ""
 kubernetes_cni_source_type: ""
@@ -11,3 +69,96 @@ kubernetes_cni_deb_version: ""
 kubernetes_cni_rpm_version: ""
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false
+
+# OS Specific Packages/Command/Kernal Params etc...
+# Structured in below format
+# OS_NAME
+#   common-packages:
+#   common-kernel-params:
+#   common-commands:
+#   common-services:
+#   PROVIDER_NAME:
+#     packages:
+#     command:
+#     service:
+#  ...
+amazon linux:
+  common-packages: *common_rpms
+  amazon:
+    service:
+      amazon-ssm-agent:
+        enabled: true
+        running: true
+    packages:
+      awscli:
+      amazon-ssm-agent:
+centos:
+  common-packages: *common_rpms
+  amazon:
+    packages:
+      amazon-ssm-agent:
+    command:
+      pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
+        exit-status: 0
+        stdout: ["awscli"]
+        stderr: []
+        timeout: 0
+  azure:
+    package:
+      azure_cli:
+  ova:
+    packages:
+      open-vm-tools:
+      cloud-init:
+      cloud-utils-growpart:
+      python2-pip:
+ubuntu:
+  common-packages:
+    <<: *common_debs
+  azure:
+    command:
+      pip3 list --format=columns | grep 'azure-cli' | awk -F' ' '{print $1}':
+        exit-status: 0
+        stdout: ["azure-cli"]
+        stderr: []
+        timeout: 0
+    packages:
+      <<: *chrony_deb
+    service:
+      chrony:
+        enabled: true
+        running: true
+  amazon:
+    service:
+      snap.amazon-ssm-agent.amazon-ssm-agent.service:
+        enabled: true
+        running: true
+    packages:
+    command:
+      snap list | grep 'amazon-ssm-agent' | awk -F' ' '{print $1}':
+        exit-status: 0
+        stdout: ["amazon-ssm-agent"]
+        stderr: []
+        timeout: 0
+      pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
+        exit-status: 0
+        stdout: ["awscli"]
+        stderr: []
+        timeout: 0
+  ova:
+    packages:
+      open-vm-tools:
+      cloud-guest-utils:
+      cloud-initramfs-copymods:
+      cloud-initramfs-dyn-netconf:
+      cloud-initramfs-growroot:
+photon:
+  common-packages:
+    <<: *common_photon_rpms
+    audit:
+  ova:
+    packages:
+      open-vm-tools:
+      cloud-init:
+      cloud-utils:
+      python3-netifaces:

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -1,8 +1,10 @@
 ---
-kubernetes_cni_version: ""
+arch: "amd64"
 containerd_version: ""
-kubernetes_version: ""
-kubernetes_source_type: ""
 kubernetes_cni_source_type: ""
+kubernetes_cni_version: ""
+kubernetes_source_type: ""
+kubernetes_version: ""
+
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -70,32 +70,32 @@ kubernetes_cni_rpm_version: ""
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false
 
-# OS Specific Packages/Command/Kernal Params etc...
+# OS Specific package/Command/Kernal Params etc...
 # Structured in below format
 # OS_NAME
-#   common-packages:
+#   common-package:
 #   common-kernel-params:
 #   common-commands:
 #   common-services:
 #   PROVIDER_NAME:
-#     packages:
+#     package:
 #     command:
 #     service:
 #  ...
 amazon linux:
-  common-packages: *common_rpms
+  common-package: *common_rpms
   amazon:
     service:
       amazon-ssm-agent:
         enabled: true
         running: true
-    packages:
+    package:
       awscli:
       amazon-ssm-agent:
 centos:
-  common-packages: *common_rpms
+  common-package: *common_rpms
   amazon:
-    packages:
+    package:
       amazon-ssm-agent:
     command:
       pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
@@ -107,13 +107,13 @@ centos:
     package:
       azure_cli:
   ova:
-    packages:
+    package:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
       python2-pip:
 ubuntu:
-  common-packages:
+  common-package:
     <<: *common_debs
   azure:
     command:
@@ -122,7 +122,7 @@ ubuntu:
         stdout: ["azure-cli"]
         stderr: []
         timeout: 0
-    packages:
+    package:
       <<: *chrony_deb
     service:
       chrony:
@@ -133,7 +133,7 @@ ubuntu:
       snap.amazon-ssm-agent.amazon-ssm-agent.service:
         enabled: true
         running: true
-    packages:
+    package:
     command:
       snap list | grep 'amazon-ssm-agent' | awk -F' ' '{print $1}':
         exit-status: 0
@@ -146,18 +146,21 @@ ubuntu:
         stderr: []
         timeout: 0
   ova:
-    packages:
+    package:
       open-vm-tools:
       cloud-guest-utils:
       cloud-initramfs-copymods:
       cloud-initramfs-dyn-netconf:
       cloud-initramfs-growroot:
 photon:
-  common-packages:
+  common-kernel-param:
+    net.ipv4.tcp_limit_output_bytes:
+      value: "1048576"
+  common-package:
     <<: *common_photon_rpms
     audit:
   ova:
-    packages:
+    package:
       open-vm-tools:
       cloud-init:
       cloud-utils:

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -5,6 +5,9 @@ kubernetes_cni_source_type: ""
 kubernetes_cni_version: ""
 kubernetes_source_type: ""
 kubernetes_version: ""
-
+kubernetes_rpm_version: ""
+kubernetes_deb_version: ""
+kubernetes_cni_deb_version: ""
+kubernetes_cni_rpm_version: ""
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -171,7 +171,11 @@
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version" : "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
+        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
+        "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+        "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+        "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
+        "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "version": "{{user `goss_version`}}"

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -167,6 +167,9 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "vars_inline": {
+        "OS": "{{user `distro_name` | lower}}",
+        "ARCH": "amd64",
+        "PROVIDER": "ova",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version" : "{{user `containerd_version`}}",


### PR DESCRIPTION
### Description
#### Adds Support for amazon, ova type providers
#### Adds support for photon, amazon linux, centos and ubuntu OS
#### Fix goss k8s pkg/binary version spec
   - Pass deb and rpm version for k8s and k8s-cni to goss
   - Add regex patterns (\QTEXT\E) for whole word match with escaping
#### Make crictl goss command robust
   - crictl now uses sed to replace last token delimited by `-` in container image name instead of awk.
        The last token is fixed value provided by Variable `arch`. arch is
        fixed for entire repo and is equal to amd64.
#### Improve goss command to match k8s version
  - Use trim and awk substitute instead of splitting on `v` as `v`
      can be part of valid semver too.



### Results
Works for all three builders (OVA, AMI, Azure) and all supported OSs.
GOSS is enabled in inspection mode by default, so this PR will not fail any build.