### PR TITLE
Fix building of ami and ova for centos

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -15,6 +15,7 @@
 - name: install aws clients
   pip:
     name: "{{ packages }}"
+    executable: pip3
   vars:
     packages:
       - awscli

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -34,6 +34,7 @@
     packages:
     - cloud-init
     - cloud-utils-growpart
+    - python2-pip
   when: ansible_os_family == "RedHat"
 
 - name: Install cloud-init and tools for VMware Photon OS


### PR DESCRIPTION
  - Adds python2-pip to vmware provider ansible riole. This is needed
  for cloud-init-vmware guestinfo to work correctly.
  - AMI now uses pip3 for downloading awscli on non amazon linux

Checked ami-centos and ova-centos for building. Both work.