### PR TITLE
Fix build name for ubuntu AMI to match cluster-api-provider-aws convention

### DIFF
--- a/images/capi/packer/ami/ubuntu-1804.json
+++ b/images/capi/packer/ami/ubuntu-1804.json
@@ -1,7 +1,7 @@
 {
   "ami_filter_name": "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*",
   "ami_filter_owners": "099720109477",
-  "build_name": "ubuntu-1804",
+  "build_name": "ubuntu-18.04",
   "distribution": "Ubuntu",
   "distribution_release": "bionic",
   "distribution_version": "18.04",


### PR DESCRIPTION
/assign @codenrhoden 

This fixes an issue where the Ubuntu AMI name was no longer matching against the default cluster-api-provider-aws lookup logic.