### PR TITLE
Remove potential python2 fallbacks

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -26,19 +26,20 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if command -v ansible >/dev/null 2>&1; then exit 0; fi
 
-if ! command -v python3 >/dev/null || command -v python >/dev/null 2>&1; then
-  echo "Python 3 or Python binary must be in \$PATH" 1>&2
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 binary must be in \$PATH" 1>&2
   exit 1
 fi
-if ! command -v pip3 || command -v pip >/dev/null 2>&1; then
+if ! command -v pip3 >/dev/null 2>&1; then
   curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python get-pip.py --user
+  python3 get-pip.py --user
   rm -f get-pip.py
 fi
-pip3 install --user "ansible==${_version}" || python -m pip install --user "ansible==${_version}"
+
+pip3 install --user "ansible==${_version}"
 echo $PATH
 
 if ! command -v ansible >/dev/null 2>&1; then
-  echo "User's Python binary directory must bin in \$PATH" 1>&2
+  echo "User's Python3 binary directory must bin in \$PATH" 1>&2
   exit 1
 fi

--- a/images/capi/hack/ensure-azure-cli.sh
+++ b/images/capi/hack/ensure-azure-cli.sh
@@ -26,17 +26,20 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if command -v az >/dev/null 2>&1; then exit 0; fi
 
-if ! command -v python3 >/dev/null || command -v python >/dev/null 2>&1; then
-  echo "Python 3 or Python binary must be in \$PATH" 1>&2
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 binary must be in \$PATH" 1>&2
   exit 1
 fi
-if ! command -v pip3 >/dev/null 2>&1 || command -v pip >/dev/null 2>&1; then
+
+if ! command -v pip3 >/dev/null 2>&1; then
   curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python get-pip.py --user
+  python3 get-pip.py --user
   rm -f get-pip.py
 fi
-pip3 install --user "azure-cli==${_version}" || python -m pip install --user "azure-cli==${_version}"
-if ! command -v ansible >/dev/null 2>&1; then
-  echo "User's Python binary directory must bin in \$PATH" 1>&2
+
+pip3 install --user "azure-cli==${_version}"
+
+if ! command -v azure-cli >/dev/null 2>&1; then
+  echo "User's Python3 binary directory must bin in \$PATH" 1>&2
   exit 1
 fi


### PR DESCRIPTION
I created a PR to update cluster-api-provider-gcp to use the `deps-gce` Make target for installing dependencies, and noticed that we aren't properly handling the python2 style fallbacks properly, this removes those fallbacks and defaults to explicitly using python3/pip3 instead