### PR TITLE
Disable Hyper-V KVP daemon for Ubuntu AMI

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -27,8 +27,8 @@
     state: present
   with_items:
     - https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-  when: 
-    - ansible_os_family == "RedHat" 
+  when:
+    - ansible_os_family == "RedHat"
     - ansible_distribution != "Amazon"
 
 - name: install aws agents RPM
@@ -57,3 +57,10 @@
     state: started
     enabled: yes
   when: ansible_distribution == "Ubuntu"
+
+- name: Disable Hyper-V KVP protocol daemon on Ubuntu
+  systemd:
+    name: hv-kvp-daemon
+    state: stopped
+    enabled: false
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
So I stumbled across this today when building Ubuntu AMIs and taking a look at the console output (something I had not done before). I noticed that it was relatively slow (IMO, and compared to AL2) to be able to SSH in after the instance showed as running. Then I saw this on the console:

```
A start job is running for sys-devi…v_kvp.device (1min 29s / 1min 30s)^M
[  *** ] A start job is running for sys-devi…v_kvp.device (1min 29s / 1min 30s)^M
[ TIME ] Timed out waiting for device sys-de…rtual-misc-vmbus\x21hv_kvp.device.
[DEPEND] Dependency failed for Hyper-V KVP Protocol Daemon.
```

I've seen that before! The exact same thing was fixed for OVAs about six months ago: https://github.com/kubernetes-sigs/image-builder/commit/c06617b963c16a22d8b5fffdfa39f7dfb08223c9

Let's give everyone launching Ubuntu 18.04 AMIs ~90 seconds off their boot time.

/assign @detiber 

Time to cloud-init is finished before:
`[  108.766451] cloud-init[1272]: Cloud-init v. 20.2-45-g5f7825e2-0ubuntu1~18.04.1 running 'modules:final' at Wed, 05 Aug 2020 01:16:43 +0000. Up 108.60 seconds.`
After:
`[   23.096428] cloud-init[1129]: Cloud-init v. 20.2-45-g5f7825e2-0ubuntu1~18.04.1 running 'modules:final' at Wed, 05 Aug 2020 02:22:51 +0000. Up 22.94 seconds.`

> When launching Ubuntu 18.04 AMIs, it can be seen from the console
> output that that a kernel daemon fails on startup, with the name
> "Dependency failed for Hyper-V KVP Protocol Daemon." This adds over 90
> seconds of boot time to the instance. Since AMIs are only running on
> AWS, there is no need for a Hyper-V daemon, and it can safely be
> disabled. The same steps were taken for OVAs/ESX images months ago.