### PR TITLE
Specify AMI root volume device name for all distributions

### DIFF
--- a/images/capi/packer/ami/amazon-2.json
+++ b/images/capi/packer/ami/amazon-2.json
@@ -6,5 +6,6 @@
   "distribution_release": "Amazon Linux 2",
   "distribution_version": "2",
   "source_ami": "",
-  "ssh_username": "ec2-user"
+  "ssh_username": "ec2-user",
+  "root_device_name": "/dev/xvda"
 }

--- a/images/capi/packer/ami/centos-7.json
+++ b/images/capi/packer/ami/centos-7.json
@@ -6,5 +6,6 @@
   "distribution_release": "Core",
   "distribution_version": "7",
   "source_ami": "",
-  "ssh_username": "centos"
+  "ssh_username": "centos",
+  "root_device_name": "/dev/sda1"
 }

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -100,7 +100,7 @@
       },
       "launch_block_device_mappings": [
         {
-          "device_name": "/dev/sda1",
+          "device_name": "{{ user `root_device_name` }}",
           "volume_size": "{{ user `volume_size` }}",
           "volume_type": "gp2",
           "delete_on_termination": true

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -141,13 +141,15 @@
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
-      "tests": ["{{user `goss_tests_dir`}}"],
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "vars_inline": {
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
-        "containerd_version" : "{{user `containerd_version`}}",
+        "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
         "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
       },

--- a/images/capi/packer/ami/ubuntu-1804.json
+++ b/images/capi/packer/ami/ubuntu-1804.json
@@ -6,5 +6,6 @@
   "distribution_release": "bionic",
   "distribution_version": "18.04",
   "source_ami": "",
-  "ssh_username": "ubuntu"
+  "ssh_username": "ubuntu",
+  "root_device_name": "/dev/sda1"
 }


### PR DESCRIPTION
Amazon Linux 2 images created after #293 were non bootable on non-nvme instance types. This is because `/dev/sda1` ended up being a blank volume overriding the `/dev/xvda` root volume. This PR creates a `root_device_name` variable, which is then set for each distribution.