### PR TITLE
Increase Bandwidth for TCP to 1MB on Photon OS

### DIFF
--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -26,3 +26,12 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Ensure Bandwidth for TCP connections should 1 Mb (same as Ubuntu)
+  sysctl:
+    name: net.ipv4.tcp_limit_output_bytes
+    value: "1048576"
+    state: present
+    sysctl_set: yes
+    reload: yes
+    sysctl_file: "{{ sysctl_conf_file }}"


### PR DESCRIPTION
  - Set `net.ipv4.tcp_limit_output_bytes` to `1048576 ` 
  - Photon's default kernel value for `net.ipv4.tcp_limit_output_bytes` is 256K compared to 1MB in Ubuntu


GOSS Kernel param entry for this will be added in #307 

Run result on powered on VM
```
root [ /home/capv ]# cat /etc/os-release
  NAME="VMware Photon OS" 
  VERSION="3.0"
  ID=photon 
  VERSION_ID=3.0
  PRETTY_NAME="VMware Photon OS/Linux"
  ANSI_COLOR="1;34"
  HOME_URL="https://vmware.github.io/photon/"
  BUG_REPORT_URL="https://github.com/vmware/photon/issues"
root [ /home/capv ]# sysctl -a | grep net.ipv4.tcp_limit_output_bytes
  net.ipv4.tcp_limit_output_bytes = 1000000000
root [ /home/capv ]#
```

/assign : @codenrhoden 