### PR TITLE
Fix GOSS specs for k8s versioning

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -151,7 +151,11 @@
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
+        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
+        "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0 }}",
+        "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+        "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
+        "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "version": "{{user `goss_version`}}"

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -189,7 +189,11 @@
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version" : "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
+        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
+        "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+        "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+        "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
+        "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "version": "{{user `goss_version`}}"

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -35,17 +35,17 @@ command:
     stdout: ["coredns", "etcd", "kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler", "pause"]
 {{end}}
 {{if eq .Vars.kubernetes_source_type "http"}}
-  kubectl version --short --client=true -o json | jq .clientVersion.gitVersion | awk -F'[v"]' '{print $3}':
+  kubectl version --short --client=true -o json | jq .clientVersion.gitVersion | tr -d '"' | awk '{print substr($1,2); }':
     exit-status: 0
     stdout: [{{ .Vars.kubernetes_version }}]
     stderr: []
     timeout: 0
-  kubeadm version -o json | jq .clientVersion.gitVersion | awk -F'[v"]' '{print $3}':
+  kubeadm version -o json | jq .clientVersion.gitVersion | tr -d '"' | awk '{print substr($1,2); }':
     exit-status: 0
     stdout: [{{ .Vars.kubernetes_version }}]
     stderr: []
     timeout: 0
-  kubelet --version | awk -F'[ v]' '{print $3}':
+  kubelet --version | awk -F' ' '{print $2}'  | tr -d '"' | awk '{print substr($1,2); }':
     exit-status: 0
     stdout: [{{ .Vars.kubernetes_version }}]
     stderr: []

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -11,7 +11,7 @@ command:
     timeout: 0
 {{if eq .Vars.kubernetes_source_type "pkg"}}
 {{if eq .Vars.kubernetes_cni_source_type "pkg"}}
-  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sort:
+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
     stderr: []
     timeout: 0
@@ -20,7 +20,7 @@ command:
 {{end}}
 {{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (not .Vars.kubernetes_load_additional_imgs)}}
 # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
-  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | awk 'BEGIN{FS=OFS="-"}NF--' | sort:
+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
     stderr: []
     timeout: 0
@@ -28,7 +28,7 @@ command:
 {{end}}
 {{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (.Vars.kubernetes_load_additional_imgs)}}
 # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
-  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | awk 'BEGIN{FS=OFS="-"}NF--' | sort:
+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
     stderr: []
     timeout: 0

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -1,7 +1,18 @@
-x-function: &kubernetes_version
+kubernetes_version: &kubernetes_version
   versions:
-    contain-element:
-      match-regexp: {{ .Vars.kubernetes_version }}
+    or:
+     - contain-element:
+         match-regexp: "^\\Q{{ .Vars.kubernetes_deb_version }}\\E$"
+     - contain-element:
+         match-regexp: "^\\Q{{ .Vars.kubernetes_rpm_version }}\\E$"
+
+kubernetes_cni_version: &kubernetes_cni_version
+  versions:
+    or:
+      - contain-element:
+          match-regexp: "^\\Q{{ .Vars.kubernetes_cni_deb_version }}\\E$"
+      - contain-element:
+          match-regexp: "^\\Q{{ .Vars.kubernetes_cni_rpm_version }}\\E$"
 
 package:
   cloud-init:
@@ -20,7 +31,5 @@ package:
 {{if eq .Vars.kubernetes_cni_source_type "pkg"}}
   kubernetes-cni:
     installed: true
-    versions:
-      contain-element:
-        match-regexp: {{ .Vars.kubernetes_cni_version }}
+    <<: *kubernetes_cni_version
 {{end}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -1,8 +1,10 @@
 ---
-kubernetes_cni_version: ""
+arch: "amd64"
 containerd_version: ""
-kubernetes_version: ""
-kubernetes_source_type: ""
 kubernetes_cni_source_type: ""
+kubernetes_cni_version: ""
+kubernetes_source_type: ""
+kubernetes_version: ""
+
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -5,6 +5,9 @@ kubernetes_cni_source_type: ""
 kubernetes_cni_version: ""
 kubernetes_source_type: ""
 kubernetes_version: ""
-
+kubernetes_rpm_version: ""
+kubernetes_deb_version: ""
+kubernetes_cni_deb_version: ""
+kubernetes_cni_rpm_version: ""
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -171,7 +171,11 @@
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
         "containerd_version" : "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
+        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
+        "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+        "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+        "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
+        "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "version": "{{user `goss_version`}}"


### PR DESCRIPTION
#### Fix goss k8s pkg/binary version spec
   - Pass deb and rpm version for k8s and k8s-cni to goss
   - Add regex patterns (\QTEXT\E) for whole word match with escaping

#### Make crictl goss command robust
   - crictl now uses sed to replace last token delimited by `-` in container image name instead of awk.
        The last token is fixed value provided by Variable `arch`. arch is
        fixed for entire repo and is equal to amd64.

#### Improve goss command to match k8s version
  - Use trim and awk substitute instead of splitting on `v` as `v`
      can be part of valid semver too.
