### PR TITLE
Add notify type to containerd systemd unit file

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -44,6 +44,13 @@
     path: /etc/systemd/system/containerd.service.d
     state: directory
 
+- name: Configure containerd process start-up type to Notify
+  ini_file:
+    path: /etc/systemd/system/containerd.service
+    section: Service
+    option: Type
+    value: notify
+
 - name: Create containerd boot order drop in file
   template:
     dest: /etc/systemd/system/containerd.service.d/boot-order.conf
@@ -74,7 +81,7 @@
     name: containerd
     daemon_reload: yes
     enabled: True
-    state: started
+    state: restarted
 
 - name: delete tarball
   file:

--- a/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
+++ b/images/capi/ansible/roles/containerd/templates/etc/systemd/system/containerd.service.d/boot-order.conf
@@ -17,9 +17,4 @@
 # cloud-init boot stage managed by the cloud-final.service:
 # https://cloudinit.readthedocs.io/en/latest/topics/boot.html#final
 After=cloud-init.service
-Before=cloud-config.service
 Wants=cloud-init.service
-
-[Install]
-WantedBy=cloud-config.service
-

--- a/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-config.service.d/boot-order.conf
+++ b/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-config.service.d/boot-order.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=containerd.service
+Wants=containerd.service

--- a/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-final.service.d/boot-order.conf
+++ b/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-final.service.d/boot-order.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=containerd.service
+Wants=containerd.service

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -27,3 +27,32 @@
 
 - include_tasks: qemu.yml
   when: packer_builder_type is search('qemu')
+
+# Create a boot order configuration
+# b/w containerd and cloud final, cloud config services
+
+- name: Creates unit file directory for cloud-final
+  file:
+    path: /etc/systemd/system/cloud-final.service.d
+    state: directory
+
+- name: Create cloud-final boot order drop in file
+  copy:
+    dest: /etc/systemd/system/cloud-final.service.d/boot-order.conf
+    src: etc/systemd/system/cloud-final.service.d/boot-order.conf
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Creates unit file directory for cloud-config
+  file:
+    path: /etc/systemd/system/cloud-config.service.d
+    state: directory
+
+- name: Create cloud-final boot order drop in file
+  copy:
+    dest: /etc/systemd/system/cloud-config.service.d/boot-order.conf
+    src: etc/systemd/system/cloud-config.service.d/boot-order.conf
+    owner: root
+    group: root
+    mode: "0755"


### PR DESCRIPTION
  - Absence of **type=notify** in containerd unit file
    causes cloud-final.service trigger `kubedam init` too soon and it
    fails without detecting a container runtime on machine.
  - Adding this type=notify will enable to enforce strict boot ordering
    between cloud-final and containerd
  - Adding an `After` & `Wants` containerd systemd dependency in
  cloud-final and cloud-config boot config

Signed-off-by: Tushar Aggarwal <taggarwal@vmware.com>