### PR TITLE
Add markdown linting

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "line_length": false
+}

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,11 @@ build-book:
 .PHONY: serve-book
 serve-book: ## Build and serve the book with live-reloading enabled
 	$(MAKE) -C docs/book serve
+
+.PHONY: lint
+lint: ## Run all the lint targets
+	$(MAKE) lint-markdown
+
+.PHONY: lint-markdown
+lint-markdown: ## Lint the project's markdown
+	docker run --rm -v "$$(pwd)":/build:ro gcr.io/cluster-api-provider-vsphere/extra/mdlint:0.23.2 -- /md/lint -i images/kube-deploy .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Image Builder
 
-## Please see our [Book](https://image-builder.sigs.k8s.io) for more in-depth documentation.
+## Please see our [Book](https://image-builder.sigs.k8s.io) for more in-depth documentation
 
-## What is the Image Builder?
+## What is the Image Builder
 
 The Image Builder is a collection of cross-provider Kubernetes virtual machine image building utilities.
 
@@ -17,6 +17,7 @@ Each project is independent from each other, with the goal of eventually merging
 The `konfigadm` directory contains manifests for use with the `konfigadm CLI`.
 
 ### Useful links
+
 - [Quick Start for Cluster API Image Builder](https://image-builder.sigs.k8s.io/capi/quickstart.html)
 - [konfigadm CLI](https://github.com/flanksource/konfigadm)
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Introduction](./introduction.md)
+
 - [CAPI](./capi/capi.md)
   - [Quick Start](./capi/quickstart.md)
   - [AWS](./capi/providers/aws.md)

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -14,12 +14,12 @@ If any needed binaries are not present, they can be installed to `images/capi/.b
 
 ## Providers
 
-* [AWS](./providers/aws.md)  
-* [Azure](./providers/azure.md)
-* [DigitalOcean](./providers/digitalocean.md)
-* Google *TODO*
-* [OpenStack](./providers/openstack.md)
-* [vSphere](./providers/vsphere.md)
+- [AWS](./providers/aws.md)  
+- [Azure](./providers/azure.md)
+- [DigitalOcean](./providers/digitalocean.md)
+- Google *TODO*
+- [OpenStack](./providers/openstack.md)
+- [vSphere](./providers/vsphere.md)
 
 ## Make targets
 
@@ -98,7 +98,6 @@ A common use-case within enterprise environments is to have a package repository
 
 For example, to build an image using only an internal mirror, create a file called `internal_repos.json` and populate it with the following:
 
-
 ```json
 {
   "disable_public_repos": "true",
@@ -136,6 +135,7 @@ PACKER_VAR_FILES=proxy.json make build-node-ova-local-photon-3
 ```
 
 ## Kubernetes versions
+
 | Tested Kubernetes Versions |
 |---------|
 | `1.14.x` |

--- a/docs/book/src/capi/goss/goss.md
+++ b/docs/book/src/capi/goss/goss.md
@@ -3,24 +3,26 @@
 ## GOSS
 
 [Goss](https://github.com/aelsabbahy/goss) is a YAML based serverspec alternative
-tool for validating a server’s configuration. It is used in conjunction with 
+tool for validating a server’s configuration. It is used in conjunction with
 [packer-provisioner-goss](https://github.com/YaleUniversity/packer-provisioner-goss/releases)
 to test if the images have all requisite components to work with cluster API.
 
-### Support Matrix 
-*For stock server-specs shipped with repo
+### Support Matrix
 
-| OS | Builder | 
+Note: **for stock server-specs shipped with repo**
+
+| OS | Builder |
 |----|---------|
 | Amazon Linux | aws
 | PhotonOS | ova
 | Ubuntu | aws , ova, azure
-| CentOS | aws, ova 
-
+| CentOS | aws, ova
 
 ### Prerequisites for Running GOSS
+
 GOSS runs as a part of image building through a packer provisioner.
 Supported arguments are passed through file: `packer/config/goss-args.json`
+
 ```json
 {
   "goss_arch": "amd64",
@@ -34,16 +36,20 @@ Supported arguments are passed through file: `packer/config/goss-args.json`
   "goss_version": "0.3.13"
 }
 ```
-##### Supported values for some of the arguments can be found [here](https://github.com/aelsabbahy/goss).
+
+Supported values for some of the arguments can be found [here](https://github.com/aelsabbahy/goss)
+
 > Enabling the `goss_inspect_mode` lets you build image even if goss tests fail.
 
 #### Manually setup GOSS
+
 - Start a VM from capi image
 - Copy complete goss dir `packer/goss` to remote machine
-- Download and setup GOSS (use version from goss-args) on the remote machine. [Instructions](https://github.com/aelsabbahy/goss#latest) 
+- Download and setup GOSS (use version from goss-args) on the remote machine. [Instructions](https://github.com/aelsabbahy/goss#latest)
 - Custom goss version can be installed if testing custom server-specs supported by higher version of GOSS.
 - All the variables used in GOSS are declared in `packer/goss/goss-vars.yaml`
 - Add more custom serverspec to corresponding GOSS files. Like, `goss-command.yaml` or `goss-kernel-params.yaml`
+
     ```yaml
       some_cli --version:
         exit-status: 0
@@ -51,16 +57,22 @@ Supported arguments are passed through file: `packer/config/goss-args.json`
         stderr: []
         timeout: 0
     ```
+
 - Add more custom variables to corresponding GOSS file `goss-vars.yaml`.
+
     ```yaml
     some_cli_version: "1.4.5+k8s-1"
     ```
+
 - Fill the variable values in `goss-vars.yaml` or specify in `--vars-inline` while executing GOSS in below steps
 - Render the goss template to fix any problems with parsing variable and serverspec yamls
+
   ```bash
     sudo goss -g goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"Ubuntu","PROVIDER":"aws", some_cli_version":"1.3.4"}' render
-  ```     
+  ```
+
 - Run the GOSS tests  
+
   ```bash
     sudo goss -g goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"Ubuntu","PROVIDER":"aws", some_cli_version":"1.3.4"}' validate --retry-timeout 0s --sleep 1s -f json -o pretty
   ```

--- a/docs/book/src/capi/providers/openstack.md
+++ b/docs/book/src/capi/providers/openstack.md
@@ -17,8 +17,8 @@ This section assumes Ubuntu 18.04 LTS.
 #### Adding your user to the kvm group
 
 ```bash
-$ sudo usermod -a -G kvm <yourusername>
-$ sudo chown root:kvm /dev/kvm
+sudo usermod -a -G kvm <yourusername>
+sudo chown root:kvm /dev/kvm
 ```
 
 Then exit and log back in to make the change take place.

--- a/docs/book/src/capi/providers/vsphere.md
+++ b/docs/book/src/capi/providers/vsphere.md
@@ -6,10 +6,10 @@ The images may be built using one of the following hypervisors:
 
 | OS | Builder | Build target |
 |----|---------|--------------|
-| Linux | VMware Workstation | build-node-ova-local-<OS> |
-| macOS | VMware Fusion | build-node-ova-local-<OS> |
-| ESXi | ESXi | build-node-ova-esx-<OS> |
-| vSphere | vSphere >= 6.5 | build-node-ova-vsphere-<OS> |
+| Linux | VMware Workstation | build-node-ova-local-`<OS>` |
+| macOS | VMware Fusion | build-node-ova-local-`<OS>` |
+| ESXi | ESXi | build-node-ova-esx-`<OS>` |
+| vSphere | vSphere >= 6.5 | build-node-ova-vsphere-`<OS>` |
 
 **NOTE** If you want to build all available OS's, uses the `-all` target. If you want to build them in parallel, use `make -j`. For example, `make -j build-node-ova-local-all`.
 
@@ -20,7 +20,8 @@ The `vsphere` builder supports building against a remote VMware vSphere using st
 
 Complete the `vsphere.json` configuration file with credentials and informations specific to the remote vSphere hypervisor used to build the `ova` file.
 This file must have the following format (`cluster` can be replace by `host`):
-```
+
+```json
 {
     "vcenter_server":"FQDN of vcenter",
     "username":"vcenter_username",
@@ -58,7 +59,6 @@ In addition to the configuration found in `images/capi/packer/config`, the `ova`
 | `ubuntu-1804.json` | The settings for the Ubuntu 18.04 image |
 | `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
 | `vsphere.json` | Additional settings needed when building on a remote vSphere |
-
 
 The images are built and located in `images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION`
 

--- a/docs/book/src/glossary.md
+++ b/docs/book/src/glossary.md
@@ -2,80 +2,85 @@
 
 [A](#a) | [C](#c) | [E](#e) | [G](#g) | [K](#k) | [O](#o) | [V](#v)
 
-# A
+## A
+
 ---
 
-## AWS
+### AWS
 
 Amazon Web Services
 
-## AMI
+### AMI
 
 [Amazon Machine Image](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)
 
-# C
+## C
+
 ---
 
-## CAPA
+### CAPA
 
 [Cluster API Provider AWS](https://github.com/kubernetes-sigs/cluster-api-provider-aws)
 
-## CAPG
+### CAPG
 
 [Cluster API Provider GCP](https://github.com/kubernetes-sigs/cluster-api-provider-gcp)
 
-## CAPI
+### CAPI
 
 The Cluster API is a Kubernetes project to bring declarative, Kubernetes-style APIs to cluster creation, configuration, and management. It provides optional, additive functionality on top of core Kubernetes.
 
 [source](https://github.com/kubernetes-sigs/cluster-api)
 
-## CAPV
+### CAPV
 
 [Cluster API Provider vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)
 
-## CAPZ
+### CAPZ
 
 [Cluster API Prover Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)
 
+## E
 
-# E
 ---
 
-## ESXi
+### ESXi
 
 ESXi (formerly ESX) is an enterprise-class, type-1 hypervisor developed by VMware. ESXi provides strong separation between VMs and itself, providing strong security boundaries between the guest and host operating systems. ESXi can be used as a standalone entity, without vCenter but this is extremely uncommon and feature limited as without a higher level manager (vCenter). ESXi cannot provide its most valuable features, like High Availability, vMotion, workload balancing and vSAN (a software defined storage stack).
 
-# G
+## G
+
 ---
 
-## GOSS
+### GOSS
 
 [Goss](https://github.com/aelsabbahy/goss) is a YAML based serverspec alternative tool for validating a server’s configuration.  It is used in conjunction with [packer-provisioner-goss](https://github.com/YaleUniversity/packer-provisioner-goss/releases) to test if the images have all requisite components to work with cluster API.
 
-# K
+## K
+
 ---
 
-## K8s
+### K8s
 
 Kubernetes
 
-## Kubernetes
+### Kubernetes
 
 Kubernetes (K8s) is an open-source system for automating deployment, scaling, and management of containerized applications.
 
 [source](https://kubernetes.io)
 
-# O
+## O
+
 ---
 
-## OVA
+### OVA
 
 Open Virtual Appliance
 
 A single package containing a pre-configured virtual machine, usually based on OVF.
 
-## OVF
+### OVF
 
 Open Virtualization Format
 
@@ -83,17 +88,18 @@ An open standard for packaging and distributing virtual appliances or, more gene
 
 [source](https://en.wikipedia.org/wiki/Open_Virtualization_Format)
 
-# V
+## V
+
 ---
 
-## vCenter
+### vCenter
 
 vCenter can be thought of as the management layer for ESXi hosts. Hosts can be arranged into Datacenters, Clusters or resources pools, vCenter is the centralized monitoring and management control plane for ESXi hosts allow centralized management, integration points for other products in the VMware SDDC stack and third party solutions, like backup, DR or networking overlay applications, such as NSX. vCenter also provides all of the higher level features of vSphere such as vMotion, vSAN, HA, DRS, Distributed Switches and more.
 
-## VM
+### VM
 
 A VM is an abstraction of an operating system from the physical machine by creating a "virtual" representation of the physical hardware the OS expects to interact with, this includes but is not limited to CPU instruction sets, memory, BIOS, PCI buses, etc. A VM is an entirely self-contained entity and shares no components with the host OS. In the case of vSphere the host OS is ESXi (see below).
 
-## vSphere
+### vSphere
 
 vSphere is the product name of the two core components of the VMware Software Defined Datacenter (SDDC) stack, they are vCenter and ESXi.

--- a/images/capi/README.md
+++ b/images/capi/README.md
@@ -2,4 +2,4 @@
 
 The Image Builder can be used to build images intended for use with Kubernetes [CAPI](https://cluster-api.sigs.k8s.io/) providers. Each provider has its own format of images that it can work with. For example, AWS instances use AMIs, and vSphere uses OVAs.
 
-For detailed documentation, see https://image-builder.sigs.k8s.io/capi/capi.html.
+For detailed documentation, see <https://image-builder.sigs.k8s.io/capi/capi.html>.

--- a/images/konfigadm/README.md
+++ b/images/konfigadm/README.md
@@ -29,7 +29,7 @@ konfigadm images upload ova --image ubuntu1804.img
 
 ## Testing images
 
-```
+```sh
 make setup
 make ubuntu1804
 ```

--- a/v1/README.md
+++ b/v1/README.md
@@ -1,7 +1,6 @@
 # image-builder CLI
 
-
-### Engines
+## Engines
 
 `image-builder` supports 3 engines for configuring images:
 
@@ -13,6 +12,7 @@
 Engines are specified and configured using the `engine` section:
 
 `packer.yaml`
+
 ```yaml
 engine:
   kind: packer
@@ -25,7 +25,7 @@ engine:
       secret_key: !!env AWS_SECRET_ACCESS_KEY
 ```
 
-### YAML Templating
+## YAML Templating
 
 `image-builder` configs can used the `!!env` and `!!template` YAML directives to replace values inline while still maintaining
 YAML compatibility.
@@ -34,7 +34,8 @@ The `!!env` directive replaces the KEY with the environment variable.
 
 The `!!template` directive templates out the value using Golang text templates combined with all the functions from the [gomplate](https://docs.gomplate.ca/) library
 
-### OS / Image Combinations
+## OS / Image Combinations
+
 To list the supported OS / Image combinations run `image-builder images`:
 The current supported combinations are:
 
@@ -47,8 +48,7 @@ debian9        debian                                                           
 ubuntu1804     ubuntu        Ubuntu         bionic           18.04     ✓     ✓            ✓       ✓        ✓
 ```
 
-
-### Configuring an image with Kubernetes
+## Configuring an image with Kubernetes
 
 ```yaml
 distroName: ubuntu1804
@@ -65,8 +65,7 @@ container_runtime:
 
 This will build an image using QEMU.
 
-
-### Customizing an image
+## Customizing an image
 
 Arbitrary konfigadm specs can be combined to further customize an image:
 
@@ -81,7 +80,7 @@ commands:
 
 ```
 
-### Transformations / Conversions
+## Transformations / Conversions
 
 `image-builder` can be used to apply arbitrary transformations to images, e.g. to convert a *qcow2* or *raw* disk image to an *ova* run
 
@@ -90,6 +89,7 @@ image-builder build -c image.yaml`
 ```
 
 `image.yaml`
+
 ```yaml
 input:
   kind: img


### PR DESCRIPTION
This patch updates the markdown files to be compliant with
markdownlint-cli, and adds a Makefile target to make it easy to run via
Docker.

This particular container image (`gcr.io/cluster-api-provider-vsphere/extra/mdlint`) is in use with a few projects for Prow CI jobs, and once this PR is merged, a presubmit job can be added to run this check!

/assign @detiber 
/assign @CecileRobertMichon 