### PR TITLE
Fix ensure Py3, Pip3, and azure-cli

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -18,6 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source hack/utils.sh
+
 _version="2.8.0"
 
 # Change directories to the parent directory of the one in which this
@@ -26,20 +28,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if command -v ansible >/dev/null 2>&1; then exit 0; fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 binary must be in \$PATH" 1>&2
-  exit 1
-fi
-if ! command -v pip3 >/dev/null 2>&1; then
-  curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python3 get-pip.py --user
-  rm -f get-pip.py
-fi
-
+ensure_py3
 pip3 install --user "ansible==${_version}"
-echo $PATH
-
-if ! command -v ansible >/dev/null 2>&1; then
-  echo "User's Python3 binary directory must bin in \$PATH" 1>&2
-  exit 1
-fi
+ensure_py3_bin ansible

--- a/images/capi/hack/ensure-azure-cli.sh
+++ b/images/capi/hack/ensure-azure-cli.sh
@@ -18,6 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source hack/utils.sh
+
 _version="2.9.0"
 
 # Change directories to the parent directory of the one in which this
@@ -26,20 +28,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if command -v az >/dev/null 2>&1; then exit 0; fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 binary must be in \$PATH" 1>&2
-  exit 1
-fi
-
-if ! command -v pip3 >/dev/null 2>&1; then
-  curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-  python3 get-pip.py --user
-  rm -f get-pip.py
-fi
-
+ensure_py3
 pip3 install --user "azure-cli==${_version}"
-
-if ! command -v azure-cli >/dev/null 2>&1; then
-  echo "User's Python3 binary directory must bin in \$PATH" 1>&2
-  exit 1
-fi
+ensure_py3_bin az

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -67,3 +67,28 @@ get_shasum() {
   fi
   echo "$present_shasum"
 }
+
+ensure_py3_bin() {
+  # If given executable is not available, the user Python bin dir is not in path
+  # This function assumes the executable to be checked was installed with
+  # pip3 install --user ...
+  if ! command -v "${1}" >/dev/null 2>&1; then
+    echo "User's Python3 binary directory must be in \$PATH" 1>&2
+    echo "This is likely \$HOME/.local/bin" 1>&2
+    echo "\$PATH is currently: $PATH" 1>&2
+    exit 1
+  fi
+}
+
+ensure_py3() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 binary must be in \$PATH" 1>&2
+    exit 1
+  fi
+  if ! command -v pip3 >/dev/null 2>&1; then
+    curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    python3 get-pip.py --user
+    rm -f get-pip.py
+    ensure_py3_bin pip3
+  fi
+}


### PR DESCRIPTION
This patch de-dups logic for making sure that Python3 and pip3 are
installed. It also corrects a corner case where pip3 could be installed
to the user local Python bin dir but that dir was not in path.

And finally, for checking that azure-cli was installed (which goes to
the user local Python bin dir), the wrong command name was used. It was
looking for `azure-cli` when it should look for `az`.

/assign @CecileRobertMichon 
@CecileRobertMichon I started looking at the container image from a CI perspective tonight, and immediately ran into this. I think this will solve your issues with running from Prow and it complaining about Python3. That is not the issue, it was that we were looking for `azure-cli` instead of `az`! 😆 