### PR TITLE
bump default K8s to 1.16.14

### DIFF
--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
   "kubernetes_series": "v1.16",
-  "kubernetes_semver": "v1.16.11",
-  "kubernetes_rpm_version": "1.16.11-1",
-  "kubernetes_deb_version": "1.16.11-01",
+  "kubernetes_semver": "v1.16.14",
+  "kubernetes_rpm_version": "1.16.14-0",
+  "kubernetes_deb_version": "1.16.14-00",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",


### PR DESCRIPTION
This change sets the default Kubernetes version to the latest patch of n-2.

I think this is also helpful to move away from 1.16.11, since 1.16.11 had a packaging revision (`-1` instead of `-0`) which has historically been rare for the project. I've seen a couple of users lately try to modify the K8s version, and leave the `-1` in place resulting in build failures.

/assign @detiber @CecileRobertMichon 