### PR TITLE
Add extra_rpms back for Azure

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -17,6 +17,7 @@
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "extra_debs": "",
     "extra_repos": "",
+    "extra_rpms": "",
     "image_offer": null,
     "image_publisher": null,
     "image_sku": null,


### PR DESCRIPTION
During a recent clean-up, this required var got removed.

Without this change, Azure builds will fail with:

```
Error initializing core: Failed to interpolate "ansible_common_vars": "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} containerd_pause_image={{user `containerd_pause_image`}} containerd_additional_settings={{user `containerd_additional_settings`}} custom_role={{user `custom_role`}} custom_role_name={{user `custom_role_name`}} disable_public_repos={{user `disable_public_repos`}} extra_debs={{user `extra_debs`}} extra_repos={{user `extra_repos`}} extra_rpms={{user `extra_rpms`}} http_proxy={{user `http_proxy`}} https_proxy={{user `https_proxy`}} kubeadm_template={{user `kubeadm_template`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_cni_http_checksum={{user `kubernetes_cni_http_checksum`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_load_additional_imgs={{user `kubernetes_load_additional_imgs`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} no_proxy={{user `no_proxy`}} redhat_epel_rpm={{user `redhat_epel_rpm`}} reenable_public_repos={{user `reenable_public_repos`}} remove_extra_repos={{user `remove_extra_repos`}} "; error: template: root:1:432: executing "root" at <user `extra_rpms`>: error calling user: Error: variable not set: extra_rpms: Please make sure that the variable you're referencing has been defined; Packer treats all variables used to interpolate other user varaibles as required.
```

/cc @dvonthenen 