### PR TITLE
Change default ova vmx_version from 13 to 15

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -42,7 +42,7 @@ def main():
     image_type.add_argument('--haproxy', action='store_true')
     parser.add_argument('--vmx',
                         dest='vmx_version',
-                        default='13',
+                        default='15',
                         help='The virtual hardware version')
     parser.add_argument('--eula_file',
                         nargs='?',

--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -27,7 +27,7 @@
   "ssh_username": "builder",
   "ssh_password": "builder",
   "ssh_timeout": "60m",
-  "vmx_version": "13",
+  "vmx_version": "15",
   "vnc_bind_address": "127.0.0.1",
   "vnc_disable_password": "false",
   "vnc_port_min": "5900",


### PR DESCRIPTION
Change default hardware version for TKG OVAs since CAPV deploys CNS and CNS requires VSphere 6.7u3