### PR TITLE
capi: suppress warnings on creating files without mode

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -28,6 +28,7 @@
     url: "{{ containerd_url }}"
     checksum: "sha256:{{ containerd_sha256 }}"
     dest: /tmp/containerd.tar.gz
+    mode: 0600
 
 # TODO(vincepri): This unpacks the entire tar in the root directory
 # we should find a better way to check what's being unpacked and where.
@@ -50,21 +51,25 @@
     section: Service
     option: Type
     value: notify
+    mode: 0644
 
 - name: Create containerd boot order drop in file
   template:
     dest: /etc/systemd/system/containerd.service.d/boot-order.conf
     src: etc/systemd/system/containerd.service.d/boot-order.conf
+    mode: 0644
 
 - name: Create containerd memory pressure drop in file
   template:
     dest: /etc/systemd/system/containerd.service.d/memory-pressure.conf
     src: etc/systemd/system/containerd.service.d/memory-pressure.conf
+    mode: 0644
 
 - name: Create containerd max tasks drop in file
   template:
     dest: /etc/systemd/system/containerd.service.d/max-tasks.conf
     src: etc/systemd/system/containerd.service.d/max-tasks.conf
+    mode: 0644
 
 - name: Creates containerd config directory
   file:
@@ -75,6 +80,7 @@
   template:
     dest: /etc/containerd/config.toml
     src: etc/containerd/config.toml
+    mode: 0644
 
 - name: start containerd service
   systemd:

--- a/images/capi/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/debian.yml
@@ -22,6 +22,7 @@
     repo: "{{ 'deb ' ~ kubernetes_deb_repo ~ ' main' }}"
     update_cache: True
     state: present
+    mode: 0644
 
 - name: Install Kubernetes
   apt:

--- a/images/capi/ansible/roles/kubernetes/tasks/ecrpull.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/ecrpull.yml
@@ -3,6 +3,7 @@
   template:
     dest: /etc/kubeadm.yml
     src: etc/kubeadm.yml
+    mode: 0600
 
 - name: Get images list
   shell: 'kubeadm config images list --config /etc/kubeadm.yml'

--- a/images/capi/ansible/roles/kubernetes/tasks/kubeadmpull.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/kubeadmpull.yml
@@ -2,6 +2,7 @@
   template:
     dest: /etc/kubeadm.yml
     src: "{{ kubeadm_template }}"
+    mode: 0600
 
 - name: Kubeadm pull images
   shell: 'kubeadm config images pull --config /etc/kubeadm.yml'

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -33,6 +33,7 @@
   template:
     dest: /etc/kubernetes-version
     src: etc/kubernetes-version
+    mode: 0644
 
 # TODO: This section will be deprecated once https://github.com/containerd/cri/issues/1131 is fixed. It is used to support ECR with containerd.
 - name: Check if Kubernetes container registry is using Amazon ECR

--- a/images/capi/ansible/roles/kubernetes/tasks/photon.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/photon.yml
@@ -16,6 +16,7 @@
   template:
     dest: /etc/yum.repos.d/kubernetes.repo
     src: etc/yum.repos.d/kubernetes.repo
+    mode: 0644
 
 - name: Install Kubernetes
   command: tdnf install {{ packages }} --nogpgcheck -y

--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -16,6 +16,7 @@
   file:
     src:   "/usr/local/bin/{{ item }}"
     dest:  "/usr/bin/{{ item }}"
+    mode: 0777
     state: link
     force: yes
   loop:
@@ -72,6 +73,7 @@
     #             checksum file format
     #checksum: "sha1:{{ kubernetes_http_source }}/bin/linux/amd64/{{ item }}.sha1"
     dest: "/tmp/{{ item }}"
+    mode: 0600
   loop: "{{ kubernetes_imgs }}"
 
 - name: Load Kubernetes images

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -34,6 +34,7 @@
       overlay
       br_netfilter
     dest: /etc/modules-load.d/kubernetes.conf
+    mode: 0644
 
 - name: Ensure net.ipv4.ip_forward sysctl is present
   sysctl:

--- a/images/capi/ansible/roles/providers/tasks/googlecompute.yml
+++ b/images/capi/ansible/roles/providers/tasks/googlecompute.yml
@@ -16,6 +16,7 @@
   get_url:
     url:  https://sdk.cloud.google.com/
     dest: /tmp/install-gcloud.sh
+    mode: 0700
 
 - name: Execute install-gcloud.sh
   shell: bash -o errexit -o pipefail /tmp/install-gcloud.sh --disable-prompts --install-dir=/

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -46,6 +46,7 @@
   file:
     src:   /usr/libexec/cloud-init
     dest:  /usr/lib/cloud-init
+    mode: 0777
     state: link
   when: ansible_os_family == "RedHat"
 

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -47,6 +47,7 @@
   get_url:
     url:  '{{ guestinfo_datasource_script }}'
     dest: /tmp/cloud-init-vmware.sh
+    mode: 0700
 
 - name: Execute cloud-init-vmware.sh
   shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh

--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -16,6 +16,7 @@
   template:
     src: etc/apt/sources.list.j2
     dest: /etc/apt/sources.list
+    mode: 0644
 
 - name: Find existing repo files
   find:
@@ -36,6 +37,7 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/apt/sources.list.d/{{ item | basename }}"
+    mode: 0644
   loop: "{{ extra_repos.split() }}"
   when: extra_repos != ""
 

--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -16,6 +16,7 @@
   template:
     dest: /home/builder/.bash_profile
     src: photon_bash_profile
+    mode: 0600
     owner: builder
     group: builder
 

--- a/images/capi/ansible/roles/setup/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/setup/tasks/rpm_repos.yml
@@ -29,5 +29,6 @@
   copy:
     src: "{{ item }}"
     dest: "/etc/yum.repos.d/{{ item | basename }}"
+    mode: 0644
   loop: "{{ extra_repos.split() }}"
   when: extra_repos != ""


### PR DESCRIPTION
Since Ansible 2.9.12 or 2.8.14, Ansible shows the following warning, when a file gets created with `mode` not being specified in the config.

```
[WARNING]: File '/tmp/kube-apiserver.tar' created with default permissions
'600'. The previous default was '666'. Specify 'mode' to avoid this warning.
```

To get rid of such a warning, specify `mode` to 0600 when creating files, as much as possible.

See also https://github.com/ansible/ansible/issues/71200 .