### PR TITLE
photon: Break out reboot into separate shell provisioner step.

### DIFF
--- a/images/capi/ansible/firstboot.yml
+++ b/images/capi/ansible/firstboot.yml
@@ -1,0 +1,25 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- hosts: all
+  become: yes
+
+  tasks:
+    - include_role:
+        name: firstboot
+
+  environment:
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"

--- a/images/capi/ansible/roles/firstboot/README.md
+++ b/images/capi/ansible/roles/firstboot/README.md
@@ -1,0 +1,2 @@
+This role is to be used for operating systems that require some operations
+that require a reboot.

--- a/images/capi/ansible/roles/firstboot/tasks/main.yaml
+++ b/images/capi/ansible/roles/firstboot/tasks/main.yaml
@@ -1,0 +1,16 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include_tasks: photon.yml
+  when: ansible_os_family == "VMware Photon OS"

--- a/images/capi/ansible/roles/firstboot/tasks/photon.yml
+++ b/images/capi/ansible/roles/firstboot/tasks/photon.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,28 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
-- name: add bash_profile
-  template:
-    dest: /home/builder/.bash_profile
-    src: photon_bash_profile
-    owner: builder
-    group: builder
-
-- import_tasks: rpm_repos.yml
 
 - name: Perform a tdnf distro-sync
   command: tdnf distro-sync -y --refresh
   register: distro
   changed_when: '"Nothing to do" not in distro.stderr'
-
-- name: Concatenate the Photon RPMs
-  set_fact:
-    photon_rpms: "{{ rpms | join(' ') }}"
-
-- name: install baseline dependencies
-  command: tdnf install {{ photon_rpms }} -y
-
-- name: install extra RPMs
-  command: tdnf install {{ extra_rpms }} -y
-  when: extra_rpms != ""

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -83,58 +83,49 @@
     {
       "type": "vsphere-iso",
       "name": "vsphere",
-
-      "vcenter_server":      "{{user `vcenter_server`}}",
-      "username":            "{{user `username`}}",
-      "password":            "{{user `password`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "username": "{{user `username`}}",
+      "password": "{{user `password`}}",
       "insecure_connection": "{{user `insecure_connection`}}",
-
       "vm_name": "{{user `build_version`}}",
       "datastore": "{{user `datastore`}}",
       "datacenter": "{{user `datacenter`}}",
       "folder": "{{user `folder`}}",
-      "host":     "{{user `host`}}",
+      "host": "{{user `host`}}",
       "convert_to_template": "{{user `convert_to_template`}}",
       "cluster": "{{user `cluster`}}",
-
       "network_adapters": [
         {
           "network": "{{user `network`}}",
           "network_card": "{{user `network_card`}}"
         }
       ],
-
       "vm_version": "{{user `vmx_version`}}",
       "CPUs": 1,
       "cpu_cores": 1,
       "RAM": 2048,
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
-
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "iso_urls": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
-
       "communicator": "ssh",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
-
       "storage": [
         {
           "disk_size": 20480,
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
-
       "boot_command": [
         "{{user `boot_command_prefix`}}",
         "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
-
       "export": {
         "force": true,
         "output_directory": "{{user `output_dir`}}"
@@ -156,14 +147,17 @@
         "--extra-vars",
         "{{user `ansible_extra_vars`}}"
       ]
-   },{
+    },
+    {
       "type": "goss",
       "arch": "{{user `goss_arch`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
-      "tests": ["{{user `goss_tests_dir`}}"],
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "vars_inline": {
@@ -172,7 +166,7 @@
         "PROVIDER": "ova",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
-        "containerd_version" : "{{user `containerd_version`}}",
+        "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
         "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
         "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -135,6 +135,32 @@
   "provisioners": [
     {
       "type": "ansible",
+      "playbook_file": "./ansible/firstboot.yml",
+      "user": "{{user `ssh_username`}}",
+      "ansible_env_vars": [
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
+        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "{{user `ansible_common_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_extra_vars`}}"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "inline": [
+        "if [ $BUILD_NAME != \"photon-3\" ]; then exit 0; fi",
+        "sudo reboot now"
+      ],
+      "expect_disconnect": true
+    },
+    {
+      "type": "ansible",
       "playbook_file": "./ansible/node.yml",
       "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [


### PR DESCRIPTION
When using Packer, Ansible roles should not include the reboot command.
This is because Packer controls the SSH connection, and has no indication
that the machine will be rebooted - the SSH connection is reset and no
attempt to reconnect is made, causing Packer to hang.
This can be obviated with some timing-dependent hacks (which will work with
varying levels of success across different infrastructures), but
here instead, we create a specific firstboot playbook, and insert a
shell provisioner step to reboot the machine using the "expect_disconnect"
flag to inform Packer that the machine will disconnect and it can move
on to the next provisioner.
