### PR TITLE
Fix call to sha256sum on Linux

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -60,7 +60,7 @@ get_shasum() {
   if command -v shasum >/dev/null 2>&1; then
     present_shasum=$(shasum -a 256 "${1}"| awk -F' ' '{print $1}')
   elif command -v sha256sum >/dev/null 2>&1; then
-    present_shasum=$(sha256sum -c "${1}" | awk -F' ' '{print $1}')
+    present_shasum=$(sha256sum "${1}" | awk -F' ' '{print $1}')
   else
     echo "missing shasum tool" 1>&2
     return 1


### PR DESCRIPTION
In utils.sh:get_shasum(), the call used on Linux (vs MacOS) was using
the `-c` flag, which is supposed to check the sum against that found in
a file, but this function is intended to calculate the sum and return
it. Fix the function by removing `-c`.

This fixes errors seen like the following:

```
hack/ensure-goss.sh
sha256sum: /home/trhoden/.packer.d/plugins/packer-provisioner-goss: no properly formatted SHA256 checksum lines found
```

This was causing the checksum to always mismatch on Linux, and for GOSS to always be (re-)downloaded, even when it wasn't necessary.

/assign @EleanorRigby 