### PR TITLE
Disable conntrackd service to reduce CPU utilization

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -31,7 +31,6 @@ common_rpms:
 common_debs:
 - apt-transport-https
 - conntrack
-- conntrackd
 - curl
 - ebtables
 - jq

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -88,3 +88,10 @@
 - name: Edit fstab file to disable swap
   shell: sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
   when: ansible_memory_mb.swap.total != 0
+
+- name: Disable conntrackd service
+  systemd:
+    name: conntrackd
+    state: stopped
+    enabled: false
+  when: ansible_os_family != "Debian"

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -8,6 +8,9 @@ service:
   kubelet:
     enabled: true
     running: false
+  conntrackd:
+    enabled: false
+    running: false
 {{range $name, $vers := index .Vars .Vars.OS "common-service"}}
   {{ $name }}:
   {{range $key, $val := $vers}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -15,7 +15,6 @@ common_rpms: &common_rpms
 common_debs: &common_debs
   apt-transport-https:
   conntrack:
-  conntrackd:
   curl:
   ebtables:
   jq:


### PR DESCRIPTION
`conntrackd` service is enabled by default as a part of `conntrack-tools` package in Photon OS. This service creates short TCP connections accessing random K8s Services. The CPU utilization goes up especially in case of large number of workload clusters. 
Primary investigation suggests that `conntrackd` isn't used by Kubernetes anywhere and can be disabled to avoid high CPU utilization.