### PR TITLE
Fix Azure CentOS build

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -37,7 +37,6 @@
     "kubernetes_semver": null,
     "kubernetes_source_type": null,
     "manifest_output": "manifest.json",
-    "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
     "skip_profile_validation": "false",
     "snapshot_groups": "all",
     "snapshot_users": "",

--- a/images/capi/packer/azure/scripts/ci-azure-e2e.sh
+++ b/images/capi/packer/azure/scripts/ci-azure-e2e.sh
@@ -58,7 +58,4 @@ cleanup() {
 trap cleanup EXIT
 
 make deps-azure
-# TODO: fix the centos build and enable
-#make -j build-azure-all
-make build-azure-vhd-ubuntu-1804
-
+make -j build-azure-all

--- a/images/capi/packer/config/common.json
+++ b/images/capi/packer/config/common.json
@@ -6,6 +6,7 @@
   "http_proxy": "",
   "https_proxy": "",
   "no_proxy": "",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
   "reenable_public_repos": "true",
   "remove_extra_repos": "false"
 }

--- a/images/capi/packer/ova/centos-7.json
+++ b/images/capi/packer/ova/centos-7.json
@@ -1,7 +1,6 @@
 {
   "build_name": "centos-7",
   "distro_name": "centos",
-  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
   "os_display_name": "CentOS 7",
   "guest_os_type": "centos7-64",
   "vsphere_guest_os_type": "centos7_64Guest",


### PR DESCRIPTION
The Azure builder was not defining redhat_epel_rpm, which is why CentOS
builds were failing on package 'jq'. This moves that definition to a
common location and makes sure it is defined for all.

This also makes it such that Azure CI E2E script can test both Ubuntu
and CentOS.