### PR TITLE
Fix Azure build VHD pipeline to use manifest output

### DIFF
--- a/images/capi/packer/azure/.pipelines/build-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/build-vhd.yaml
@@ -42,28 +42,29 @@ jobs:
     displayName: Building VHD
     workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
   - script: |
-      RESOURCE_GROUP_NAME="$(cat packer.out | grep "resource group name:" | cut -d " " -f 4)"
-      STORAGE_ACCOUNT_NAME=$(cat packer.out | grep "storage name:" | cut -d " " -f 3)
-      OS_DISK_URI=$(cat packer.out | grep "OSDiskUri:" | cut -d " " -f 2)
-      printf "${OS_DISK_URI}?" | tee vhd-url.out
+      set -o pipefail
+      RESOURCE_GROUP_NAME=$(jq -r '.builds[-1].custom_data.resource_group_name' manifest.json | cut -d ":" -f2)
+      STORAGE_ACCOUNT_NAME=$(jq -r '.builds[-1].custom_data.storage_account_name' manifest.json | cut -d ":" -f2)
+      OS_DISK_URI=$(cat packer/azure/packer.out | grep "OSDiskUri:" | cut -d " " -f 2)
+      printf "${OS_DISK_URI}?" | tee packer/azure/vhd-url.out
       az login --service-principal -u $(AZURE_CLIENT_ID) -p $(AZURE_CLIENT_SECRET) --tenant ${AZURE_TENANT_ID}
       az account set -s ${AZURE_SUBSCRIPTION_ID}
       ACCOUNT_KEY=$(az storage account keys list -g ${RESOURCE_GROUP_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --account-name ${STORAGE_ACCOUNT_NAME} --query '[0].value')
       start_date=$(date +"%Y-%m-%dT00:00Z" -d "-1 day")
       expiry_date=$(date +"%Y-%m-%dT00:00Z" -d "+1 year")
-      az storage container generate-sas --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start $start_date --expiry $expiry_date | tr -d '\"' | tee -a vhd-url.out
+      az storage container generate-sas --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start $start_date --expiry $expiry_date | tr -d '\"' | tee -a packer/azure/vhd-url.out
     displayName: Getting OS VHD URL
-    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/azure'
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
     condition: eq(variables.CLEANUP, 'False')
   - script: |
-      VHD_URL="$(cat vhd-url.out)"
-      cat <<EOF > vhd-publishing-info.json
+      VHD_URL="$(cat packer/azure/vhd-url.out)"
+      cat <<EOF > packer/azure/vhd-publishing-info.json
       {
           "vhd_url" : "$VHD_URL"
       }
       EOF
     displayName: Generating publishing info for VHD
-    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/azure'
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
     condition: eq(variables.CLEANUP, 'False')
   - task: PublishPipelineArtifact@1
     inputs:
@@ -71,13 +72,14 @@ jobs:
       path: '$(system.defaultWorkingDirectory)/images/capi/packer/azure/vhd-publishing-info.json'
     condition: eq(variables.CLEANUP, 'False')
   - script: |
-      RESOURCE_GROUP_NAME="$(cat packer.out | grep "resource group name:" | cut -d " " -f 4)"
-      STORAGE_ACCOUNT_NAME="$(cat packer.out | grep "storage name:" | cut -d " " -f 3)"
+      set -o pipefail
+      RESOURCE_GROUP_NAME=$(jq -r '.builds[-1].resource_group_name' manifest.json | cut -d ":" -f2)
+      STORAGE_ACCOUNT_NAME=$(jq -r '.builds[-1].storage_account_name' manifest.json | cut -d ":" -f2)
       az login --service-principal -u $(AZURE_CLIENT_ID) -p $(AZURE_CLIENT_SECRET) --tenant ${AZURE_TENANT_ID}
       az account set -s ${AZURE_SUBSCRIPTION_ID}
       az storage account delete -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} --yes
     displayName: cleanup - delete storage account
-    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi/packer/azure'
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
     condition: eq(variables.CLEANUP, 'True')
   - script: |
       chown -R $USER:$USER .

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -170,7 +170,7 @@
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "os_name": "{{user `distro_name`}}",
         "resource_group_name": "{{user `resource_group_name`}}",
-        "storage_account": "{{user `storage_account_name`}}"
+        "storage_account_name": "{{user `storage_account_name`}}"
       }
     }
   ]


### PR DESCRIPTION
Fixed the Azure DevOps pipeline to use the right storage account and resource group name outputs from the manifest.json packer output.

I accidentally broke it when removing echo statements in https://github.com/kubernetes-sigs/image-builder/commit/2ef06323f20bde597cd13ef7000c9b196e468b62#diff-765a596ea414b4b5e20a054a79d47439L12. This uses the manifest output instead which is more reliable from parsing an output log.