### PR TITLE
capi: update ansible version to 2.10

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -8,7 +8,7 @@ The Image Builder can be used to build images intended for use with Kubernetes [
 
 - [Packer](https://www.packer.io/intro/getting-started/install.html) version >= 1.6.0
 - [Goss plugin for Packer](https://github.com/YaleUniversity/packer-provisioner-goss) version >= 1.2.0
-- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.8.0
+- [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.10.0
 
 If any needed binaries are not present, they can be installed to `images/capi/.bin` with the `make deps` command. This directory will need to be added to your `$PATH`.
 

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.8.0"
+_version="2.10.0"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
`ensure-ansible.sh` needs to install the latest Ansible version 2.10, to make Flatcar supports as simple as possible.

Also update documents to recommend 2.10.