### PR TITLE
CAPI: Update default k8s version to 1.17.11

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -134,11 +134,3 @@ Then, execute the build (using a Photon OVA as an example) with the following:
 ```sh
 PACKER_VAR_FILES=proxy.json make build-node-ova-local-photon-3
 ```
-
-## Kubernetes versions
-| Tested Kubernetes Versions |
-|---------|
-| `1.14.x` |
-| `1.15.x` |
-| `1.16.x` |
-| `1.17.x` |

--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
-  "kubernetes_series": "v1.16",
-  "kubernetes_semver": "v1.16.14",
-  "kubernetes_rpm_version": "1.16.14-0",
-  "kubernetes_deb_version": "1.16.14-00",
+  "kubernetes_series": "v1.17",
+  "kubernetes_semver": "v1.17.11",
+  "kubernetes_rpm_version": "1.17.11-0",
+  "kubernetes_deb_version": "1.17.11-00",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",


### PR DESCRIPTION
Now that 1.19.0 (and .1) has been released, updating the default k8s version to the latest 1.17 patch to stay at N-2.