### PR TITLE
Allows providing a path to the hack directory for vSphere Node Builder

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -33,7 +33,8 @@
     "kubernetes_container_registry": null,
     "output_dir": "./output/{{user `build_version`}}",
     "username": "",
-    "vcenter_server": ""
+    "vcenter_server": "",
+    "hack_directory": "../../hack"
   },
   "builders": [
     {
@@ -212,7 +213,7 @@
         "cd {{user `output_dir`}}",
         "tar xf {{user `build_version`}}.ova",
         "rm {{user `build_version`}}.ova",
-        "../../hack/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk1.vmdk"
+        "{{user `hack_directory`}}/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula {{user `hack_directory`}}/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk1.vmdk"
       ]
     },
     {
@@ -220,7 +221,7 @@
       "type": "shell-local",
       "inline": [
         "cd {{user `output_dir`}}",
-        "../../hack/image-build-ova.py --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk-0.vmdk"
+        "{{user `hack_directory`}}/image-build-ova.py --node --vmx {{user `vmx_version`}} --eula {{user `hack_directory`}}/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk-0.vmdk"
       ]
     },
     {


### PR DESCRIPTION
This supports the use case with later versions of ansible that is executing the post shell scripts from the `/tmp` directory and not the current location, since the hacking scripts are references as relative, the `../../hack` location would go nowhere as a result.

You would need to provide an absolute path like if you're running from the container:

```
    "hack_directory": "/home/imagebuilder/hack"
```