### PR TITLE
:bug: Forces python3 for ova script post processor

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Copyright 2019 The Kubernetes Authors.
 #


### PR DESCRIPTION
The container for image builder is using a later version of Ubuntu that explicitly removes the `python` binary to enforce only supporting Python 3.x, this moves the script to likewise explicitly leverage `python3` so that it can work inside a containerized environment.

/bug
/assign @EleanorRigby 