### PR TITLE
Update containerd to 1.4.0

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -134,11 +134,3 @@ Then, execute the build (using a Photon OVA as an example) with the following:
 ```sh
 PACKER_VAR_FILES=proxy.json make build-node-ova-local-photon-3
 ```
-
-## Kubernetes versions
-| Tested Kubernetes Versions |
-|---------|
-| `1.14.x` |
-| `1.15.x` |
-| `1.16.x` |
-| `1.17.x` |

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -40,18 +40,22 @@
     extra_opts:
       - --no-overwrite-dir
 
+# Remove /opt/cni directory, as we will install cni later
+- name: delete /opt/cni directory
+  file:
+    path: /opt/cni
+    state: absent
+
+# Remove /etc/cni directory, as we will configure cni later
+- name: delete /etc/cni directory
+  file:
+    path: /etc/cni
+    state: absent
+
 - name: Creates unit file directory
   file:
     path: /etc/systemd/system/containerd.service.d
     state: directory
-
-- name: Configure containerd process start-up type to Notify
-  ini_file:
-    path: /etc/systemd/system/containerd.service
-    section: Service
-    option: Type
-    value: notify
-    mode: 0644
 
 - name: Create containerd boot order drop in file
   template:

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -12,7 +12,7 @@
     "aws_secret_key": "",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "build_timestamp": "{{timestamp}}",
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",

--- a/images/capi/packer/azure/.pipelines/stages.yaml
+++ b/images/capi/packer/azure/.pipelines/stages.yaml
@@ -27,8 +27,7 @@ stages:
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID_VHD)
 
   - stage: sku
-    dependsOn: vhd
-    condition: eq(variables.CLEANUP, 'False')
+    condition: and(succeeded(), eq(variables.CLEANUP, 'False'))
     jobs:
     - template: create-sku.yaml
     variables:

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -9,7 +9,7 @@
     "client_secret": null,
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "distribution": null,
     "distribution_release": null,
     "distribution_version": null,

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.3.4",
-    "containerd_sha256": "4616971c3ad21c24f2f2320fa1c085577a91032a068dd56a41c7c4b71a458087",
+    "containerd_version": "1.4.0",
+    "containerd_sha256": "b379f29417efd583f77e095173d4d0bd6bb001f0081b2a63d152ee7aef653ce1",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null
 }

--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
-  "kubernetes_series": "v1.16",
-  "kubernetes_semver": "v1.16.14",
-  "kubernetes_rpm_version": "1.16.14-0",
-  "kubernetes_deb_version": "1.16.14-00",
+  "kubernetes_series": "v1.17",
+  "kubernetes_semver": "v1.17.11",
+  "kubernetes_rpm_version": "1.17.11-0",
+  "kubernetes_deb_version": "1.17.11-00",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",

--- a/images/capi/packer/digitalocean/packer.json
+++ b/images/capi/packer/digitalocean/packer.json
@@ -9,7 +9,7 @@
     "image_name": "cluster-api-ubuntu-1804",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -10,7 +10,7 @@
     "zone": null,
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -7,7 +7,7 @@
     "cluster": "",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "datastore": "",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "folder": "",

--- a/images/capi/packer/ova/vsphere.json
+++ b/images/capi/packer/ova/vsphere.json
@@ -1,12 +1,12 @@
 {
-    "vcenter_server":"10.92.183.180",
-    "username":"administrator@vsphere.local",
-    "password":"Admin!23",
-    "datastore":"sharedVmfs-0",
-    "datacenter":"dc0",
-    "folder": "capv",
-    "cluster": "cluster0",
-    "network": "VM Network",
-    "convert_to_template": "true",
-    "insecure_connection": "true"
+    "vcenter_server":"",
+    "username":"",
+    "password":"",
+    "datastore":"",
+    "datacenter":"",
+    "folder": "",
+    "cluster": "",
+    "network": "",
+    "convert_to_template": "false",
+    "insecure_connection": "false"
 }

--- a/images/capi/packer/ova/vsphere.json
+++ b/images/capi/packer/ova/vsphere.json
@@ -1,12 +1,12 @@
 {
-    "vcenter_server":"",
-    "username":"",
-    "password":"",
-    "datastore":"",
-    "datacenter":"",
-    "folder": "",
-    "cluster": "",
-    "network": "",
-    "convert_to_template": "false",
-    "insecure_connection": "false"
+    "vcenter_server":"10.92.183.180",
+    "username":"administrator@vsphere.local",
+    "password":"Admin!23",
+    "datastore":"sharedVmfs-0",
+    "datacenter":"dc0",
+    "folder": "capv",
+    "cluster": "cluster0",
+    "network": "VM Network",
+    "convert_to_template": "true",
+    "insecure_connection": "true"
 }

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -6,7 +6,7 @@
     "build_timestamp": "{{timestamp}}",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "accelerator": "kvm",
     "cpus": "1",


### PR DESCRIPTION
The containerd is released & packaged in a new way here: https://github.com/containerd/containerd/releases/tag/v1.4.0

After we download the tar.gz, configure the ansible role to remove /etc/cni and /opt/cni, as we will install cni later.

Corresponding issue https://github.com/kubernetes-sigs/image-builder/issues/332 @EleanorRigby 