### PR TITLE
[WIP] Add Fedora 32 support for VMware builder

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -152,11 +152,13 @@ ABSOLUTE_PACKER_VAR_FILES := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-fil
 ## Platform and version combinations
 ## --------------------------------------
 CENTOS_VERSIONS			:=	centos-7
+FEDORA_VERSIONS			:=	fedora-32
 PHOTON_VERSIONS			:=	photon-3
 RHEL_VERSIONS				:=	rhel-7
 UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004
 
 PLATFORMS_AND_VERSIONS	:=	$(CENTOS_VERSIONS) \
+							$(FEDORA_VERSIONS) \
 							$(PHOTON_VERSIONS) \
 							$(RHEL_VERSIONS) \
 							$(UBUNTU_VERSIONS)
@@ -332,12 +334,14 @@ build-haproxy-ova-local-photon-3: ## Builds Photon 3 HAProxy OVA w local hypervi
 build-node-ova-esx-centos-7: ## Builds CentOS 7 Node OVA w remote hypervisor
 build-node-ova-esx-photon-3: ## Builds Photon 3 Node OVA w remote hypervisor
 build-node-ova-esx-rhel-7: ## Builds RHEL 7 Node OVA w remote hypervisor
+build-node-ova-esx-fedora-32: ## Builds Fedora 32 Node OVA w remote hypervisor
 build-node-ova-esx-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA w remote hypervisor
 build-node-ova-esx-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA w remote hypervisor
 build-node-ova-esx-all: $(NODE_OVA_ESX_BUILD_TARGETS) ## Builds all Node OVAs w remote hypervisor
 build-haproxy-ova-esx-photon-3: ## Builds Photon 3 HAProxy OVA w remote hypervisor
 
 build-node-ova-vsphere-centos-7: ## Builds CentOS 7 Node OVA and template on vSphere
+build-node-ova-vsphere-fedora-32: ## Builds Fedora 32 Node OVA and template on vSphere
 build-node-ova-vsphere-photon-3: ## Builds Photon 3 Node OVA and template on vSphere
 build-node-ova-vsphere-rhel-7: ## Builds RHEL 7 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -34,7 +34,7 @@
     packages:
     - cloud-init
     - cloud-utils-growpart
-    - python2-pip
+    - python3-pip
   when: ansible_os_family == "RedHat"
 
 - name: Install cloud-init and tools for VMware Photon OS

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -110,7 +110,7 @@ centos:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
-      python2-pip:
+      python3-pip:
 rhel:
   common-package: *common_rpms
   ova:
@@ -118,7 +118,15 @@ rhel:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
-      python2-pip:
+      python3-pip:
+fedora:
+  common-package: *common_rpms
+  ova:
+    package:
+      open-vm-tools:
+      cloud-init:
+      cloud-utils-growpart:
+      python3-pip:
 ubuntu:
   common-package:
     <<: *common_debs

--- a/images/capi/packer/ova/fedora-32.json
+++ b/images/capi/packer/ova/fedora-32.json
@@ -1,0 +1,16 @@
+{
+  "build_name": "fedora-32",
+  "ssh_password": "builder",
+  "distro_name": "fedora",
+  "os_display_name": "Fedora 32",
+  "guest_os_type": "centos7-64",
+  "vsphere_guest_os_type": "centos7_64Guest",
+  "iso_url": "https://download.fedoraproject.org/pub/fedora/linux/releases/32/Server/x86_64/iso/Fedora-Server-netinst-x86_64-32-1.6.iso",
+  "iso_checksum": "7f4afd2a26c718f9f15e4bbfd9c2e8849f81036d2a82a4e81fa4a313a833da9c",
+  "iso_checksum_type": "sha256",
+  "boot_command_prefix": "<up>e<down><down><end> text ks=",
+  "boot_command_suffix": "/32/ks.cfg<leftCtrlOn>x<leftCtrlOff><wait>",
+  "shutdown_command": "shutdown -P now",
+  "vmware_firmware": "efi-secure",
+  "redhat_epel_rpm": ""
+}

--- a/images/capi/packer/ova/linux/fedora/http/32/ks.cfg
+++ b/images/capi/packer/ova/linux/fedora/http/32/ks.cfg
@@ -1,0 +1,115 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Perform a fresh install, not an upgrade
+url --mirrorlist="https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-32&arch=x86_64"
+repo --name=fedora-updates --mirrorlist="https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f32&arch=x86_64" --cost=0
+
+# Perform a text installation
+# text
+
+# Do not install an X server
+skipx
+
+# Configure the locale/keyboard
+lang en_US.UTF-8
+keyboard us
+
+# Configure networking
+network --onboot yes --bootproto dhcp --hostname capv.vm
+firewall --disabled
+selinux --permissive
+timezone UTC
+
+rootpw --lock
+
+# Configure the user(s)
+authselect sssd
+user --name=builder --plaintext --password=builder --groups=wheel
+
+# Disable general install minutia
+firstboot --disabled
+eula --agreed
+
+# Create a single partition with no swap space
+bootloader --location=mbr --append="systemd.unified_cgroup_hierarchy=0"
+zerombr
+clearpart --all --initlabel
+part /boot/efi --fstype=efi --grow --maxsize=200 --size=20 --label=EFI
+part /boot --fstype=ext4 --size=2048 --label=boot
+part / --grow --asprimary --fstype=xfs --label=root
+
+%packages --ignoremissing --excludedocs
+@base
+@core
+audit
+ca-certificates
+conntrack-tools
+curl
+ebtables
+ethtool
+gcc
+iproute-tc
+jq
+nano
+ntp
+open-vm-tools
+openssh
+openssh-clients
+openssh-server
+python3-netifaces
+python3-requests
+python3-pip
+python3-devel
+sed
+socat
+sssd
+sudo
+sysstat
+vim-minimal
+yum-utils
+
+# Remove other unnecessary packages
+-postfix
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+# Perform a reboot once the installation has completed
+reboot
+
+# The %post section is essentially a shell script
+%post --erroronfail
+
+# Update the root certificates
+update-ca-trust force-enable
+
+# Ensure that the "builder" user doesn't require a password to use sudo,
+# or else Ansible will fail
+echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+chmod 440 /etc/sudoers.d/builder
+
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+# Ensure on next boot that network devices get assigned unique IDs.
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -25,5 +25,6 @@
   "vnc_bind_address": "127.0.0.1",
   "vnc_disable_password": "false",
   "vnc_port_min": "5900",
-  "vnc_port_max": "6000"
+  "vnc_port_max": "6000",
+  "vmware_firmware": "bios"
 }

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -52,6 +52,7 @@
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "guest_os_type": "{{user `guest_os_type`}}",
+      "firmware": "{{ user `vmware_firmware`}}",
       "headless": "{{user `headless`}}",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
@@ -83,58 +84,50 @@
     {
       "type": "vsphere-iso",
       "name": "vsphere",
-
-      "vcenter_server":      "{{user `vcenter_server`}}",
-      "username":            "{{user `username`}}",
-      "password":            "{{user `password`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "username": "{{user `username`}}",
+      "password": "{{user `password`}}",
       "insecure_connection": "{{user `insecure_connection`}}",
-
+      "firmware": "{{ user `vmware_firmware`}}",
       "vm_name": "{{user `build_version`}}",
       "datastore": "{{user `datastore`}}",
       "datacenter": "{{user `datacenter`}}",
       "folder": "{{user `folder`}}",
-      "host":     "{{user `host`}}",
+      "host": "{{user `host`}}",
       "convert_to_template": "{{user `convert_to_template`}}",
       "cluster": "{{user `cluster`}}",
-
       "network_adapters": [
         {
           "network": "{{user `network`}}",
           "network_card": "{{user `network_card`}}"
         }
       ],
-
       "vm_version": "{{user `vmx_version`}}",
       "CPUs": 1,
       "cpu_cores": 1,
       "RAM": 2048,
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
-
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "iso_urls": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
-
       "communicator": "ssh",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
-
       "storage": [
         {
           "disk_size": 20480,
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
-
       "boot_command": [
         "{{user `boot_command_prefix`}}",
         "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
-
       "export": {
         "force": true,
         "output_directory": "{{user `output_dir`}}"
@@ -156,14 +149,17 @@
         "--extra-vars",
         "{{user `ansible_extra_vars`}}"
       ]
-   },{
+    },
+    {
       "type": "goss",
       "arch": "{{user `goss_arch`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
-      "tests": ["{{user `goss_tests_dir`}}"],
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
       "url": "{{user `goss_url`}}",
       "use_sudo": true,
       "vars_inline": {
@@ -172,7 +168,7 @@
         "PROVIDER": "ova",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "kubernetes_cni_source_type": "{{user `kubernetes_cni_source_type`}}",
-        "containerd_version" : "{{user `containerd_version`}}",
+        "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_version": "{{user `kubernetes_cni_semver` | replace \"v\" \"\" 1}}",
         "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
         "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",


### PR DESCRIPTION
Extremely WIP PR.

I basically wanted a way to test images with the latest and greatest Linux kernels, and with sets of packages I understand, so starting to add Fedora 32.

Another important change is building this straight away with UEFI secure boot. Would like to move the other distros to UEFI at some point, as it opens the path forward for better bootstrap security.