### PR TITLE
WIP: Add a tcpdump service for optional debugging

### DIFF
--- a/images/capi/ansible/node.yml
+++ b/images/capi/ansible/node.yml
@@ -25,6 +25,8 @@
     - include_role:
         name: kubernetes
     - include_role:
+        name: debug-tools
+    - include_role:
         name: "{{ role }}"
       loop: "{{ custom_role_names.split() }}"
       loop_control:

--- a/images/capi/ansible/roles/debug-tools/files/etc/systemd/system/tcpdump@.service
+++ b/images/capi/ansible/roles/debug-tools/files/etc/systemd/system/tcpdump@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Capture packets for %I
+Wants=network.target
+BindsTo=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
+
+[Service]
+Restart=always
+RestartSec=1
+Environment="TCPDUMP_FORMAT=%i-%%Y-%%m-%%d__%%H-%%M"
+ExecStartPre=/bin/mkdir -p /var/log/tcpdumpd/
+ExecStart=/sbin/tcpdump -i %i  -G 1800 -s 65535 -w '/var/log/tcpdumpd/${TCPDUMP_FORMAT}.pcap'
+ExecStop=/bin/kill -s QUIT $MAINPID
+
+[Install]
+WantedBy=multi-user.target sys-subsystem-net-devices-%i.device

--- a/images/capi/ansible/roles/debug-tools/tasks/main.yaml
+++ b/images/capi/ansible/roles/debug-tools/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Create tcpdump systemd file
+  copy:
+    src: files/etc/systemd/system/tcpdump@.service
+    dest: /etc/systemd/system/tcpdump@.service
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
If someone wants to do packet capture for a device on the host, they can run `systemctl enable tcpdump@<if name>`