### PR TITLE
photon: Remove appliance optimisations not suitable for container host

### DIFF
--- a/images/capi/ansible/roles/node/files/etc/systemd/scripts/iptables
+++ b/images/capi/ansible/roles/node/files/etc/systemd/scripts/iptables
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# Begin /etc/systemd/scripts/iptables
+
+# Insert connection-tracking modules
+# (not needed if built into the kernel)
+modprobe nf_conntrack
+modprobe xt_LOG
+
+# Enable broadcast echo Protection
+echo 1 > /proc/sys/net/ipv4/icmp_echo_ignore_broadcasts
+
+# Disable Source Routed Packets
+echo 0 > /proc/sys/net/ipv4/conf/all/accept_source_route
+echo 0 > /proc/sys/net/ipv4/conf/default/accept_source_route
+
+# Enable TCP SYN Cookie Protection
+echo 1 > /proc/sys/net/ipv4/tcp_syncookies
+
+# Disable ICMP Redirect Acceptance
+echo 0 > /proc/sys/net/ipv4/conf/default/accept_redirects
+
+# Do not send Redirect Messages
+echo 0 > /proc/sys/net/ipv4/conf/all/send_redirects
+echo 0 > /proc/sys/net/ipv4/conf/default/send_redirects
+
+# Drop Spoofed Packets coming in on an interface, where responses
+# would result in the reply going out a different interface.
+echo 2 > /proc/sys/net/ipv4/conf/all/rp_filter
+echo 2 > /proc/sys/net/ipv4/conf/default/rp_filter
+
+# Log packets with impossible addresses.
+echo 1 > /proc/sys/net/ipv4/conf/all/log_martians
+echo 1 > /proc/sys/net/ipv4/conf/default/log_martians
+
+# be verbose on dynamic ip-addresses  (not needed in case of static IP)
+echo 2 > /proc/sys/net/ipv4/ip_dynaddr
+
+# disable Explicit Congestion Notification
+# too many routers are still ignorant
+echo 0 > /proc/sys/net/ipv4/tcp_ecn
+
+# Set a known state
+iptables -P INPUT   DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT  DROP
+
+ip6tables -P INPUT   DROP
+ip6tables -P FORWARD DROP
+ip6tables -P OUTPUT  DROP
+
+# These lines are here in case rules are already in place and the
+# script is ever rerun on the fly. We want to remove all rules and
+# pre-existing user defined chains before we implement new rules.
+iptables -F
+iptables -X
+iptables -Z
+
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+
+ip6tables -F
+ip6tables -X
+ip6tables -Z
+
+ip6tables -t nat -F
+ip6tables -t nat -X
+ip6tables -t mangle -F
+ip6tables -t mangle -X
+
+#restore ipv4 rules
+iptables-restore < /etc/systemd/scripts/ip4save
+
+#restore ipv6 rules
+ip6tables-restore < /etc/systemd/scripts/ip6save
+
+# End /etc/systemd/scripts/iptables

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -50,6 +50,20 @@
     - { param: net.ipv4.ip_forward, val: 1 }
     - { param: net.ipv6.conf.all.forwarding, val: 1 }
     - { param: net.ipv6.conf.all.disable_ipv6, val: 0 }
+    - { param: net.ipv4.conf.all.rp_filter, val: 2 }
+    - { param: kernel.sysrq, val: 16 }
+    - { param: kernel.core_uses_pid, val: 1 }
+    # Do not accept source routing
+    - { param: net.ipv4.conf.all.accept_source_route, val: 0 }
+    # Promote secondary addresses when the primary address is removed
+    - { param: net.ipv4.conf.all.promote_secondaries, val: 1 }
+    # Fair Queue CoDel packet scheduler to fight bufferbloat
+    - { param: net.core.default_qdisc, val: fq_codel }
+    # Request Explicit Congestion Notification (ECN) on both in and outgoing connections
+    - { param: net.ipv4.tcp_ecn, val: 1 }
+    # Enable hard and soft link protection
+    - { param: fs.protected_hardlinks, val: 1 }
+    - { param: fs.protected_symlinks, val: 1 }
 
 - name: Disable swap memory
   shell: |

--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -13,6 +13,43 @@
 # limitations under the License.
 
 ---
+- name: Ensure auditd is running and comes on at reboot
+  service:
+    name: auditd
+    state: started
+    enabled: yes
+
+- name: configure auditd rules for containerd
+  copy:
+    src: etc/audit/rules.d/containerd.rules
+    dest: /etc/audit/rules.d/containerd.rules
+    owner: root
+    group: root
+    mode: 0644
+
+- name: configure iptables
+  copy:
+    src: etc/systemd/scripts/iptables
+    dest: /etc/systemd/scripts/iptables
+    owner: root
+    group: root
+    mode: 0755
+
+- name: remove va-tune-up sysctls
+  file:
+    path: /etc/sysctl.d/90-va-tune-up.conf
+    state: absent
+
+- name: remove default sysctls
+  file:
+    path: /etc/sysctl.d/50-default.conf
+    state: absent
+
+- name: remove default sysctls 2
+  file:
+    path: /usr/lib/sysctl.d/50-default.conf
+    state: absent    
+
 - name: Ensure Bandwidth for TCP connections should 1 Mb (same as Ubuntu)
   sysctl:
     name: net.ipv4.tcp_limit_output_bytes


### PR DESCRIPTION
PhotonOS has a bunch of sysctls that are appropriate for a standalone server, but not for a container host. When these are on, when using packet encapsulation based CNIs, L3 routing is broken:

This is what we had
```
# Disable response to broadcasts.
# You don't want yourself becoming a Smurf amplifier.
net.ipv4.icmp_echo_ignore_broadcasts = 1
# enable route verification on all interfaces
net.ipv4.conf.all.rp_filter = 1
# enable ipV6 forwarding
#net.ipv6.conf.all.forwarding = 1
# increase the number of possible inotify(7) watches
fs.inotify.max_user_watches = 65536
# avoid deleting secondary IPs on deleting the primary IP
net.ipv4.conf.default.promote_secondaries = 1
net.ipv4.conf.all.promote_secondaries = 1
net.ipv4.conf.default.accept_source_route=0
net.ipv4.tcp_max_syn_backlog=1280
net.ipv4.conf.all.accept_redirects=0
net.ipv4.conf.default.accept_redirects=0
net.ipv4.conf.all.send_redirects=0
net.ipv4.conf.default.send_redirects=0
net.ipv4.conf.all.secure_redirects=0
net.ipv4.conf.default.secure_redirects=0
net.ipv4.conf.all.log_martians=1
net.ipv4.conf.default.log_martians=1
net.ipv4.conf.default.rp_filter=1
net.ipv6.conf.all.accept_redirects=0
net.ipv6.conf.default.accept_redirects=0
net.ipv6.conf.all.router_solicitations=0
net.ipv6.conf.default.router_solicitations=0
kernel.printk = 3 4 1 7
```
In particular, `net.ipv4.conf.all.rp_filter = 1` breaks subnet routing in Calico.

Am OK with selectively adding these back to the sysctls

This PR brings Photon into line with other OS.