### PR TITLE
update containerd to 1.4.1

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -40,18 +40,22 @@
     extra_opts:
       - --no-overwrite-dir
 
+# Remove /opt/cni directory, as we will install cni later
+- name: delete /opt/cni directory
+  file:
+    path: /opt/cni
+    state: absent
+
+# Remove /etc/cni directory, as we will configure cni later
+- name: delete /etc/cni directory
+  file:
+    path: /etc/cni
+    state: absent
+
 - name: Creates unit file directory
   file:
     path: /etc/systemd/system/containerd.service.d
     state: directory
-
-- name: Configure containerd process start-up type to Notify
-  ini_file:
-    path: /etc/systemd/system/containerd.service
-    section: Service
-    option: Type
-    value: notify
-    mode: 0644
 
 - name: Create containerd boot order drop in file
   template:

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -12,7 +12,7 @@
     "aws_secret_key": "",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "build_timestamp": "{{timestamp}}",
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -9,7 +9,7 @@
     "client_secret": null,
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "distribution": null,
     "distribution_release": null,
     "distribution_version": null,

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.3.4",
-    "containerd_sha256": "4616971c3ad21c24f2f2320fa1c085577a91032a068dd56a41c7c4b71a458087",
+    "containerd_version": "1.4.1",
+    "containerd_sha256": "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null
 }

--- a/images/capi/packer/digitalocean/packer.json
+++ b/images/capi/packer/digitalocean/packer.json
@@ -9,7 +9,7 @@
     "image_name": "cluster-api-ubuntu-1804",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -10,7 +10,7 @@
     "zone": null,
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "kubernetes_cni_rpm_version": null,
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -7,7 +7,7 @@
     "cluster": "",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "datastore": "",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "folder": "",

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -6,7 +6,7 @@
     "build_timestamp": "{{timestamp}}",
     "containerd_version": null,
     "containerd_sha256": null,
-    "containerd_url": "https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{user `containerd_version`}}.linux-amd64.tar.gz",
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "accelerator": "kvm",
     "cpus": "1",


### PR DESCRIPTION
Link to the new release: https://github.com/containerd/containerd/releases/tag/v1.4.1

This PR is related to the closed PR (update to 1.4.0), more context could be found there: https://github.com/kubernetes-sigs/image-builder/pull/372

Tested on capv and capa.

Fixes #332