### PR TITLE
Disable H/W tx offload for ethernet devices on Photon

### DIFF
--- a/images/capi/ansible/roles/node/files/etc/udev/rules.d/90-netif-disable-hw-offload.rules
+++ b/images/capi/ansible/roles/node/files/etc/udev/rules.d/90-netif-disable-hw-offload.rules
@@ -1,0 +1,3 @@
+ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth*", TAG+="netif_hw_tx_offload_disable"
+ACTION=="add", SUBSYSTEM=="net", KERNEL=="en*", TAG+="netif_hw_tx_offload_disable"
+TAG=="netif_hw_tx_offload_disable", RUN+="/usr/sbin/ethtool -K $name tx off"

--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -13,7 +13,17 @@
 # limitations under the License.
 
 ---
-- name: Ensure Bandwidth for TCP connections should 1 Mb (same as Ubuntu)
+# Due to https://github.com/vmware/photon/issues/1047
+# We disable tx offload for ethernet devices
+- name: Disable transmission HW offload
+  copy:
+    src: etc/udev/rules.d/90-netif-disable-hw-offload.rules
+    dest: /etc/udev/rules.d/90-netif-disable-hw-offload.rules
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Double TCP small queue limit to be the same as Ubuntu 
   sysctl:
     name: net.ipv4.tcp_limit_output_bytes
     value: "524288"


### PR DESCRIPTION
/hold
for testing

Disables H/W offload on the transmit path for ethernet devices on Photon.

Is a workaround for https://github.com/vmware/photon/issues/1047 