### PR TITLE
Default to BBR TCP congestion control algorithm

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -50,6 +50,7 @@
     - { param: net.ipv4.ip_forward, val: 1 }
     - { param: net.ipv6.conf.all.forwarding, val: 1 }
     - { param: net.ipv6.conf.all.disable_ipv6, val: 0 }
+    - { param: net.ipv4.tcp_congestion_control, val: bbr }
 
 - name: Disable swap memory
   shell: |


### PR DESCRIPTION
See https://queue.acm.org/detail.cfm?id=3022184

This changes the default TCP congestion control algorith to TCP BBR
(Bottleneck Bandwidth and Round-trip propagation time), which is
a send-side only algorithm (doesn't require client support)
that reduces latency and increases throughput
even with mismatched bandwidths, e.g. mobile device connecting to server
with 10Gbps bandwidth.

BBR is available on Linux 4.9 and up.

This is in line with GKE that defaults to BBR.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>