### PR TITLE
Update to latest Kubernetes version and cloud-init guestinfo_datasource version

### DIFF
--- a/images/capi/cloudinit/user-data
+++ b/images/capi/cloudinit/user-data
@@ -230,7 +230,7 @@ write_files:
       etcd: {}
       imageRepository: k8s.gcr.io
       kind: ClusterConfiguration
-      kubernetesVersion: 1.16.11
+      kubernetesVersion: 1.17.11
       networking:
         dnsDomain: cluster.local
         podSubnet: 100.96.0.0/11

--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -6,7 +6,7 @@
   "disk_type_id": "0",
   "format": "",
   "guestinfo_datasource_slug": "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo",
-  "guestinfo_datasource_ref": "v1.3.1",
+  "guestinfo_datasource_ref": "v1.4.0",
   "guestinfo_datasource_script": "{{user `guestinfo_datasource_slug`}}/{{user `guestinfo_datasource_ref`}}/install.sh",
   "headless": "true",
   "insecure_connection": "false",


### PR DESCRIPTION
- Update Kubernetes version to the latest 1.17.11
- Update VMware cloud-init guestinfo version to the latest release 1.4.0

