### PR TITLE
Add chrony module for supported distros and providers

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -16,10 +16,10 @@ common_rpms:
 - audit
 - ca-certificates
 - conntrack-tools
+- chrony
 - curl
 - ebtables
 - jq
-- ntp
 - open-vm-tools
 - python3-pip
 - python-netifaces
@@ -32,6 +32,7 @@ common_debs:
 - auditd
 - apt-transport-https
 - conntrack
+- chrony
 - curl
 - ebtables
 - jq
@@ -41,7 +42,6 @@ common_debs:
 - libnetfilter-log1
 - linux-cloud-tools-virtual
 - linux-tools-virtual
-- ntp
 - open-vm-tools
 - python3-distutils
 - python3-netifaces
@@ -51,11 +51,11 @@ common_debs:
 common_photon_rpms:
 - audit
 - conntrack-tools
+- chrony
 - distrib-compat
 - ebtables
 - jq
 - net-tools
-- ntp
 - openssl-c_rehash
 - open-vm-tools
 - python-netifaces

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -17,3 +17,15 @@
 
 - import_tasks: debian.yml
   when: ansible_os_family == "Debian"
+
+- name: Configure PTP
+  lineinfile:
+    path: /etc/chrony/chrony.conf
+    create: yes
+    line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+
+- name: Ensure makestep parameter set as per Azure recommendation
+  lineinfile:
+    path: /etc/chrony/chrony.conf
+    regexp: '^makestep'
+    line: makestep 1.0 -1

--- a/images/capi/ansible/roles/providers/tasks/debian.yml
+++ b/images/capi/ansible/roles/providers/tasks/debian.yml
@@ -19,27 +19,3 @@
   vars:
     packages:
       - azure-cli
-
-- name: Ansible apt install chrony
-  apt:
-    name: chrony
-    state: present
-  
-- name: Configure PTP
-  lineinfile:
-    path: /etc/chrony/chrony.conf
-    create: yes
-    line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
-
-- name: Ensure makestep parameter set as per Azure recommendation
-  lineinfile:
-    path: /etc/chrony/chrony.conf
-    regexp: '^makestep'
-    line: makestep 1.0 -1
-
-- name: Enable chrony.service
-  systemd:
-    enabled: yes
-    state: started
-    daemon_reload: yes
-    name: chrony.service

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -85,3 +85,14 @@
     group: root
     mode: 0644
   when: ansible_os_family == "Debian"
+
+- name: Ensure chrony is running
+  systemd:
+    enabled: yes
+    state: started
+    daemon_reload: yes
+    name: chronyd
+  when: packer_builder_type.startswith('amazon') or
+        packer_builder_type.startswith('azure') or
+        packer_builder_type is search('vmware') or
+        packer_builder_type is search('vsphere')

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -17,6 +17,8 @@ kubernetes_cni_version: &kubernetes_cni_version
 package:
   cloud-init:
     installed: true
+  ntp:
+    installed: false
 {{if eq .Vars.kubernetes_source_type "pkg"}}
   kubeadm:
     installed: true

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -14,6 +14,9 @@ service:
   auditd:
     enabled: true
     running: true
+  chronyd:
+    enabled: true
+    running: true
 {{range $name, $vers := index .Vars .Vars.OS "common-service"}}
   {{ $name }}:
   {{range $key, $val := $vers}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -2,10 +2,10 @@
 common_rpms: &common_rpms
   ca-certificates:
   conntrack-tools:
+  chrony:
   curl:
   ebtables:
   jq:
-  ntp:
   open-vm-tools:
   python-netifaces:
   python-requests:
@@ -16,6 +16,7 @@ common_debs: &common_debs
   auditd:
   apt-transport-https:
   conntrack:
+  chrony:
   curl:
   ebtables:
   jq:
@@ -25,7 +26,6 @@ common_debs: &common_debs
   libnetfilter-log1:
   linux-cloud-tools-virtual:
   linux-tools-virtual:
-  ntp:
   open-vm-tools:
   python3-distutils:
   python3-netifaces:
@@ -42,11 +42,11 @@ chrony_deb: &chrony_deb
 common_photon_rpms: &common_photon_rpms
   audit:
   conntrack-tools:
+  chrony:
   distrib-compat:
   ebtables:
   jq:
   net-tools:
-  ntp:
   openssl-c_rehash:
   open-vm-tools:
   python-netifaces:


### PR DESCRIPTION
Use `chrony` time sync service in the following provider/OS combinations -
- AWS - Ubuntu 18.04/20.04, CentOS, Amazon Linux 2
- Azure - Ubuntu18.04/20.04, CentOS
- VMware - Ubuntu18.04/20.04, CentOS

Waiting for Chrony to be available on Photon to include it in the above list.