### PR TITLE
skip post-processors when building base vmx locally

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -154,7 +154,8 @@
       "vmx_data": {
         "ethernet0.networkName": "{{user `network`}}"
       }
-    },{
+    },
+    {
       "type": "vsphere-iso",
       "name": "vsphere-iso-base",
       "vcenter_server": "{{user `vcenter_server`}}",
@@ -370,6 +371,7 @@
   "post-processors": [
     {
       "type": "manifest",
+      "except": ["vmware-iso-base"],
       "output": "{{user `output_dir`}}/packer-manifest.json",
       "strip_path": true,
       "custom_data": {
@@ -409,6 +411,7 @@
     {
       "name": "local",
       "type": "shell-local",
+      "except": ["vmware-iso-base"],
       "inline": [
         "./hack/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt {{user `output_dir`}}",
         "./hack/image-post-create-config.sh {{user `output_dir`}}"


### PR DESCRIPTION
Skip packer post-processors when building base ova locally. 
Fixes #400 