### PR TITLE
Revert "Disable H/W tx offload for ethernet devices on Photon"

### DIFF
--- a/images/capi/ansible/roles/node/files/etc/udev/rules.d/90-netif-disable-hw-offload.rules
+++ b/images/capi/ansible/roles/node/files/etc/udev/rules.d/90-netif-disable-hw-offload.rules
@@ -1,3 +1,0 @@
-ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth*", TAG+="netif_hw_tx_offload_disable"
-ACTION=="add", SUBSYSTEM=="net", KERNEL=="en*", TAG+="netif_hw_tx_offload_disable"
-TAG=="netif_hw_tx_offload_disable", RUN+="/usr/sbin/ethtool -K $name tx off"

--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 ---
-# Due to https://github.com/vmware/photon/issues/1047
-# We disable tx offload for ethernet devices
-- name: Disable transmission HW offload
-  copy:
-    src: etc/udev/rules.d/90-netif-disable-hw-offload.rules
-    dest: /etc/udev/rules.d/90-netif-disable-hw-offload.rules
-    owner: root
-    group: root
-    mode: 0644
-
 - name: Double TCP small queue limit to be the same as Ubuntu 
   sysctl:
     name: net.ipv4.tcp_limit_output_bytes


### PR DESCRIPTION
The original issue was fixed as of PhotonOS Linux 4.19.148 and mainline 5.9 in https://github.com/torvalds/linux/commit/1dac3b1bc66dc68dbb0c9f43adac71a7d0a0331a

This reverts commit 98363edee213a76adbac3ec7a4225be2f3abeed9.

Fixes #393 