### PR TITLE
Make default Azure storage account name unique and check name before create

### DIFF
--- a/images/capi/packer/azure/scripts/init-vhd.sh
+++ b/images/capi/packer/azure/scripts/init-vhd.sh
@@ -10,5 +10,7 @@ export RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-cluster-api-images}"
 export AZURE_LOCATION="${AZURE_LOCATION:-southcentralus}"
 az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION} --tags ${TAGS}
 CREATE_TIME="$(date +%s)"
-export STORAGE_ACCOUNT_NAME="capi${CREATE_TIME}"
+RANDOM_SUFFIX="$(head /dev/urandom | LC_ALL=C tr -dc a-z | head -c 4 ; echo '')"
+export STORAGE_ACCOUNT_NAME="capi${CREATE_TIME}${RANDOM_SUFFIX}"
+az storage account check-name --name ${STORAGE_ACCOUNT_NAME}
 az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME}


### PR DESCRIPTION
Fixes #417 

This addresses a flake in e2e where all jobs share the same resource group and the storage account name is only based on create time, which means if two builds create the storage account at the exact same time, the create operation will succeed because the storage already exists but might later result in ` An operation is currently performing on this storage account that requires exclusive access.` as two jobs will be using the same storage account.

This PR adds a random 4 letter suffix to the default storage account name and also adds a check before creating the storage account to make sure that the name is valid and that it is unique so that, if a collision does occur, it should fail with a clearer error message (although a collision could only occur two names are set at the exact same second and the same 4 letter suffix is chosen, ie. 𝑃(26,4)=> 1 in 358800).