### PR TITLE
Imagebuilder Container Permissions

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -23,6 +23,7 @@ ARG ARCH
 ARG PASSED_IB_VERSION
 
 COPY . /home/imagebuilder
+RUN chown -R imagebuilder:imagebuilder /home/imagebuilder
 
 USER imagebuilder
 


### PR DESCRIPTION
Content copied into container doesn't have proper permissions to execute Makefile target. Fixed by fixing owner of `/home/imagebuilder` contents.