### PR TITLE
CAPI: temporarily disable Azure Ubuntu 20.04 build

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -181,8 +181,8 @@ HAPROXY_OVA_VSPHERE_BUILD_NAMES		:=	$(addprefix haproxy-ova-vsphere-,$(PHOTON_VE
 
 AMI_BUILD_NAMES			?=	ami-centos-7 ami-ubuntu-1804 ami-ubuntu-2004 ami-amazon-2
 GCE_BUILD_NAMES			?=	gce-default
-AZURE_BUILD_VHD_NAMES		?=	azure-vhd-ubuntu-1804 azure-vhd-ubuntu-2004 azure-vhd-centos-7
-AZURE_BUILD_SIG_NAMES		?=	azure-sig-ubuntu-1804 azure-sig-ubuntu-2004 azure-sig-centos-7
+AZURE_BUILD_VHD_NAMES		?=	azure-vhd-ubuntu-1804 azure-vhd-centos-7 ## azure-vhd-ubuntu-2004
+AZURE_BUILD_SIG_NAMES		?=	azure-sig-ubuntu-1804 azure-sig-centos-7 ## azure-sig-ubuntu-2004
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 


### PR DESCRIPTION
The Azure 20.04 CI build is failing with `vhd-ubuntu-2004: fatal: [default]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: unknown reason"}`

This looks like it might be an issue with either a new apt package or with a new base image for ubuntu 20.04. Temporarily disable the test while we investigate to avoid blocking PRs.

