### PR TITLE
Update default k8s version 1.18.10

### DIFF
--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -1,8 +1,8 @@
 {
-  "kubernetes_series": "v1.17",
-  "kubernetes_semver": "v1.17.11",
-  "kubernetes_rpm_version": "1.17.11-0",
-  "kubernetes_deb_version": "1.17.11-00",
+  "kubernetes_series": "v1.18",
+  "kubernetes_semver": "v1.18.10",
+  "kubernetes_rpm_version": "1.18.10-0",
+  "kubernetes_deb_version": "1.18.10-00",
   "kubernetes_source_type": "pkg",
   "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
   "kubernetes_rpm_repo": "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64",
@@ -13,7 +13,7 @@
   "kubernetes_container_registry": "k8s.gcr.io",
   "kubernetes_load_additional_imgs": "false",
   "kubeadm_template": "etc/kubeadm.yml",
-  "crictl_version": "1.16.1",
-  "crictl_sha256": "19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1",
+  "crictl_version": "1.19.0",
+  "crictl_sha256": "87d8ef70b61f2fe3d8b4a48f6f712fd798c6e293ed3723c1e4bbb5052098f0ae",
   "crictl_source_type": "pkg"
 }


### PR DESCRIPTION
This updates the default k8s version as well as new crictl version.  I wasn't sure if it should be 1.18.10 or 1.19.3 just let me know which and I will update.