### PR TITLE
CAPZ: add creation timestamp tag for VHD packer RG

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -61,6 +61,7 @@
       "ssh_username": "packer",
       "azure_tags": {
         "build_timestamp": "{{user `build_timestamp`}}",
+        "creationTimestamp": "{{user `build_timestamp`}}",
         "distribution": "{{user `distribution`}}",
         "distribution_release": "{{user `distribution_release`}}",
         "distribution_version": "{{user `distribution_version`}}",


### PR DESCRIPTION
https://github.com/kubernetes-sigs/image-builder/commit/aa577de677b8c3ca676fa4847359da165147f7d4# only updated the SIG builder tags, this updates the VHD ones as well to prevent pkr resource group deletion during a CI run.