### PR TITLE
Azure: fix parse prow creds script

### DIFF
--- a/images/capi/packer/azure/scripts/parse-prow-creds.sh
+++ b/images/capi/packer/azure/scripts/parse-prow-creds.sh
@@ -19,7 +19,7 @@ set -o pipefail
 set +o xtrace
 
 parse_cred() {
-    grep -E -o "$1[[:blank:]]*=[[:blank:]]*\"[^[:space:]\"]+\"" | cut -d '"' -f 2
+    grep -E -o "\b$1[[:blank:]]*=[[:blank:]]*\"[^[:space:]\"]+\"" | cut -d '"' -f 2
 }
 
 


### PR DESCRIPTION
A recent change to the prow azure creds added a new MultiTenancyClientID which is getting picked up by our regex since `ClientID` is a substring of `MultiTenancyClientID`. This adds a word boundary character at the beginning of the regex to make sure only `ClientID` is parsed.

/assign @chewong 