### PR TITLE
legacy image-builder: Pin pyrsistent to python2 compatible version

### DIFF
--- a/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
+++ b/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
@@ -37,7 +37,7 @@ func (c *Config) InitDefaults() {
 	setupCommands := []string{
 		"sudo apt-get update",
 		"sudo apt-get install --yes git python debootstrap python-pip kpartx parted",
-		"sudo pip install --upgrade requests termcolor jsonschema fysom docopt pyyaml boto boto3",
+		"sudo pip install --upgrade requests termcolor jsonschema fysom docopt pyyaml boto boto3 pyrsistent==0.16.0",
 	}
 	for _, cmd := range setupCommands {
 		c.SetupCommands = append(c.SetupCommands, strings.Split(cmd, " "))


### PR DESCRIPTION
We still use python2 for these older images, and pyrsistent broke
python2 compatability in an update.  Pin to an older version (which is
likely more reproducible anyway).