### PR TITLE
Add OpenStack builder for CAPI OpenStack

### DIFF
--- a/docs/book/src/capi/providers/openstack.md
+++ b/docs/book/src/capi/providers/openstack.md
@@ -2,13 +2,18 @@
 
 ## Hypervisor
 
-The image is built using KVM hypervisor.
+The image is built using the following environments:
 
-### Prerequisites for QCOW2
+| Environment | Builder   | Build target       |
+|-------------|-----------|--------------------|
+| KVM         | QEMU      | build-qemu-ubuntu- |
+| OpenStack   | OpenStack | build-openstack    |
 
-Execute the following command to install qemu-kvm and other packages if you are running Ubuntu 18.04 LTS.
+### Prerequisites for QEMU Builder
 
 #### Installing packages to use qemu-img
+
+Execute the following command to install qemu-kvm and other packages if you are running Ubuntu 18.04 LTS.
 
 ```bash
 $ sudo -i
@@ -31,23 +36,29 @@ $ sudo chown root:kvm /dev/kvm
 
 Then exit and log back in to make the change take place.
 
+### Prerequisites for OpenStack Builder
+
+Complete the `images/capi/packer/qemu/openstack.json` configuration file with credentials and informations specific to the remote OpenStack environment.
+Please refer to the [Packer documentation for the OpenStack Builder](https://www.packer.io/docs/builders/openstack) for each variables.
+
 ## Building Images
 
-The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
-building qemu images are managed by running:
+### Building Images using QEMU Builder
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for building images are managed by running:
 
 ```bash
 make deps-qemu
 ```
 
-### Building QCOW2 Image
+From the `images/capi` directory, run `make build-qemu-ubuntu-xxxx`. The image is built and located in `images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION`. Please replace xxxx with `1804` or `2004` depending on the version you want to build the image for.
 
-From the `images/capi` directory, run `make build-qemu-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `1804` or `2004` depending on the version you want to build the image for.
+### Building Images using OpenStack Builder
 
-For building a ubuntu-2004 based capi image, run the following commands -
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for building images are managed by running:
 
 ```bash
-$ git clone https://github.com/kubernetes-sigs/image-builder.git
-$ cd image-builder/images/capi/
-$ make build-qemu-ubuntu-2004
+make deps-openstack
 ```
+
+From the `images/capi` directory, run `make build-openstack`. The images is built in the remote OpenStack environment with the name `BUILD_NAME+kube-KUBERNETES_VERSION`.

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -88,6 +88,12 @@ deps-qemu:
 	hack/ensure-ansible.sh
 	hack/ensure-packer.sh
 
+.PHONY: deps-openstack
+deps-openstack: ## Installs/checks dependencies for QEMU builds
+deps-openstack:
+	hack/ensure-ansible.sh
+	hack/ensure-packer.sh
+
 ## --------------------------------------
 ## Container variables
 ## --------------------------------------
@@ -187,6 +193,7 @@ AZURE_BUILD_SIG_NAMES		?=	azure-sig-ubuntu-1804 azure-sig-centos-7 ## azure-sig-
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004
+OPENSTACK_BUILD_NAMES			?=	openstack
 
 ## --------------------------------------
 ## Dynamic build targets
@@ -215,6 +222,8 @@ DO_BUILD_TARGETS 	:= $(addprefix build-,$(DO_BUILD_NAMES))
 DO_VALIDATE_TARGETS 	:= $(addprefix validate-,$(DO_BUILD_NAMES))
 QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 QEMU_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_BUILD_NAMES))
+OPENSTACK_BUILD_TARGETS	:= $(addprefix build-,$(OPENSTACK_BUILD_NAMES))
+OPENSTACK_VALIDATE_TARGETS	:= $(addprefix validate-,$(OPENSTACK_BUILD_NAMES))
 
 .PHONY: $(NODE_OVA_LOCAL_BUILD_TARGETS)
 $(NODE_OVA_LOCAL_BUILD_TARGETS): deps-ova
@@ -306,11 +315,19 @@ $(DO_VALIDATE_TARGETS): deps-do
 
 .PHONY: $(QEMU_BUILD_TARGETS)
 $(QEMU_BUILD_TARGETS): deps-qemu
-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/qemu-common.json)" -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" -only="local" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
 
 .PHONY: $(QEMU_VALIDATE_TARGETS)
 $(QEMU_VALIDATE_TARGETS): deps-qemu
-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/qemu-common.json)" -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" -only="local" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+
+.PHONY: $(OPENSTACK_BUILD_TARGETS)
+$(OPENSTACK_BUILD_TARGETS): deps-openstack
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/openstack.json)" -only="openstack" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+
+.PHONY: $(OPENSTACK_VALIDATE_TARGETS)
+$(OPENSTACK_VALIDATE_TARGETS): deps-openstack
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/openstack.json)" -only="openstack" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
 
 ## --------------------------------------
 ## Dynamic clean targets
@@ -411,6 +428,8 @@ build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-all: $(QEMU_BUILD_TARGETS) ## Builds all Qemu images
 
+build-openstack: ## Builds QEMU image
+
 ## --------------------------------------
 ## Document dynamic validate targets
 ## --------------------------------------
@@ -460,13 +479,16 @@ validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-all: $(QEMU_VALIDATE_TARGETS) ## Validates all Qemu Packer config
 
+validate-openstack: ## Validates QEMU image packer config
+
 validate-all: validate-ami-all \
 	validate-azure-all \
 	validate-do-all \
 	validate-gce-default \
 	validate-node-ova-local-all \
 	validate-haproxy-ova-local-photon-3 \
-	validate-qemu-all
+	validate-qemu-all \
+	validate-openstack
 validate-all: ## Validates the Packer config for all build targets
 
 ## --------------------------------------

--- a/images/capi/packer/qemu/openstack.json
+++ b/images/capi/packer/qemu/openstack.json
@@ -1,0 +1,15 @@
+{
+  "build_name": "",
+  "identity_endpoint": "",
+  "tenant_name": "",
+  "domain_name": "",
+  "username": "",
+  "password": "",
+  "region": "",
+  "insecure": "",
+  "flavor": "",
+  "networks": "",
+  "floating_ip_network": "",
+  "source_image": "",
+  "ssh_username": ""
+} 

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -2,20 +2,12 @@
   "variables": {
     "ansible_common_vars": "",
     "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
-    "boot_wait": "10s",
-    "build_timestamp": "{{timestamp}}",
     "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "crictl_version": null,
     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
-    "accelerator": "kvm",
-    "cpus": "1",
-    "disk_size": "20480",
-    "memory": "2048",
-    "format": "qcow2",
-    "headless": "true",
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_semver": null,
     "kubernetes_cni_source_type": null,
@@ -33,14 +25,11 @@
     "kubernetes_deb_gpg_key": null,
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
-    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
-    "qemu_binary": "qemu-system-x86_64",
-    "ssh_password": "builder",
-    "ssh_username": "builder"
+    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
   },
   "builders": [
     {
-      "name": "{{ user `build_name`}}",
+      "name": "local",
       "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
       "output_directory": "{{user `output_directory`}}",
       "type": "qemu",
@@ -65,6 +54,25 @@
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "3h"
+    },
+    {
+      "name": "openstack",
+      "type": "openstack",
+      "identity_endpoint": "{{user `identity_endpoint`}}",
+      "tenant_name": "{{user `tenant_name`}}",
+      "domain_name": "{{user `domain_name`}}",
+      "username": "{{user `username`}}",
+      "password": "{{user `password`}}",
+      "region": "{{user `region`}}",
+      "insecure": "{{user `insecure`}}",
+      "flavor": "{{user `flavor`}}",
+      "networks": "{{user `networks`}}",
+      "floating_ip_network": "{{user `floating_ip_network`}}",
+      "image_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "source_image": "{{user `source_image`}}",
+      "external_source_image_url": "{{user `external_source_image_url`}}",
+      "ssh_username": "{{user `ssh_username`}}",
       "ssh_timeout": "2h"
     }
   ],
@@ -72,7 +80,7 @@
     {
       "type": "ansible",
       "playbook_file": "./ansible/node.yml",
-      "user": "builder",
+      "user": "{{user `ssh_username`}}",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
         "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"

--- a/images/capi/packer/qemu/qemu-common.json
+++ b/images/capi/packer/qemu/qemu-common.json
@@ -1,0 +1,13 @@
+{
+  "boot_wait": "10s",
+  "build_timestamp": "{{timestamp}}",
+  "accelerator": "kvm",
+  "cpus": "1",
+  "disk_size": "20480",
+  "memory": "4096",
+  "format": "qcow2",
+  "headless": "true",
+  "qemu_binary": "qemu-system-x86_64",
+  "ssh_password": "builder",
+  "ssh_username": "builder"
+}


### PR DESCRIPTION
Currently CAPI OpenStack user uses QEMU builder which requires local build environment. It is more useful to build an image from existing image in OpenStack environment.