### PR TITLE
Added ability to override variables with env vars

### DIFF
--- a/docs/book/src/capi/quickstart.md
+++ b/docs/book/src/capi/quickstart.md
@@ -32,27 +32,14 @@ With the CAPI image builder installed and dependencies satisfied, you are now re
 
 ## Environment Variables
 
-To assist with automation, there is also the option of overriding any variable with a corresponding environment variable prefixed with `PKR_OVR_`. A useful example of this is providing logon credentials for the vsphere.json or the kubernetes version you would like to build.  
+To assist with automation, there is also the option of overriding any variable with a corresponding environment variable prefixed with `PKR_OVR_`.
 
 ``` sh
-#Override vsphere.json
-export PKR_OVR_vcenter_server=vsphere
-export PKR_OVR_username=administrator@vsphere.local
-export PKR_OVR_password=myPassword
-export PKR_OVR_cluster=myCluster
-export PKR_OVR_datastore=myDatastore
-export PKR_OVR_datacenter=myDatacenter
-export PKR_OVR_folder=myFolder
-export PKR_OVR_resource_pool=myResourcePool
-export PKR_OVR_convert_to_template=true
-export PKR_OVR_linked_clone=false
-export PKR_OVR_create_snapshot=false
-export PKR_OVR_template=
-export PKR_OVR_insecure_connection=true
+### Any user variable can be set
+export PKR_OVR_crictl_version=v1.16.1
+export PKR_OVR_crictl_sha256=19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1
+export PKR_OVR_kubernetes_semver=v1.19.4
 
 #Spaces are accepted but single quotes will not work.
-export PKR_OVR_network=VM Network
-
-### Any user variable can be set
-export PKR_OVR_kubernetes_semver=v1.19.4
+export PKR_OVR_additional_prepull_images=docker.io/sigwindowstools/flannel:0.12.0, docker.io/sigwindowstools/kube-proxy:v1.19.4
 ```

--- a/docs/book/src/capi/quickstart.md
+++ b/docs/book/src/capi/quickstart.md
@@ -29,3 +29,30 @@ export PATH=$PWD/.bin:$PATH
 ## Builds
 
 With the CAPI image builder installed and dependencies satisfied, you are now ready to build an image. In general, this is done via `make` targets, and each provider (e.g. AWS, GCE, etc.) will have different requirements for what information needs to be provided (such as cloud provider authentication credentials). Certain providers may have dependencies that are not satisfied by `make deps`, for example the vSphere provider needs access to a hypervisor (VMware Fusion on macOS, VMware Workstation on Linux). See the [specific documentation](./capi.md#providers) for your desired provider for more details.
+
+## Environment Variables
+
+To assist with automation, there is also the option of overriding any variable with a corresponding environment variable prefixed with `PKR_OVR_`. A useful example of this is providing logon credentials for the vsphere.json or the kubernetes version you would like to build.  
+
+``` sh
+#Override vsphere.json
+export PKR_OVR_vcenter_server=vsphere
+export PKR_OVR_username=administrator@vsphere.local
+export PKR_OVR_password=myPassword
+export PKR_OVR_cluster=myCluster
+export PKR_OVR_datastore=myDatastore
+export PKR_OVR_datacenter=myDatacenter
+export PKR_OVR_folder=myFolder
+export PKR_OVR_resource_pool=myResourcePool
+export PKR_OVR_convert_to_template=true
+export PKR_OVR_linked_clone=false
+export PKR_OVR_create_snapshot=false
+export PKR_OVR_template=
+export PKR_OVR_insecure_connection=true
+
+#Spaces are accepted but single quotes will not work.
+export PKR_OVR_network=VM Network
+
+### Any user variable can be set
+export PKR_OVR_kubernetes_semver=v1.19.4
+```

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -153,6 +153,14 @@ COMMON_WINDOWS_VAR_FILES :=	packer/config/kubernetes.json \
 					packer/config/windows/common.json \
 					packer/config/windows/cloudbase-init.json
 
+
+##Accept override environment variables with prefix PKR_OVR_ to assist with automation
+OVERRIDES := $(shell env | grep '^PKR_OVR_.*$$'| sed 's/ /~space~/g')
+
+#strip the prefix and add a add quote after =
+OVERRIDE_VARS := $(foreach v,$(OVERRIDES),$(v:PKR_OVR_%=%))
+OVERRIDE_VARS := $(foreach v,$(OVERRIDE_VARS),$(subst =,=',$(v)))
+
 # Initialize a list of flags to pass to Packer. This includes any existing flags
 # specified by PACKER_FLAGS, as well as prefixing the list with the variable
 # files from COMMON_VAR_FILES, with each file prefixed by -var-file=.
@@ -162,7 +170,8 @@ PACKER_NODE_FLAGS := $(foreach f,$(abspath $(COMMON_NODE_VAR_FILES)),-var-file="
 				$(PACKER_FLAGS)
 PACKER_HAPROXY_FLAGS := $(foreach f,$(abspath $(COMMON_HAPROXY_VAR_FILES)),-var-file="$(f)" ) \
 				$(PACKER_FLAGS)
-ABSOLUTE_PACKER_VAR_FILES := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" )
+ABSOLUTE_PACKER_VAR_FILES := $(foreach f,$(abspath $(PACKER_VAR_FILES)),-var-file="$(f)" ) \
+				$(foreach v,$(OVERRIDE_VARS), -var=$(subst ~space~, ,$(v))')
 PACKER_WINDOWS_NODE_FLAGS := $(foreach f,$(abspath $(COMMON_WINDOWS_VAR_FILES)),-var-file="$(f)" ) \
 				$(PACKER_FLAGS)
 


### PR DESCRIPTION
To help with automation and to avoid scripted file edits, I have added a way to create additional variables to the packer build command in the makefile by using environment variables.  With this addition, a user can now export any required variable with a `PKR_OVR_` prefix to avoid needing to edit a file.  These variables will then be appended to the end of the `packer build` command as `-var=key=value` and packer will override the contents of the user variables in configuration files.  I have updated the docs with the usage.

/kind feature