### PR TITLE
Bump containerd version to 1.4.3

### DIFF
--- a/images/capi/ansible/windows/roles/runtimes/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/runtimes/defaults/main.yml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-containerd_url: https://github.com/containerd/containerd/releases/download/v1.4.1/containerd-1.4.1-windows-amd64.tar.gz
-containerd_sha256: 757e0e2cd47881a7d5d252c72aab78b19564220df9b8f9b35740932219994288
 pause_image: mcr.microsoft.com/oss/kubernetes/pause:1.4.0
 containerd_additional_settings: ""
 

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,6 +1,6 @@
 {
-    "containerd_version": "1.4.1",
-    "containerd_sha256": "757efb93a4f3161efc447a943317503d8a7ded5cb4cc0cba3f3318d7ce1542ed",
+    "containerd_version": "1.4.3",
+    "containerd_sha256": "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null
 }

--- a/images/capi/packer/config/windows/containerd.json
+++ b/images/capi/packer/config/windows/containerd.json
@@ -1,5 +1,6 @@
 {
-    "containerd_version": "1.4.1",
-    "containerd_sha256": "757e0e2cd47881a7d5d252c72aab78b19564220df9b8f9b35740932219994288",
-    "containerd_additional_settings": null
+    "containerd_version": "1.4.3",
+    "containerd_sha256": "4464dc16978b6e984c442e17cfcc0826e1aebd8e12cb64a3ce2bdb89affa2138",
+    "containerd_additional_settings": null,
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/containerd-{{user `containerd_version`}}-windows-amd64.tar.gz"
 }


### PR DESCRIPTION
Link to the new release: https://github.com/containerd/containerd/releases/tag/v1.4.3

1.4.3 has fixes for CVE-2020-15257. Details are here - https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4

Signed-off-by: Davanum Srinivas <davanum@gmail.com>