### PR TITLE
gce: add scripts for CI test and nightly builds

### DIFF
--- a/images/capi/hack/ensure-boskosctl.sh
+++ b/images/capi/hack/ensure-boskosctl.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+if [[ -z "$(command -v boskosctl)" ]]; then
+  echo "installing boskosctl"
+  GO111MODULE=on go get sigs.k8s.io/boskos/cmd/boskosctl@master
+  echo "'boskosctl' has been installed to $GOPATH/bin, make sure this directory is in your \$PATH"
+fi
+
+echo "testing boskosctl"
+boskosctl --help

--- a/images/capi/hack/ensure-go.sh
+++ b/images/capi/hack/ensure-go.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+# Ensure the go tool exists and is a viable version.
+verify_go_version() {
+  if [[ -z "$(command -v go)" ]]; then
+    if [[ "${INSTALL_GO:-"true"}" == "true" ]]; then
+      curl -sSL https://golang.org/dl/go${GO_VERSION:-"1.16.3"}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+      export PATH=/usr/local/go/bin:$PATH
+      export PATH=$(go env GOPATH)/bin:$PATH
+    else
+      cat <<EOF
+Can't find 'go' in PATH, please fix and retry.
+See http://golang.org/doc/install for installation instructions.
+EOF
+      return 2
+    fi
+  fi
+
+  local go_version
+  IFS=" " read -ra go_version <<< "$(go version)"
+  local minimum_go_version
+  minimum_go_version=1.16.0
+  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
+    cat <<EOF
+Detected go version: ${go_version[*]}.
+Kubernetes requires ${minimum_go_version} or greater.
+Please install ${minimum_go_version} or later.
+EOF
+    return 2
+  fi
+}
+
+echo "Checking if go is available"
+verify_go_version
+
+go version
+
+# Explicitly opt into go modules, even though we're inside a GOPATH directory
+export GO111MODULE=on

--- a/images/capi/packer/gce/ci/nightly/README.md
+++ b/images/capi/packer/gce/ci/nightly/README.md
@@ -1,0 +1,5 @@
+## Configs for nightly builds
+
+The configurations in the directory is being used for the nightly job to build the images for GCE.
+
+The script that runs is [ci-gce-nightly.sh](../../../../scripts/ci-gce-nightly.sh)

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
@@ -1,0 +1,7 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.18.18-00",
+  "kubernetes_rpm_version": "1.18.18-0",
+  "kubernetes_semver": "v1.18.18",
+  "kubernetes_series": "v1.18"
+}

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
@@ -1,0 +1,7 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.19.10-00",
+  "kubernetes_rpm_version": "1.19.10-0",
+  "kubernetes_semver": "v1.19.10",
+  "kubernetes_series": "v1.19"
+}

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
@@ -1,0 +1,7 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.20.6-00",
+  "kubernetes_rpm_version": "1.20.6-0",
+  "kubernetes_semver": "v1.20.6",
+  "kubernetes_series": "v1.20"
+}

--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# usage: ci-gce-nightly.sh
+# This program build all images for capi gce for the nightly build
+################################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${CAPI_ROOT}" || exit 1
+
+# Verify the required Environment Variables are present.
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Environment variable empty or not defined.}"
+: "${GCP_PROJECT:?Environment variable empty or not defined.}"
+
+if [[ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+  cat <<EOF
+GOOGLE_APPLICATION_CREDENTIALS is not set.
+Please set this to the path of the service account used to run this script.
+EOF
+  return 2
+else
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
+
+# assume we are running in the CI environment as root
+# Add a user for ansible to work properly
+groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
+chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
+# use the packer user to run the build
+
+# build image for 1.18
+# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-18.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+
+# build image for 1.19
+# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-19.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+
+# build image for 1.20
+# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-20.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+
+echo "Displaying the generated image information"
+filter="name~cluster-api-ubuntu-*"
+gcloud compute images list --project "$GCP_PROJECT" \
+  --no-standard-images --filter="${filter}"

--- a/images/capi/scripts/ci-gce.sh
+++ b/images/capi/scripts/ci-gce.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+################################################################################
+# usage: ci-gce.sh
+# This program build all images for capi gce
+################################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${CAPI_ROOT}" || exit 1
+
+# shellcheck source=ensure-go.sh
+source "./hack/ensure-go.sh"
+# shellcheck source=ensure-boskosctl.sh
+source "./hack/ensure-boskosctl.sh"
+
+# Verify the required Environment Variables are present.
+: "${GOOGLE_APPLICATION_CREDENTIALS:?Environment variable empty or not defined.}"
+
+function boskosctlwrapper() {
+  boskosctl --server-url http://"${BOSKOS_HOST}" --owner-name "cluster-api-provider-gcp" "${@}"
+}
+
+cleanup() {
+  echo "Cleaning up image"
+  filter="name~cluster-api-ubuntu-*"
+  (gcloud compute images list --project "$GCP_PROJECT" \
+    --no-standard-images --format="table[no-heading](name)" --filter="${filter}" \
+    | awk '{print "gcloud compute images delete --quiet --project '"$GCP_PROJECT"' "$1" " "\n"}' \
+    | bash ) || true
+
+  # stop boskos heartbeat
+  if [ -n "${BOSKOS_HOST:-}" ]; then
+    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state used
+  fi
+
+  exit "${test_status}"
+}
+trap cleanup EXIT
+
+if [[ -z "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+  cat <<EOF
+GOOGLE_APPLICATION_CREDENTIALS is not set.
+Please set this to the path of the service account used to run this script.
+EOF
+  return 2
+else
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
+
+# If BOSKOS_HOST is set then acquire an GCP account from Boskos.
+if [ -n "${BOSKOS_HOST:-}" ]; then
+  echo "Boskos acquire - ${BOSKOS_HOST}"
+  export BOSKOS_RESOURCE="$( boskosctlwrapper acquire --type gce-project --state free --target-state busy --timeout 1h )"
+  export RESOURCE_NAME=$(echo $BOSKOS_RESOURCE | jq  -r ".name")
+  export GCP_PROJECT=$(echo $BOSKOS_RESOURCE | jq  -r ".name")
+
+  # send a heartbeat in the background to keep the lease while using the resource
+  echo "Starting Boskos HeartBeat"
+  boskosctlwrapper heartbeat --resource "${BOSKOS_RESOURCE}" &
+fi
+
+# assume we are running in the CI environment as root
+# Add a user for ansible to work properly
+groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
+chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
+# use the packer user to run the build
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS make deps-gce build-gce-all'"
+test_status="${?}"
+
+echo "Displaying the generated image information"
+filter="name~cluster-api-ubuntu-*"
+gcloud compute images list --project "$GCP_PROJECT" --no-standard-images --filter="${filter}"
+
+exit "${test_status}"


### PR DESCRIPTION
The first part to add GCE image builder to run on CI

This PR adds the script that will be used in prow to build the images for CAPI/GCE

Also adds scripts to run nightly builds

Fixes: https://github.com/kubernetes-sigs/image-builder/issues/437

Will open the test-infra PR to add the job


Please let me know if there is a better way to use boskos 

/assign @detiber @vincepri 