### PR TITLE
Document default k8s versions skew

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -36,7 +36,7 @@ The `images/capi/packer/config` directory includes several JSON files that defin
 | `packer/config/ansible-args.json` | A common set of variables that are sent to the Ansible playbook |
 | `packer/config/cni.json` | The version of Kubernetes CNI to install |
 | `packer/config/containerd.json` | The version of containerd to install and customizations specific to the containerd runtime |
-| `packer/config/kubernetes.json` | The version of Kubernetes to install |
+| `packer/config/kubernetes.json` | The version of Kubernetes to install. The default version is kept at n-2. See [Customization](#customization) section below for overriding this value |
 
 Due to OS differences, Windows images has additional configuration in the `packer/config/windows` folder.  See [Windows documentation](windows/windows.md) for more details.
 


### PR DESCRIPTION
This updates the docs to call out the default version in the kubernetes configuration as mentioned in https://github.com/kubernetes-sigs/image-builder/pull/427#issuecomment-729977732