### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - timothysc
-  - justinsb
-  - luxas
-  - moshloop
-  - figo
-  - codenrhoden
-  - akutz
-  - CecileRobertMichon
+  - image-builder-maintainers
+
+reviewers:
+  - image-builder-maintainers
+  - image-builder-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,9 +1,66 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 aliases:
-  cluster-api-admins:
+  image-builder-maintainers:
+    - akutz
+    - CecileRobertMichon
+    - codenrhoden
+    - detiber
+    - figo
+    - justinsb
+    - luxas
+    - moshloop
+    - timothysc
+  image-builder-reviewers:
+    - EleanorRigby
+    - randomvariable
+  image-builder-azure-reviewers:
+    - jsturtevant
+  image-builder-openstack-reviewers:
+    - hidekazuna
+  cluster-api-maintainers:
     - justinsb
     - detiber
-    - davidewatson
-    - vincepri
     - ncdc
+    - vincepri
+    - CecileRobertMichon
+  cluster-api-aws-maintainers:
+    - detiber
+    - ncdc
+    - randomvariable
+    - richardcase
+    - rudoi
+    - vincepri
+  cluster-api-azure-maintainers:
+    - awesomenix
+    - CecileRobertMichon
+    - devigned
+    - justaugustus
+    - nader-ziada
+  cluster-api-gcp-maintainers:
+    - cpanato
+    - detiber
+    - gab-satchi
+    - justinsb
+    - krousey
+    - maisem
+    - rsmitty
+    - vincepri
+  cluster-api-digitalocean-maintainers:
+    - cpanato
+    - MorrisLaw
+    - prksu
+    - xmudrii
+  cluster-api-openstack-maintainers:
+    - chaosaffe
+    - chrigl
+    - dims
+    - gyliu513
+    - jichenjc
+    - Lion-Wei
+    - m1093782566
+    - sbueringer
+  cluster-api-vsphere-maintainers:
+    - frapposelli
+    - yastij
+    - randomvariable

--- a/images/capi/packer/ami/OWNERS
+++ b/images/capi/packer/ami/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cluster-api-maintainers
+  - cluster-api-aws-maintainers

--- a/images/capi/packer/azure/OWNERS
+++ b/images/capi/packer/azure/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-azure-maintainers
+
+reviewers:
+  - cluster-api-azure-maintainers
+  - image-builder-azure-reviewers

--- a/images/capi/packer/digitalocean/OWNERS
+++ b/images/capi/packer/digitalocean/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cluster-api-maintainers
+  - cluster-api-digitalocean-maintainers

--- a/images/capi/packer/gce/OWNERS
+++ b/images/capi/packer/gce/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cluster-api-maintainers
+  - cluster-api-gcp-maintainers

--- a/images/capi/packer/ova/OWNERS
+++ b/images/capi/packer/ova/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cluster-api-maintainers
+  - cluster-api-vsphere-maintainers

--- a/images/capi/packer/qemu/OWNERS
+++ b/images/capi/packer/qemu/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-openstack-maintainers
+
+reviewers:
+  - cluster-api-openstack-maintainers
+  - image-builder-openstack-reviewers


### PR DESCRIPTION
Following yesterday's office hours discussion on adding reviewers, this PR makes the following changes to OWNERS files:

- Adds @detiber as image-builder approver
- Adds @EleanorRigby and @randomvariable as image-builder reviewers
- Adds `cluster-api-maintainers` as images/capi approvers (and removes `cluster-api-admins`)
- Adds `cluster-api-aws-maintainers` as  images/capi/packer/ami approvers
- Adds `cluster-api-azure-maintainers` as  images/capi/packer/azure approvers and @jsturtevant as reviewer
- Adds `cluster-api-digitalocean-maintainers` as  images/capi/packer/digitalocean approvers
- Adds `cluster-api-openstack-maintainers` as  images/capi/packer/qemu approvers and @hidekazuna as reviewer
- Adds `cluster-api-vsphere-maintainers` as  images/capi/packer/ova approvers

Going forward, if you are interested in becoming an image-builder reviewer and have been helping with PR reviews/made significant contributions to the project, please open a PR to add yourself to the reviewers list (note that you must already be a member of kubernetes-sigs).

/assign @akutz @codenrhoden @detiber @figo @justinsb @luxas @moshloop @timothysc 

/hold to give all maintainers a chance to review