### PR TITLE
Add image-promotion process to publish container images

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.1-experimental
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -20,6 +20,9 @@ SHELL := /usr/bin/env bash
 
 .DEFAULT_GOAL := help
 
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
 export IB_VERSION ?= $(shell git describe --dirty)
 
 ## --------------------------------------
@@ -94,6 +97,7 @@ deps-qemu:
 ## Container variables
 ## --------------------------------------
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+STAGING_REGISTRY := gcr.io/k8s-staging-scl-image-builder
 IMAGE_NAME ?= cluster-node-image-builder
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
@@ -570,9 +574,14 @@ clean-packer-cache:
 ## Docker targets
 ## --------------------------------------
 ##@ Docker
+
+.PHONY: docker-pull-prerequisites
+docker-pull-prerequisites:
+	docker pull docker/dockerfile:1.1-experimental
+
 .PHONY: docker-build
-docker-build: ## Build the docker image for controller-manager
-	docker build --pull --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
+	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image
@@ -585,3 +594,13 @@ docker-push: ## Push the docker image
 .PHONY: test-azure
 test-azure: ## Run the tests for Azure builders
 	$(abspath packer/azure/scripts/ci-azure-e2e.sh)
+
+## --------------------------------------
+## Release targets
+## --------------------------------------
+##@ Release
+
+.PHONY: release-staging
+release-staging: ## Builds and push container images to the staging bucket.
+	TAG=$(IB_VERSION) REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build docker-push
+

--- a/images/capi/cloudbuild.yaml
+++ b/images/capi/cloudbuild.yaml
@@ -1,0 +1,18 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 3000s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  # 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud@sha256:0ef22100e63c0f7cdf4758d4732008c99d51ec149baca736f8cf94d7cf9b7a1b'
+    entrypoint: make
+    env:
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+      - TAG=$_GIT_TAG
+      - DOCKER_BUILDKIT=1
+    args:
+      - release-staging
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'


### PR DESCRIPTION
Use GCR to publish official container images for image-builder. 

This PR

- Edits `Makefile` to build and push container image to the staging registry.
- Adds `cloudbuild.yaml` to produce a container image