### PR TITLE
Fix QEMU image for OpenStack not to execute Flatcar specific provisioner and post-processor

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -219,7 +219,8 @@ AZURE_BUILD_SIG_NAMES	?=	azure-sig-ubuntu-1804 azure-sig-ubuntu-2004 azure-sig-c
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-flatcar qemu-ubuntu-1804 qemu-ubuntu-2004
+QEMU_FLATCAR_BUILD_NAMES	?=	qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004
 
 ## --------------------------------------
 ## Dynamic build targets
@@ -246,6 +247,8 @@ AZURE_BUILD_SIG_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_SIG_NAMES))
 AZURE_VALIDATE_SIG_TARGETS	:= $(addprefix validate-,$(AZURE_BUILD_SIG_NAMES))
 DO_BUILD_TARGETS 	:= $(addprefix build-,$(DO_BUILD_NAMES))
 DO_VALIDATE_TARGETS 	:= $(addprefix validate-,$(DO_BUILD_NAMES))
+QEMU_FLATCAR_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_FLATCAR_BUILD_NAMES))
+QEMU_FLATCAR_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_FLATCAR_BUILD_NAMES))
 QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 QEMU_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_BUILD_NAMES))
 
@@ -337,13 +340,21 @@ $(DO_BUILD_TARGETS): deps-do
 $(DO_VALIDATE_TARGETS): deps-do
 	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst validate-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
 
+.PHONY: $(QEMU_FLATCAR_BUILD_TARGETS)
+$(QEMU_FLATCAR_BUILD_TARGETS): deps-qemu
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -only=flatcar packer/qemu/packer.json
+
+.PHONY: $(QEMU_FLATCAR_VALIDATE_TARGETS)
+$(QEMU_FLATCAR_VALIDATE_TARGETS): deps-qemu
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -only=flatcar packer/qemu/packer.json
+
 .PHONY: $(QEMU_BUILD_TARGETS)
 $(QEMU_BUILD_TARGETS): deps-qemu
-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/qemu/packer.json
 
 .PHONY: $(QEMU_VALIDATE_TARGETS)
 $(QEMU_VALIDATE_TARGETS): deps-qemu
-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/qemu/packer.json
 
 ## --------------------------------------
 ## Dynamic clean targets
@@ -504,6 +515,7 @@ validate-node-ova-local-base-rhel-7: ## Validates RHEL 7 Base Node OVA w local h
 validate-node-ova-local-base-ubuntu-1804: ## Validates Ubuntu 18.04 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-2004: ## Validates Ubuntu 20.04 Base Node OVA w local hypervisor
 
+validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-all: $(QEMU_VALIDATE_TARGETS) ## Validates all Qemu Packer config
@@ -514,6 +526,7 @@ validate-all: validate-ami-all \
 	validate-gce-all \
 	validate-node-ova-local-all \
 	validate-haproxy-ova-local-photon-3 \
+	validate-qemu-flatcar \
 	validate-qemu-all
 validate-all: ## Validates the Packer config for all build targets
 

--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -46,7 +46,7 @@ run_vagrant() {
 
     vagrant_name="flatcar-${channel}-${release}"
     img_name="flatcar-${channel}-${release}_vagrant_box_image_0.img"
-    box_name="packer_flatcar-${channel}-${release}_libvirt.box"
+    box_name="packer_flatcar_libvirt.box"
 
     export VAGRANT_VAGRANTFILE="${VAGRANT_VAGRANTFILE:-hack/Vagrantfile.flatcar}"
     export VAGRANT_DEFAULT_PROVIDER="libvirt"

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -42,7 +42,34 @@
   },
   "builders": [
     {
-      "name": "{{ user `build_name`}}",
+      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "output_directory": "{{user `output_directory`}}",
+      "type": "qemu",
+      "accelerator": "{{user `accelerator`}}",
+      "cpus": "{{user `cpus`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "memory": "{{user `memory`}}",
+      "boot_wait": "{{user `boot_wait`}}",
+      "disk_interface": "virtio-scsi",
+      "format": "{{user `format`}}",
+      "headless": "{{user `headless`}}",
+      "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_command_suffix`}}"
+      ],
+      "net_device": "virtio-net",
+      "qemu_binary": "{{user `qemu_binary`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "2h"
+    },
+    {
+      "name": "flatcar",
       "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
       "output_directory": "{{user `output_directory`}}",
       "type": "qemu",
@@ -69,9 +96,11 @@
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_timeout": "2h"
     }
+
   ],
   "provisioners": [
     {
+      "only": ["flatcar"],
       "type": "shell",
       "environment_vars": [
         "BUILD_NAME={{user `build_name`}}"
@@ -97,6 +126,7 @@
   ],
   "post-processors": [
     {
+      "only": ["flatcar"],
       "type": "vagrant"
     }
   ]


### PR DESCRIPTION
bootstrap-flatcar.sh provisioner and vagrant post-processor are only needed for Flatcar.

Fixes: #454 