### PR TITLE
capi: fix Flatcar issues with versions and AMIs

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -190,8 +190,8 @@ RHEL_VERSIONS				:=	rhel-7
 UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004
 
 # Set Flatcar Container Linux channel and version if not supplied
-FLATCAR_CHANNEL ?= beta
-FLATCAR_VERSION ?= 2643.1.0
+FLATCAR_CHANNEL ?= stable
+FLATCAR_VERSION ?= 2605.10.0
 
 export FLATCAR_CHANNEL FLATCAR_VERSION
 

--- a/images/capi/hack/image-grok-latest-flatcar-version.sh
+++ b/images/capi/hack/image-grok-latest-flatcar-version.sh
@@ -6,5 +6,5 @@ curl -s \
      "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
     | jq -r 'to_entries[] | "\(.key)"' \
     | grep -v "current" \
-    | sort \
+    | sort --version-sort \
     | tail -n1

--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -11,7 +11,7 @@
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
   "python_path": "/opt/bin/builder-env/site-packages",
-  "root_device_name": "/dev/sda1",
+  "root_device_name": "/dev/xvda",
   "ssh_username": "core",
   "systemd_prefix": "/etc/systemd",
   "sysusr_prefix": "/opt",


### PR DESCRIPTION
As soon as Flatcar stable [2605.10.0](https://www.flatcar-linux.org/releases/#release-2605.10.0) was released, the script `image-grok-latest-flatcar-version.sh` stopped working as expected.
What happens is, the json [feed](https://www.flatcar-linux.org/releases-json/releases-stable.json) returns a list of versions with `2605.9.0` at the end, not `2605.10.0`, because the list is sorted alphanumerically.

To convert the list into a semver-sorted one, we should apply a filter `sort --version-sort`, not a pure `sort`.

We need to update the default channel & version of Flatcar to in Makefile.

Also fix root_device_name of Flatcar AMI.
In case of AWS AMI, the root device of Flatcar AMI must be `/dev/xvda`.
Otherwise the instance does not boot.
