### PR TITLE
Update the Azure publishing pipeline to output result from pub

### DIFF
--- a/images/capi/packer/azure/scripts/new-disk-version.sh
+++ b/images/capi/packer/azure/scripts/new-disk-version.sh
@@ -88,4 +88,8 @@ offer=$(< $SKU_INFO jq -r ".offer")
 sku=$(< $SKU_INFO jq -r ".sku_id")
 
 # TODO: Update pub versions put to take in version.json as a file
-(set -x ; ./pub_linux_amd64 versions put corevm -p $publisher -o $offer -s $sku --version $image_version --vhd-uri $vhd_url --media-name $media_name --label "$label" --desc "$description" --published-date "$published_date")
+echo "Create new disk version"
+set -x  
+./pub_linux_amd64 versions put corevm -p $publisher -o $offer -s $sku --version $image_version --vhd-uri $vhd_url --media-name $media_name --label "$label" --desc "$description" --published-date "$published_date"
+set +x
+echo -e "\nCreated disk version"

--- a/images/capi/packer/azure/scripts/new-sku.sh
+++ b/images/capi/packer/azure/scripts/new-sku.sh
@@ -65,7 +65,10 @@ echo "Getting pub..."
 (set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.2.6/pub_v0.2.6_linux_amd64.tar.gz -o pub; tar -xzf pub)
 
 echo "Creating new SKU"
-(set -x ; ./pub_linux_amd64 skus put -p $PUBLISHER -o "$OFFER" -f sku.json ; echo "")
+set -x 
+./pub_linux_amd64 skus put -p $PUBLISHER -o "$OFFER" -f sku.json 
+set +x
+echo -e "\nCreated sku"
 
 echo "Writing publishing info"
 cat <<EOF > sku-publishing-info.json


### PR DESCRIPTION
This updates the script for the case where the command errors out the error and the message is lost. This now prints out any output from pub

/assign @CecileRobertMichon 