### PR TITLE
Update Windows pre-pull images and use Dec Patches

### DIFF
--- a/images/capi/packer/azure/windows-2019.json
+++ b/images/capi/packer/azure/windows-2019.json
@@ -3,10 +3,10 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2019-Datacenter-Core-smalldisk",
-  "image_version": "17763.1518.2010132039",
-  "windows_updates_kbs": "KB4580390",
+  "image_version": "17763.1637.2012040632",
+  "windows_updates_kbs": "",
   "vm_size": "Standard_D4s_v3",
   "distribution": "windows",
   "distribution_version": "2019",
-  "additional_prepull_images": "docker.io/sigwindowstools/flannel:0.12.0, docker.io/sigwindowstools/kube-proxy:{{user `kubernetes_semver`}}"
+  "additional_prepull_images": "docker.io/sigwindowstools/flannel:v0.13.0-nanoserver, docker.io/sigwindowstools/kube-proxy:{{user `kubernetes_semver`}}-nanoserver"
 }


### PR DESCRIPTION
This adds uses the latest [kube-proxy](https://hub.docker.com/repository/docker/sigwindowstools/kube-proxy) and [flannel images](https://hub.docker.com/layers/130250611/sigwindowstools/flannel/v0.13.0-nanoserver/images/sha256-ca8fc9b86ff676a2dd25b8582e8f17b8d3d8064fc8e98252506a5eb429ae456f?context=explore&tab=layers) which have been moved to nanoserver and updates to the use the [December](https://support.microsoft.com/en-us/help/4592440) patches.

You can find the latest images:

```
az vm image show --urn MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core-with-Containers-smalldisk:latest  

{
  "automaticOsUpgradeProperties": {
    "automaticOsUpgradeSupported": false
  },
  "dataDiskImages": [],
  "hyperVgeneration": "V1",
  "id": "/Subscriptions/b9d9436a-0c07-4fe8-b779-2c1030bd7997/Providers/Microsoft.Compute/Locations/westus/Publishers/MicrosoftWindowsServer/ArtifactTypes/VMImage/Offers/WindowsServer/Skus/2019-Datacenter-Core-with-Containers-smalldisk/Versions/17763.1637.2012040632",
  "location": "westus",
  "name": "17763.1637.2012040632",
  "osDiskImage": {
    "operatingSystem": "Windows",
    "sizeInBytes": 32214352384,
    "sizeInGb": 31
  },
  "plan": null,
  "tags": null
}
```