### PR TITLE
Fix comparison for custom post processor

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -426,7 +426,7 @@
         "CUSTOM_POST_PROCESSOR={{user `custom_post_processor`}}"
       ],
       "inline": [
-        "if [[ $CUSTOM_POST_PROCESSOR != \"true\" ]]; then exit 0; fi",
+        "if [ $CUSTOM_POST_PROCESSOR != \"true\" ]; then exit 0; fi",
         "{{user `custom_post_processor_command`}}"
       ]
     }


### PR DESCRIPTION
What this PR does / why we need it:
Currently the evaluation of the condition for the custom prost processor just fails, this fixes it
before:
```
==> vsphere (shell-local): Running local shell script: /tmp/packer-shell814371810
==> vsphere (shell-local): /tmp/packer-shell814371810: 2: /tmp/packer-shell814371810: [[: not found
```