### PR TITLE
add distro version & arch info to OVF Metadata

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -124,6 +124,9 @@ def main():
         'POPULATED_DISK_SIZE': vmdk['size'],
         'STREAM_DISK_SIZE': vmdk['stream_size'],
         'VMX_VERSION': args.vmx_version,
+        'DISTRO_NAME': build_data['distro_name'],
+        'DISTRO_VERSION': build_data['distro_version'],
+        'DISTRO_ARCH': build_data['distro_arch']
     }
 
     if args.node:
@@ -379,6 +382,9 @@ ${EULA}
       <FullVersion>kube-${KUBERNETES_SEMVER}</FullVersion>
       <VendorUrl>https://vmware.com</VendorUrl>
       <Category>Cluster API Provider (CAPI)</Category>
+      <Property ovf:userConfigurable="false" ovf:value="${DISTRO_NAME}" ovf:type="string" ovf:key="DISTRO_NAME"/>
+      <Property ovf:userConfigurable="false" ovf:value="${DISTRO_VERSION}" ovf:type="string" ovf:key="DISTRO_VERSION"/>
+      <Property ovf:userConfigurable="false" ovf:value="${DISTRO_ARCH}" ovf:type="string" ovf:key="DISTRO_ARCH"/>
       <Property ovf:userConfigurable="false" ovf:value="${BUILD_TIMESTAMP}" ovf:type="string" ovf:key="BUILD_TIMESTAMP"/>
       <Property ovf:userConfigurable="false" ovf:value="${BUILD_DATE}" ovf:type="string" ovf:key="BUILD_DATE"/>
       <Property ovf:userConfigurable="false" ovf:value="${CNI_VERSION}" ovf:type="string" ovf:key="CNI_VERSION"/>

--- a/images/capi/packer/ova/centos-7.json
+++ b/images/capi/packer/ova/centos-7.json
@@ -1,6 +1,8 @@
 {
   "build_name": "centos-7",
   "distro_name": "centos",
+  "distro_version": "7",
+  "distro_arch": "amd64",
   "os_display_name": "CentOS 7",
   "guest_os_type": "centos7-64",
   "vsphere_guest_os_type": "centos7_64Guest",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -378,6 +378,9 @@
       "strip_path": true,
       "custom_data": {
         "build_name": "{{user `build_name`}}",
+        "distro_name": "{{ user `distro_name` }}",
+        "distro_version": "{{ user `distro_version` }}",
+        "distro_arch": "{{ user `distro_arch` }}",
         "build_timestamp": "{{user `build_timestamp`}}",
         "build_date": "{{isotime}}",
         "build_type": "node",

--- a/images/capi/packer/ova/photon-3.json
+++ b/images/capi/packer/ova/photon-3.json
@@ -1,6 +1,8 @@
 {
   "build_name": "photon-3",
   "distro_name": "photon",
+  "distro_version": "3",
+  "distro_arch": "amd64",
   "os_display_name": "VMware Photon OS 64-bit",
   "guest_os_type": "vmware-photon-64",
   "vsphere_guest_os_type": "vmwarePhoton64Guest",

--- a/images/capi/packer/ova/rhel-7.json
+++ b/images/capi/packer/ova/rhel-7.json
@@ -1,6 +1,8 @@
 {
   "build_name": "rhel-7",
   "distro_name": "rhel",
+  "distro_version": "7",
+  "distro_arch": "amd64",
   "os_display_name": "RHEL 7",
   "guest_os_type": "rhel7-64",
   "vsphere_guest_os_type": "rhel7_64Guest",

--- a/images/capi/packer/ova/ubuntu-1804.json
+++ b/images/capi/packer/ova/ubuntu-1804.json
@@ -1,6 +1,8 @@
 {
   "build_name": "ubuntu-1804",
   "distro_name": "ubuntu",
+  "distro_version": "20.04",
+  "distro_arch": "amd64",
   "os_display_name": "Ubuntu 18.04",
   "guest_os_type": "ubuntu-64",
   "vsphere_guest_os_type": "ubuntu64Guest",

--- a/images/capi/packer/ova/ubuntu-2004.json
+++ b/images/capi/packer/ova/ubuntu-2004.json
@@ -1,6 +1,8 @@
 {
   "build_name": "ubuntu-2004",
   "distro_name": "ubuntu",
+  "distro_version": "20.04",
+  "distro_arch": "amd64",
   "os_display_name": "Ubuntu 20.04",
   "guest_os_type": "ubuntu-64",
   "vsphere_guest_os_type": "ubuntu64Guest",


### PR DESCRIPTION
What this PR does / why we need it:
OVF Metadata was missing distro version and arch fields. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @codenrhoden 