### PR TITLE
[WiP] Expose ContainerD mirror support for "advanced" usecases

### DIFF
--- a/images/capi/ansible/roles/containerd/defaults/main.yml
+++ b/images/capi/ansible/roles/containerd/defaults/main.yml
@@ -17,3 +17,47 @@ containerd_flatcar_bins:
 - containerd
 - containerd-shim
 
+# examples on how to use the mirror function
+# registry_mirrors:
+#   harbor:
+#     - harbor.yourdomain.com
+#     - harbor-alternative.yourdomain.com
+#   artifactory:
+#     - artifactory.yourdomain.com
+
+
+# containerd_registry_mirrors:
+#   - name: docker.io
+#     mirrors:
+#       - path: v2/docker-hub
+#         type: harbor
+#       - path: v2/docker.bintray.io
+#         type: artifactory
+#   - name: docker.elastic.co
+#     mirrors:
+#       - path: v2/elastic
+#         type: harbor
+#   - name: "*.gcr.io"
+#     mirrors:
+#       - path: v2/gcr
+#         type: harbor
+#   - name: gcr.io
+#     mirrors:
+#       - path: v2/gcr
+#         type: harbor
+#   - name: k8s.gcr.io
+#     mirrors:
+#       - path: v2/gcr
+#         type: harbor
+#   - name: us.gcr.io
+#     mirrors:
+#       - path: v2/gcr
+#         type: harbor
+#   - name: quay.io
+#     mirrors:
+#       - path: v2/quay
+#         type: harbor
+#   - name: ghcr.io
+#     mirrors:
+#       - path: v2/ghcr.io
+#         type: harbor

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -37,6 +37,14 @@ version = 2
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ containerd_pause_image }}"
+    {% if containerd_registry_mirrors is defined and registry_mirrors is defined %}
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+      {% for containerd_registry_mirror in containerd_registry_mirrors %}
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ containerd_registry_mirror.name }}"]
+          endpoint = [{% for mirror_config in containerd_registry_mirror.mirrors %}{% for registry_mirror in registry_mirrors[mirror_config.type] %}"https://{{ registry_mirror }}/{{ mirror_config.path }}"{{ '' if loop.last else ',' }}{% endfor %}{{ '' if loop.last else ',' }}{% endfor %}]
+      {% endfor %}
+      {% endif %}
 
 {% endif %}
     


### PR DESCRIPTION
Internally we run all our Clusters airgapped, thus we make use of the mirror support in ContainerD.
This PR exposes that in the image building process so that other folx can use it as well, if it would be applicable in their environment.
This is a WiP, mostly there to gather feedback 😅 ( for example its not working for flatcar and windows right now, as its a straight copy from our fork)