### PR TITLE
use latest so anyone building always gets the latest version

### DIFF
--- a/images/capi/packer/azure/windows-2019.json
+++ b/images/capi/packer/azure/windows-2019.json
@@ -3,7 +3,7 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2019-Datacenter-Core-smalldisk",
-  "image_version": "17763.1637.2012040632",
+  "image_version": "latest",
   "windows_updates_kbs": "",
   "vm_size": "Standard_D4s_v3",
   "distribution": "windows",


### PR DESCRIPTION
What this PR does / why we need it:
Sets the image to default to the "latest" image. This will always use the latest image published by Azure which will have the latest windows patches.  We need some more fine to control but this can be done by overriding this value in our Pipelines instead of the default value which will all for less churn on this file and ensure anyone using the project they get the latest when building at a given point in time.  

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @CecileRobertMichon 