### PR TITLE
Fix missing comma from PR 402 causing syntax error

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -129,7 +129,7 @@ def main():
         'VMX_VERSION': args.vmx_version,
         'DISTRO_NAME': build_data['distro_name'],
         'DISTRO_VERSION': build_data['distro_version'],
-        'DISTRO_ARCH': build_data['distro_arch']
+        'DISTRO_ARCH': build_data['distro_arch'],
         'NESTEDHV': "false"
     }
 


### PR DESCRIPTION
What this PR does / why we need it:

Fixes build errors created by PR # 402 in the ova export

**Additional context**
This is a missing comma in the python script that builds the ova