### PR TITLE
Azure: change creation timestamp tag to RFC 3339 format

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -54,8 +54,9 @@
       "winrm_timeout": "10m",
       "winrm_username": "packer",
       "azure_tags": {
+        "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
-        "creationTimestamp": "{{user `build_timestamp`}}",
+        "creationTimestamp": "{{isotime \"2006-01-02T15:04:05Z\"}}",
         "os_version": "{{user `image_sku`}}",
         "kubernetes_version": "{{user `kubernetes_semver`}}"
       }
@@ -89,8 +90,9 @@
       "winrm_timeout": "10m",
       "winrm_username": "packer",
       "azure_tags": {
+        "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
-        "creationTimestamp": "{{user `build_timestamp`}}",
+        "creationTimestamp": "{{isotime \"2006-01-02T15:04:05Z\"}}",
         "os_version": "{{user `image_sku`}}",
         "kubernetes_version": "{{user `kubernetes_semver`}}"
       }

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -60,8 +60,9 @@
       "location": "{{user `azure_location`}}",
       "ssh_username": "packer",
       "azure_tags": {
+        "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
-        "creationTimestamp": "{{user `build_timestamp`}}",
+        "creationTimestamp": "{{isotime \"2006-01-02T15:04:05Z\"}}",
         "distribution": "{{user `distribution`}}",
         "distribution_release": "{{user `distribution_release`}}",
         "distribution_version": "{{user `distribution_version`}}",
@@ -93,8 +94,9 @@
       "location": "{{user `azure_location`}}",
       "ssh_username": "packer",
       "azure_tags": {
+        "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
-        "creationTimestamp": "{{user `build_timestamp`}}",
+        "creationTimestamp": "{{isotime \"2006-01-02T15:04:05Z\"}}",
         "distribution": "{{user `distribution`}}",
         "distribution_release": "{{user `distribution_release`}}",
         "distribution_version": "{{user `distribution_version`}}",


### PR DESCRIPTION
What this PR does / why we need it: Change the rg tag format to be compatible with kubetest cleanup jobs.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers