### PR TITLE
Bump mdbook to v0.4.6

### DIFF
--- a/docs/book/build.sh
+++ b/docs/book/build.sh
@@ -24,6 +24,8 @@ cd "${KUBE_ROOT}" || exit 1
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
+MDBOOK_VERSION="0.4.6"
+
 # translate arch to rust's conventions (if we can)
 if [[ ${arch} == "amd64" ]]; then
     arch="x86_64"
@@ -54,9 +56,9 @@ esac
 
 # grab mdbook
 # we hardcode linux/amd64 since rust uses a different naming scheme and it's a pain to tran
-echo "downloading mdBook-v0.3.1-${arch}-${target}.${ext}"
+echo "downloading mdBook-v${MDBOOK_VERSION}-${arch}-${target}.${ext}"
 set -x
-curl -sL -o /tmp/mdbook.${ext} "https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdBook-v0.3.1-${arch}-${target}.${ext}"
+curl -sL -o /tmp/mdbook.${ext} "https://github.com/rust-lang-nursery/mdBook/releases/download/v${MDBOOK_VERSION}/mdBook-v${MDBOOK_VERSION}-${arch}-${target}.${ext}"
 ${cmd} /tmp/mdbook.${ext}
 chmod +x /tmp/mdbook
 


### PR DESCRIPTION
What this PR does / why we need it:

The version of `mdbook` being used was about 18 months old. This PR updates to the latest, and modifies the script so that the version is only defined in one place rather than being hardcoded in 3.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/cc @SanikaGawhane 
/cc @kkeshavamurthy 