### PR TITLE
Fixup gcb build args

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,8 +10,7 @@ steps:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - TAG=$_GIT_TAG
       - DOCKER_BUILDKIT=1
-    args:
-      - -C images/capi release-staging
+    args: ['-C', 'images/capi', 'release-staging']
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
What this PR does / why we need it:
The most recent image [build](https://storage.googleapis.com/kubernetes-jenkins/logs/post-image-builder-push-images/1353754740831293440/build-log.txt) failed, seemingly from incorrect arg syntax. This PR changes the `args` line to look like what is in the GCB [docs](https://github.com/codenrhoden/image-builder/pull/new/gcb-cmd).

/assign @kkeshavamurthy 
FYI, @SanikaGawhane 