### PR TITLE
Add EFI Support for OVA creation

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -207,7 +207,7 @@ CENTOS_VERSIONS			:=	centos-7
 FLATCAR_VERSIONS		:=	flatcar
 PHOTON_VERSIONS			:=	photon-3
 RHEL_VERSIONS			:=	rhel-7
-UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004
+UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi
 WINDOWS_VERSIONS		:=	windows-2019 windows-2004
 
 # Set Flatcar Container Linux channel and version if not supplied
@@ -302,6 +302,7 @@ $(NODE_OVA_ESX_BUILD_TARGETS): deps-ova
 .PHONY: $(NODE_OVA_VSPHERE_BUILD_TARGETS)
 $(NODE_OVA_VSPHERE_BUILD_TARGETS): deps-ova
 	packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS))  -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json" -except=esx -except=local -only=vsphere-iso $(ABSOLUTE_PACKER_VAR_FILES) -only=vsphere packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
+
 
 .PHONY: $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS)
 $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS): deps-ova
@@ -487,7 +488,9 @@ build-node-ova-vsphere-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template
 build-node-ova-vsphere-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
 build-node-ova-vsphere-windows-2019: ## Builds for Windows Server 2019 and template on vSphere
 build-node-ova-vsphere-windows-2004: ## Builds for Windows Server 2004 SAC and template on vSphere
+build-node-ova-vsphere-ubuntu-2004-efi: ## Builds Ubuntu 20.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-all: $(NODE_OVA_VSPHERE_BUILD_TARGETS) ## Builds all Node OVAs and templates on vSphere
+
 build-haproxy-ova-vsphere-photon-3: ## Builds Photon 3 HAProxy OVA and template on vSphere
 
 build-node-ova-vsphere-clone-centos-7: ## Builds CentOS 7 Node OVA and template on vSphere

--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -140,7 +140,8 @@ def main():
         'DISTRO_NAME': build_data['distro_name'],
         'DISTRO_VERSION': build_data['distro_version'],
         'DISTRO_ARCH': build_data['distro_arch'],
-        'NESTEDHV': "false"
+        'NESTEDHV': "false",
+        'FIRMWARE': build_data['firmware']
     }
 
     capv_url = "https://github.com/kubernetes-sigs/cluster-api-provider-vsphere"

--- a/images/capi/hack/ovf_template.xml
+++ b/images/capi/hack/ovf_template.xml
@@ -127,7 +127,7 @@
       <vmw:Config ovf:required="false" vmw:key="cpuHotAddEnabled" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="cpuHotRemoveEnabled" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="memoryHotAddEnabled" vmw:value="false"/>
-      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="bios"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="${FIRMWARE}"/>
       <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>

--- a/images/capi/packer/ova/linux/ubuntu/http/20.04/preseed-efi.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/20.04/preseed-efi.cfg
@@ -1,0 +1,15 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+d-i preseed/include string ../base/preseed-efi.cfg

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed-efi.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed-efi.cfg
@@ -1,0 +1,128 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configure the locale
+d-i debian-installer/locale string en_US.utf8
+d-i console-setup/ask_detect boolean false
+d-i console-setup/layout string us
+
+# Configure the clock
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+d-i clock-setup/utc boolean true
+
+# Configure the keyboard
+d-i kbd-chooser/method select American English
+
+# Configure networking
+d-i netcfg/wireless_wep string
+
+# Select the kernel
+d-i base-installer/kernel/override-image string linux-virtual
+
+# Configure a non-interactive install
+debconf debconf/frontend select Noninteractive
+
+# Configure the base installation
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/language-packs multiselect
+tasksel tasksel/first multiselect # standard, ubuntu-server
+
+
+### Simple GPT configuration w/o LVM
+d-i partman-auto/disk string /dev/sda
+
+d-i partman/alignment string cylinder
+d-i partman/confirm_write_new_label boolean true
+d-i partman-basicfilesystems/choose_label string gpt
+d-i partman-basicfilesystems/default_label string gpt
+d-i partman-partitioning/choose_label string gpt
+d-i partman-partitioning/default_label string gpt
+d-i partman/choose_label string gpt
+d-i partman/default_label string gpt
+
+d-i partman-auto/method string regular
+d-i partman-auto/choose_recipe select gpt-boot-root-swap
+d-i partman-auto/expert_recipe string         \
+   gpt-boot-root-swap ::                      \
+      1 1 1 free                              \
+         $bios_boot{ }                        \
+         method{ biosgrub } .                 \
+      200 200 200 fat32                       \
+         $primary{ }                          \
+         method{ efi } format{ } .            \
+      512 512 512 ext3                        \
+         $primary{ } $bootable{ }             \
+         method{ format } format{ }           \
+         use_filesystem{ } filesystem{ ext3 } \
+         mountpoint{ /boot } .                \
+      1000 20000 -1 ext4                      \
+         $primary{ }                          \
+         method{ format } format{ }           \
+         use_filesystem{ } filesystem{ ext4 } \
+         mountpoint{ / } .
+
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+# Create the default user.
+d-i passwd/user-fullname string builder
+d-i passwd/username string builder
+d-i passwd/user-password password builder
+d-i passwd/user-password-again password builder
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+# Disable upgrading packages upon installation.
+d-i pkgsel/upgrade select none
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+d-i pkgsel/update-policy select none
+
+# Disable use of the apt mirror during base install
+# This means only packages available in the ISO can be installed
+d-i apt-setup/use_mirror boolean false
+
+# Disable the security repo as well (it's on by default)
+d-i apt-setup/services-select multiselect none
+
+# Customize the list of packages installed.
+d-i pkgsel/include string openssh-server open-vm-tools
+
+
+# Ensure questions about these packages do not bother the installer.
+libssl1.1 libssl1.1/restart-without-asking boolean true
+libssl1.1:amd64  libssl1.1/restart-without-asking boolean true
+libssl1.1 libssl1.1/restart-services string
+libssl1.1:amd64 libssl1.1/restart-services string
+
+
+# This command runs after all other steps; it:
+# 1. Ensures the "builder" user doesn't require a password to use sudo
+# 2. Cleans up any packages that are no longer required
+# 3. Cleans the package cache
+# 4. Removes the cached list of packages
+# 5. Disables swapfiles
+# 6. Removes the existing swapfile
+# 7. Removes the swapfile entry from /etc/fstab
+d-i preseed/late_command string \
+    echo 'builder ALL=(ALL) NOPASSWD: ALL' >/target/etc/sudoers.d/builder ; \
+    in-target chmod 440 /etc/sudoers.d/builder ; \
+    in-target swapoff -a ; \
+    in-target rm -f /swapfile ; \
+    in-target sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab ; \
+    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules

--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -4,6 +4,7 @@
   "disk_controller_type": "pvscsi",
   "disk_thin_provisioned": "true",
   "disk_type_id": "0",
+  "firmware": "bios",
   "format": "",
   "guestinfo_datasource_ref": "v1.4.0",
   "guestinfo_datasource_script": "{{user `guestinfo_datasource_slug`}}/{{user `guestinfo_datasource_ref`}}/install.sh",

--- a/images/capi/packer/ova/packer-haproxy.json
+++ b/images/capi/packer/ova/packer-haproxy.json
@@ -62,6 +62,7 @@
         "force": true,
         "output_directory": "{{user `output_dir`}}"
       },
+      "firmware": "{{user `firmware`}}",
       "folder": "{{user `folder`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
       "host": "{{user `host`}}",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -140,6 +140,7 @@
         "force": true,
         "output_directory": "{{user `base_output_dir`}}"
       },
+      "firmware": "{{user `firmware`}}",
       "floppy_dirs": "{{ user `floppy_dirs`}}",
       "folder": "{{user `folder`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
@@ -194,6 +195,7 @@
         "manifest": "{{ user `export_manifest`}}",
         "output_directory": "{{user `output_dir`}}"
       },
+      "firmware": "{{user `firmware`}}",
       "floppy_dirs": "{{ user `floppy_dirs`}}",
       "folder": "{{user `folder`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
@@ -272,6 +274,7 @@
         "distro_arch": "{{ user `distro_arch` }}",
         "distro_name": "{{ user `distro_name` }}",
         "distro_version": "{{ user `distro_version` }}",
+        "firmware": "{{user `firmware`}}",
         "guest_os_type": "{{user `guest_os_type`}}",
         "ib_version": "{{user `ib_version`}}",
         "kubernetes_cni_semver": "{{user `kubernetes_cni_semver`}}",

--- a/images/capi/packer/ova/ubuntu-2004-efi.json
+++ b/images/capi/packer/ova/ubuntu-2004-efi.json
@@ -1,0 +1,19 @@
+{
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>linux /install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost preseed/file=",
+  "boot_command_suffix": "/20.04/preseed-efi.cfg -- <wait><enter>initrd /install/initrd.gz<enter>boot<enter><wait>",
+  "boot_media_path": "/media/HTTP",
+  "build_name": "ubuntu-2004-efi",
+  "cdrom_type": "sata",
+  "distro_arch": "amd64",
+  "distro_name": "ubuntu",
+  "distro_version": "20.04",
+  "firmware": "efi",
+  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+  "iso_checksum_type": "sha256",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+  "os_display_name": "Ubuntu 20.04",
+  "shutdown_command": "shutdown -P now",
+  "vsphere_guest_os_type": "ubuntu64Guest"
+}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds support for building OVAs that boot using EFI. We need EFI support for using DirectPathIO devices with more than 16GB of mapped memory. This is necessary for GPU devices.

I do wonder if EFI should be made the default, as I don't know any benefit to maintaining non-EFI images separately. 