### PR TITLE
Only place required files in Docker container

### DIFF
--- a/images/capi/.dockerignore
+++ b/images/capi/.dockerignore
@@ -1,6 +1,9 @@
-# Ignore files that shouldn't go into the container
-.bin/
-output/
-packer_cache/
-manifest.json
-docker/
+# Ignore all files
+*
+
+# Exceptions
+!ansible
+!cloudinit
+!hack
+!packer
+!Makefile

--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -24,18 +24,19 @@ RUN apt-get update && apt-get install -y apt-transport-https ca-certificates pyt
 ARG ARCH
 ARG PASSED_IB_VERSION
 
-COPY . /home/imagebuilder
-RUN chown -R imagebuilder:imagebuilder /home/imagebuilder
-
 USER imagebuilder
+WORKDIR /home/imagebuilder/
+
+COPY --chown=imagebuilder:imagebuilder ansible ansible/
+COPY --chown=imagebuilder:imagebuilder cloudinit cloudinit/
+COPY --chown=imagebuilder:imagebuilder hack hack/
+COPY --chown=imagebuilder:imagebuilder packer packer/
+COPY --chown=imagebuilder:imagebuilder Makefile Makefile
 
 ENV PATH="/home/imagebuilder/.local/bin:${PATH}"
-
 ENV PACKER_ARGS ''
 ENV PACKER_VAR_FILES ''
 ENV IB_VERSION "${PASSED_IB_VERSION}"
-
-WORKDIR /home/imagebuilder/
 
 RUN make deps
 


### PR DESCRIPTION
What this PR does / why we need it:
This patch changes up the `Dockerfile` and `.dockerignore` to start with an
explicit deny all approach, and then add only the files/dirs that are
needed. This is most useful for developers, who may have additional
files/folders located withiin images/capi that are not part of the git
repo. Since the old Docker file was doing "COPY .", this copied anything
that wasn't explicitly ruled out in .dockerignore. This patch takes the
opposite approach.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
This may not be an issue in CI, but as an example, this reduced the final build size of the image from ~4.5G to ~2.2G. Also cut the build time down by about 4 minutes.

Another issue (actually the one that sent me down this path) is that if you are developing on a Mac, the old `COPY . /home/imagebuilder` meant that it would copy `.local/bin`, which may contain Mac-compiled packer binaries. Those then end up in the container image and then the image does not work. This was originally covered by the `.bin/` entry in `.dockerignore`, but at some point we started installing Packer to `.local/bin` instead, and the `.dockerignore` file never got updated.

/assign @kkeshavamurthy 
FYI @SanikaGawhane 