### PR TITLE
Add --pull to docker build

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -581,7 +581,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --pull --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image
@@ -603,4 +603,3 @@ test-azure: ## Run the tests for Azure builders
 .PHONY: release-staging
 release-staging: ## Builds and push container images to the staging bucket.
 	TAG=$(IB_VERSION) REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build docker-push
-


### PR DESCRIPTION
What this PR does / why we need it:
This will make sure that it always tries to pull a newer image version.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
The latest CI job is [here](https://storage.googleapis.com/kubernetes-jenkins/logs/post-image-builder-push-images/1354495681301057536/build-log.txt). It appears to have failed for not pulling ubuntu:focal, but I thought `docker build` would always do that anyways if the image was missing. Regardless, it is good practice to always to try and pull a newer image when pointing to an image with a moving tag (e.g. `ubuntu:focal`), so this makes sense regardless.

/assign @kkeshavamurthy 
FYI @SanikaGawhane 