### PR TITLE
prepull ubuntu:focal for use with buildkit

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:focal
+FROM docker.io/library/ubuntu:focal
 
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates python3-pip curl wget git rsync vim unzip build-essential \
     && useradd -ms /bin/bash imagebuilder \

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -577,11 +577,13 @@ clean-packer-cache:
 
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
+	# We must pre-pull images https://github.com/moby/buildkit/issues/1271
 	docker pull docker/dockerfile:1.1-experimental
+	docker pull docker.io/library/ubuntu:focal
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --pull --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image


### PR DESCRIPTION
What this PR does / why we need it:
there are issues with containerd+buildkit when referencing an image that
is not already cached. See https://github.com/moby/buildkit/issues/1271.
Instead, we explicitly pre-pull the image.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Hopefully this one does the trick! Thanks for the heads up on this one, @dims!

/assign @kkeshavamurthy 
cc: @SanikaGawhane 