### PR TITLE
capi: make ignition capable of detecting Flatcar images

### DIFF
--- a/images/capi/packer/files/bootstrap-flatcar.sh
+++ b/images/capi/packer/files/bootstrap-flatcar.sh
@@ -38,3 +38,6 @@ ln -s builder-env/bin/pip ${BINDIR}/pip
 ln -s builder-env/bin/pip ${BINDIR}/pip3
 
 touch ${BINDIR}/.bootstrapped
+
+# make the image detected by ignition during the next boot
+touch /boot/flatcar/first_boot


### PR DESCRIPTION
Flatcar images created by image-builder had a bug, so that ignition could not detect if VMs launched by the images are the first boot.

The standard AMIs published by Flatcar already have a special file `/boot/flatcar/first_boot` created by itself.
However, image-builder images did not have that, because image-builder runs in 2 steps:
one for running the standard Flatcar AMI, and the following installation steps.
Ignition could detect the first boot in the first step, but not in the second step, because ignition already removed the `first_boot` file in the first step.

To fix the issue, simply touch `/boot/flatcar/first_boot` before finishing bootstrapping.

The current AMIs published for k8s v1.18.15 were already created with this fix, so they should work fine.
