### PR TITLE
kube-deploy: Pre-populate the caches with newer dependencies

### DIFF
--- a/images/kube-deploy/imagebuilder/templates/1.11-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.11-stretch.yml
@@ -145,11 +145,18 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
        # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
 
-       # Install docker
-       - [ 'wget', 'http://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_17.03.2~ce-0~debian-stretch_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "36773361cf44817371770cb4e6e6823590d10297  docker.deb" | shasum -c -' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
-       - [ 'rm', '{root}/tmp/docker.deb' ]
+       # We no longer pre-install docker (instead we pre-seed the cache);
+       # having docker run automatically makes it harder to upgrade and can cause problems with iptables.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
+
+       # Preload some files to our cache, in the hope we can avoid some downloads
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.12-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.12-stretch.yml
@@ -145,11 +145,18 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
        # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
 
-       # Install docker
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~debian_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "93b5a055a39462867d79109b00db1367e3d9e32f  docker.deb" | shasum -c -' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
-       - [ 'rm', '{root}/tmp/docker.deb' ]
+       # We no longer pre-install docker (instead we pre-seed the cache);
+       # having docker run automatically makes it harder to upgrade and can cause problems with iptables.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
+
+       # Preload some files to our cache, in the hope we can avoid some downloads
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.13-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.13-stretch.yml
@@ -145,11 +145,18 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
        # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
 
-       # Install docker
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~debian_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "93b5a055a39462867d79109b00db1367e3d9e32f  docker.deb" | shasum -c -' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
-       - [ 'rm', '{root}/tmp/docker.deb' ]
+       # We no longer pre-install docker (instead we pre-seed the cache);
+       # having docker run automatically makes it harder to upgrade and can cause problems with iptables.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
+
+       # Preload some files to our cache, in the hope we can avoid some downloads
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.14-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.14-stretch.yml
@@ -145,11 +145,18 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
        # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
 
-       # Install docker
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~debian_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "93b5a055a39462867d79109b00db1367e3d9e32f  docker.deb" | shasum -c -' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
-       - [ 'rm', '{root}/tmp/docker.deb' ]
+       # We no longer pre-install docker (instead we pre-seed the cache);
+       # having docker run automatically makes it harder to upgrade and can cause problems with iptables.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
+
+       # Preload some files to our cache, in the hope we can avoid some downloads
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.15-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.15-stretch.yml
@@ -145,11 +145,18 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
        # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
 
-       # Install docker
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.06.3~ce~3-0~debian_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "93b5a055a39462867d79109b00db1367e3d9e32f  docker.deb" | shasum -c -' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
-       - [ 'rm', '{root}/tmp/docker.deb' ]
+       # We no longer pre-install docker (instead we pre-seed the cache);
+       # having docker run automatically makes it harder to upgrade and can cause problems with iptables.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
+
+       # Preload some files to our cache, in the hope we can avoid some downloads
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz', '-O', '{root}/var/cache/nodeup/sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8  sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.16-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.16-stretch.yml
@@ -145,17 +145,18 @@ plugins:
        - [ 'chroot', '{root}', '/bin/sh', '-c', 'echo "APT::Periodic::Unattended-Upgrade \"0\"; " >> /etc/apt/apt.conf.d/20auto-upgrades' ]
        # - [ 'chroot', '{root}', 'apt-get', 'remove', '--yes', 'unattended-upgrades' ]
 
-       # Install docker
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/containerd.io_1.2.10-3_amd64.deb', '-O', '{root}/tmp/containerd.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "186f2f2c570f37b363102e6b879073db6dec671d  containerd.deb" | shasum -c -' ]
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce-cli_18.09.9~3-0~debian-stretch_amd64.deb', '-O', '{root}/tmp/docker-cli.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "88f8f3103d2e5011e2f1a73b9e6dbf03d6e6698a  docker-cli.deb" | shasum -c -' ]
-       - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.09.9~3-0~debian-stretch_amd64.deb', '-O', '{root}/tmp/docker.deb' ]
-       - [ '/bin/sh', '-c', 'cd {root}/tmp; echo "9d564b56f5531a08e24c8c7724445d128742572e  docker.deb" | shasum -c -' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/containerd.deb' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker-cli.deb' ]
-       - [ 'chroot', '{root}', '/bin/sh', '-c', 'DEBIAN_FRONTEND=noninteractive dpkg --install /tmp/docker.deb' ]
-       - [ 'rm', '{root}/tmp/containerd.deb', '{root}/tmp/docker-cli.deb', '{root}/tmp/docker.deb' ]
+       # We no longer pre-install docker (instead we pre-seed the cache);
+       # having docker run automatically makes it harder to upgrade and can cause problems with iptables.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
+
+       # Preload some files to our cache, in the hope we can avoid some downloads
+       - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.09.9.tgz', '-O', '{root}/var/cache/nodeup/sha256:82a362af7689038c51573e0fd0554da8703f0d06f4dfe95dd5bda5acf0ae45fb_https___download_docker_com_linux_static_stable_x86_64_docker-18_09_9_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "82a362af7689038c51573e0fd0554da8703f0d06f4dfe95dd5bda5acf0ae45fb  sha256:82a362af7689038c51573e0fd0554da8703f0d06f4dfe95dd5bda5acf0ae45fb_https___download_docker_com_linux_static_stable_x86_64_docker-18_09_9_tgz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz', '-O', '{root}/var/cache/nodeup/sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8  sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.17-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.17-stretch.yml
@@ -152,14 +152,24 @@ plugins:
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/packages; echo "e5a6cde8a9e5249bdfbad4d9c38ab23f22dd55595ad5f6a1c11cfbc9ed3129b6  docker-ce.deb" | sha256sum -c -' ]
        - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce-cli_19.03.11~3-0~debian-stretch_amd64.deb', '-O', '{root}/var/cache/nodeup/packages/docker-ce-cli.deb' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/packages; echo "4b2644b31c66537155334941a46219515a937aa97b0d9f9c074380062f73216d  docker-ce-cli.deb" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-19.03.14.tgz', '-O', '{root}/var/cache/nodeup/sha256:9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847_https___download_docker_com_linux_static_stable_x86_64_docker-19_03_14_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847  sha256:9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847_https___download_docker_com_linux_static_stable_x86_64_docker-19_03_14_tgz" | sha256sum -c -' ]
+
        - [ 'wget', 'https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/containerd.io_1.2.13-2_amd64.deb', '-O', '{root}/var/cache/nodeup/packages/containerd.io.deb' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/packages; echo "c2f6d8070ccf3813644cd465c2640c0e8f2967ecd01ccecbdcfa4b2acc9c9c92  containerd.io.deb" | sha256sum -c -' ]
 
+       - [ 'wget', 'https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz', '-O', '{root}/var/cache/nodeup/sha256:96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75_https___github_com_containerd_containerd_releases_download_v1_3_9_cri-containerd-cni-1_3_9-linux-amd64_tar_gz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75  sha256:96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75_https___github_com_containerd_containerd_releases_download_v1_3_9_cri-containerd-cni-1_3_9-linux-amd64_tar_gz" | sha256sum -c -' ]
+
        - [ 'wget', 'https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz', '-O', '{root}/var/cache/nodeup/sha256:994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_6_cni-plugins-linux-amd64-v0_8_6_tgz' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5  sha256:994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_6_cni-plugins-linux-amd64-v0_8_6_tgz" | sha256sum -c -' ]
+       - [ 'wget', 'https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz', '-O', '{root}/var/cache/nodeup/sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8  sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz" | sha256sum -c -' ]
 
        # Unlike earlier images, we no longer preinstall docker, instead we try to prepopulate the download cache.
        # Preinstalling docker caused problems with the iptables/nftables transition, also with containerd vs docker skew.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.18-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.18-stretch.yml
@@ -148,16 +148,18 @@ plugins:
        # Preload some files to our cache, in the hope we can avoid some downloads
        - [ 'chroot', '{root}', 'mkdir', '-p', '/var/cache/nodeup/archives' ]
 
-       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-19.03.11.tgz', '-O', '{root}/var/cache/nodeup/archives/docker-ce' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/archives; echo "0f4336378f61ed73ed55a356ac19e46699a995f2aff34323ba5874d131548b9e  docker-ce" | sha256sum -c -' ]
-       - [ 'wget', 'https://storage.googleapis.com/cri-containerd-release/cri-containerd-1.2.13.linux-amd64.tar.gz', '-O', '{root}/var/cache/nodeup/archives/containerd.io' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup/archives; echo "92d6ae6c60f6b068652b31811ce23d650ec0f6cc1e618ec9ae23db9321956258  containerd.io" | sha256sum -c -' ]
+       - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-19.03.14.tgz', '-O', '{root}/var/cache/nodeup/sha256:9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847_https___download_docker_com_linux_static_stable_x86_64_docker-19_03_14_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847  sha256:9f1ec28e357a8f18e9561129239caf9c0807d74756e21cc63637c7fdeaafe847_https___download_docker_com_linux_static_stable_x86_64_docker-19_03_14_tgz" | sha256sum -c -' ]
 
-       - [ 'wget', 'https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz', '-O', '{root}/var/cache/nodeup/sha256:994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_6_cni-plugins-linux-amd64-v0_8_6_tgz' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5  sha256:994fbfcdbb2eedcfa87e48d8edb9bb365f4e2747a7e47658482556c12fd9b2f5_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_6_cni-plugins-linux-amd64-v0_8_6_tgz" | sha256sum -c -' ]
+       - [ 'wget', 'https://github.com/containerd/containerd/releases/download/v1.3.9/cri-containerd-cni-1.3.9-linux-amd64.tar.gz', '-O', '{root}/var/cache/nodeup/sha256:96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75_https___github_com_containerd_containerd_releases_download_v1_3_9_cri-containerd-cni-1_3_9-linux-amd64_tar_gz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75  sha256:96663699e0f888fbf232ae6629a367aa7421f6b95044e7ee5d4d4e02841fac75_https___github_com_containerd_containerd_releases_download_v1_3_9_cri-containerd-cni-1_3_9-linux-amd64_tar_gz" | sha256sum -c -' ]
+
+       - [ 'wget', 'https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz', '-O', '{root}/var/cache/nodeup/sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8  sha256:977824932d5667c7a37aa6a3cbba40100a6873e7bd97e83e8be837e3e7afd0a8_https___storage_googleapis_com_k8s-artifacts-cni_release_v0_8_7_cni-plugins-linux-amd64-v0_8_7_tgz" | sha256sum -c -' ]
 
        # Unlike earlier images, we no longer preinstall docker, instead we try to prepopulate the download cache.
        # Preinstalling docker caused problems with the iptables/nftables transition, also with containerd vs docker skew.
+       # Issue: https://github.com/kubernetes/kops/issues/10122
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)


### PR DESCRIPTION
CNI 0.8.7, CRI 1.3.9 and docker 19.03.14 are the versions generally
used now.