### PR TITLE
kube-deploy: set default instance type to m4.large

### DIFF
--- a/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
+++ b/images/kube-deploy/imagebuilder/pkg/imagebuilder/config.go
@@ -58,7 +58,7 @@ type AWSConfig struct {
 
 func (c *AWSConfig) InitDefaults(region string) {
 	c.Config.InitDefaults()
-	c.InstanceType = "m3.medium"
+	c.InstanceType = "m4.large"
 
 	if region == "" {
 		region = "us-east-1"


### PR DESCRIPTION
Available more broadly at this point, and higher performance.

We can't currently use the NVME instances because of mount paths;
likely not worth fixing for the stretch builder (we have a different
builder we can use for buster & beyond).