### PR TITLE
Switch Ubuntu to boot from floppy

### DIFF
--- a/images/capi/packer/ova/centos-7.json
+++ b/images/capi/packer/ova/centos-7.json
@@ -6,10 +6,12 @@
   "os_display_name": "CentOS 7",
   "guest_os_type": "centos7-64",
   "vsphere_guest_os_type": "centos7_64Guest",
-  "iso_url": "https://mirrors.edge.kernel.org/centos/7.8.2003/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso",
-  "iso_checksum": "659691c28a0e672558b003d223f83938f254b39875ee7559d1a4a14c79173193",
+  "iso_url": "https://mirrors.edge.kernel.org/centos/7.9.2009/isos/x86_64/CentOS-7-x86_64-Minimal-2009.iso",
+  "iso_checksum": "07b94e6b1a0b0260b94c83d6bb76b26bf7a310dc78d7a9c7432809fb9bc6194a",
   "iso_checksum_type": "sha256",
+  "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
   "boot_command_prefix": "<tab> text ks=",
+  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
   "boot_command_suffix": "/7/ks.cfg<enter><wait>",
   "shutdown_command": "sys-unconfig"
 }

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -83,7 +83,6 @@
       "disk_type_id": "{{user `disk_type_id`}}",
       "disk_adapter_type": "scsi",
       "boot_wait": "{{user `boot_wait`}}",
-      "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "guest_os_type": "{{user `guest_os_type`}}",
       "headless": "{{user `headless`}}",
       "iso_url": "{{user `iso_url`}}",
@@ -92,9 +91,11 @@
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
+      "http_directory": "{{ user `http_directory`}}",
+      "floppy_dirs": "{{ user `floppy_dirs`}}",
       "boot_command": [
         "{{user `boot_command_prefix`}}",
-        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_media_path`}}",
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c '{{user `shutdown_command`}}'",
@@ -127,7 +128,6 @@
       "disk_type_id": "{{user `disk_type_id`}}",
       "disk_adapter_type": "scsi",
       "boot_wait": "{{user `boot_wait`}}",
-      "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "guest_os_type": "{{user `guest_os_type`}}",
       "headless": "{{user `headless`}}",
       "iso_url": "{{user `iso_url`}}",
@@ -136,9 +136,11 @@
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
+      "http_directory": "{{ user `http_directory`}}",
+      "floppy_dirs": "{{ user `floppy_dirs`}}",
       "boot_command": [
         "{{user `boot_command_prefix`}}",
-        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_media_path`}}",
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
@@ -185,7 +187,6 @@
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
       "boot_wait": "{{user `boot_wait`}}",
-      "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "iso_urls": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
       "communicator": "ssh",
@@ -199,9 +200,11 @@
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
+      "http_directory": "{{ user `http_directory`}}",
+      "floppy_dirs": "{{ user `floppy_dirs`}}",
       "boot_command": [
         "{{user `boot_command_prefix`}}",
-        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_media_path`}}",
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c '{{user `shutdown_command`}}'",
@@ -238,7 +241,6 @@
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
       "boot_wait": "{{user `boot_wait`}}",
-      "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
       "iso_urls": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
       "communicator": "ssh",
@@ -251,9 +253,11 @@
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
+      "http_directory": "{{ user `http_directory`}}",
+      "floppy_dirs": "{{ user `floppy_dirs`}}",
       "boot_command": [
         "{{user `boot_command_prefix`}}",
-        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_media_path`}}",
         "{{user `boot_command_suffix`}}"
       ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",

--- a/images/capi/packer/ova/photon-3.json
+++ b/images/capi/packer/ova/photon-3.json
@@ -9,7 +9,9 @@
   "iso_url": "https://packages.vmware.com/photon/3.0/Rev3/iso/photon-minimal-3.0-a383732.iso",
   "iso_checksum": "c2883a42e402a2330d9c39b4d1e071cf9b3b5898",
   "iso_checksum_type": "sha1",
+  "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
   "boot_command_prefix": "<esc><wait> vmlinuz initrd=initrd.img root/dev/ram0 loglevel=3 photon.media=cdrom ks=",
+  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
   "boot_command_suffix": "/3/ks.json<enter><wait>",
   "shutdown_command": "shutdown now"
 }

--- a/images/capi/packer/ova/rhel-7.json
+++ b/images/capi/packer/ova/rhel-7.json
@@ -9,7 +9,9 @@
   "iso_url": "file:///rhel-server-7.7-x86_64-dvd.iso",
   "iso_checksum": "88b42e934c24af65e78e09f0993e4dded128d74ec0af30b89b3cdc02ec48f028",
   "iso_checksum_type": "sha256",
+  "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
   "boot_command_prefix": "<tab><wait><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>quiet text inst.ks=",
+  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
   "boot_command_suffix": "/7/ks.cfg<enter><wait>",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
   "shutdown_command": "sys-unconfig"

--- a/images/capi/packer/ova/ubuntu-1804.json
+++ b/images/capi/packer/ova/ubuntu-1804.json
@@ -9,7 +9,9 @@
   "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.5-server-amd64.iso",
   "iso_checksum": "8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
   "iso_checksum_type": "sha256",
-  "boot_command_prefix": "<enter><wait><f6><wait><esc><wait><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
+  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+  "boot_command_prefix": "<enter><wait><f6><wait><esc><wait><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/file=",
+  "boot_media_path": "/media/HTTP",
   "boot_command_suffix": "/18.04/preseed.cfg -- <enter>",
   "shutdown_command": "shutdown -P now"
 }

--- a/images/capi/packer/ova/ubuntu-2004.json
+++ b/images/capi/packer/ova/ubuntu-2004.json
@@ -9,7 +9,9 @@
   "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
   "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
   "iso_checksum_type": "sha256",
-  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
+  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/file=",
+  "boot_media_path": "/media/HTTP",
   "boot_command_suffix": "/20.04/preseed.cfg -- <wait><enter><wait>",
   "shutdown_command": "shutdown -P now"
 }


### PR DESCRIPTION
Choose between floppy & http boot methods based on OS

What this PR does / why we need it:
Booting from HTTP does not work in CI env since remote VM is unable to reach the packer runner. So switching the boot method to floppy in supported OSes (Ubuntu 18.04 & Ubuntu 20.04)

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers
- Now boot method can chosen per OS ( HTTP -> `Photon, RHEL-7, Centos-7`  FLOPPY -> `Ubuntu 18.04, 20.04`)
- Changed for `vsphere` & `vmware-iso` builders
- Updated Centos ISO path. 


/assign @codenrhoden 
CC: @MaxRink 