### PR TITLE
Added a variable to configure hard disk size

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -29,7 +29,6 @@ import subprocess
 from string import Template
 import tarfile
 
-
 def main():
     parser = argparse.ArgumentParser(
         description="Builds an OVA using the artifacts from a Packer build")
@@ -134,7 +133,7 @@ def main():
         'OS_VERSION': OS_id_map[build_data['guest_os_type']]['version'],
         'IB_VERSION': build_data['ib_version'],
         'DISK_NAME': vmdk['stream_name'],
-        'DISK_SIZE': "20",
+        'DISK_SIZE': build_data['disk_size'],
         'POPULATED_DISK_SIZE': vmdk['size'],
         'STREAM_DISK_SIZE': vmdk['stream_size'],
         'VMX_VERSION': args.vmx_version,
@@ -175,9 +174,7 @@ def main():
                 for k, v in custom_properties.items():
                     data['PROPERTIES'] = data['PROPERTIES'] + f'''      <Property ovf:userConfigurable="false" ovf:value="{v}" ovf:type="string" ovf:key="{k}"/>\n'''
 
-        # windows nodes use nested virtualisation and require a larger hard drive
         if "windows" in OS_id_map[build_data['guest_os_type']]['type']:
-            data['DISK_SIZE'] = "80"
             if build_data['disable_hypervisor'] != "true":
                 data['NESTEDHV'] = "true"
     elif args.haproxy:

--- a/images/capi/hack/ovf_template.xml
+++ b/images/capi/hack/ovf_template.xml
@@ -5,7 +5,7 @@
   </References>
   <DiskSection>
     <Info>Virtual disk information</Info>
-    <Disk ovf:capacity="${DISK_SIZE}" ovf:capacityAllocationUnits="byte * 2^30" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:populatedSize="${POPULATED_DISK_SIZE}"/>
+    <Disk ovf:capacity="${DISK_SIZE}" ovf:capacityAllocationUnits="byte * 2^20" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:populatedSize="${POPULATED_DISK_SIZE}"/>
   </DiskSection>
   <NetworkSection>
     <Info>The list of logical networks</Info>

--- a/images/capi/packer/ova/packer-haproxy.json
+++ b/images/capi/packer/ova/packer-haproxy.json
@@ -14,7 +14,8 @@
     "output_dir": "./output/{{user `build_version`}}",
     "username": "",
     "vcenter_server": "",
-    "vsphere_guest_os_type": null
+    "vsphere_guest_os_type": null,
+    "disk_size": "20480"
   },
   "builders": [
     {
@@ -27,7 +28,7 @@
       "cpus": 1,
       "cores": 1,
       "memory": 2048,
-      "disk_size": 20480,
+      "disk_size": "{{user `disk_size`}}",
       "disk_type_id": "{{user `disk_type_id`}}",
       "boot_wait": "{{user `boot_wait`}}",
       "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
@@ -102,7 +103,7 @@
 
       "storage": [
         {
-          "disk_size": 20480,
+          "disk_size": "{{user `disk_size`}}",
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
@@ -152,7 +153,8 @@
         "ib_version": "{{user `ib_version`}}",
         "vsphere_guest_os_type": "{{user `vsphere_guest_os_type`}}",
         "dataplaneapi_version": "v{{user `dataplaneapi_version`}}",
-        "os_name": "{{user `os_display_name`}}"
+        "os_name": "{{user `os_display_name`}}",
+        "disk_size": "{{user `disk_size`}}"
       }
     },
     {

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -38,7 +38,8 @@
     "base_output_dir": "./output/{{user `base_build_version`}}",
     "username": "",
     "vcenter_server": "",
-    "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}"
+    "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}", 
+    "disk_size": "20480"
   },
   "builders": [
     {
@@ -80,7 +81,7 @@
       "cpus": 1,
       "cores": 1,
       "memory": 2048,
-      "disk_size": 20480,
+      "disk_size": "{{user `disk_size`}}",
       "disk_type_id": "{{user `disk_type_id`}}",
       "disk_adapter_type": "scsi",
       "boot_wait": "{{user `boot_wait`}}",
@@ -125,7 +126,7 @@
       "cpus": 1,
       "cores": 1,
       "memory": 2048,
-      "disk_size": 20480,
+      "disk_size": "{{user `disk_size`}}",
       "disk_type_id": "{{user `disk_type_id`}}",
       "disk_adapter_type": "scsi",
       "boot_wait": "{{user `boot_wait`}}",
@@ -197,7 +198,7 @@
       "ssh_clear_authorized_keys": "false",
       "storage": [
         {
-          "disk_size": 20480,
+          "disk_size": "{{user `disk_size`}}",
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
@@ -250,7 +251,7 @@
       "ssh_timeout": "4h",
       "storage": [
         {
-          "disk_size": 20480,
+          "disk_size": "{{user `disk_size`}}",
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
@@ -398,7 +399,8 @@
         "kubernetes_semver": "{{user `kubernetes_semver`}}",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "os_name": "{{user `os_display_name`}}",
-        "kubernetes_typed_version": "{{user `kubernetes_typed_version`}}"
+        "kubernetes_typed_version": "{{user `kubernetes_typed_version`}}",
+        "disk_size": "{{user `disk_size`}}"
       }
     },
     {

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -16,6 +16,7 @@
     "containerd_url": "",
     "containerd_version": null,
     "disable_hypervisor": null,
+    "disk_size": "81920",
     "ib_version": "{{env `IB_VERSION`}}",
     "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/binaries/node/windows/{{user `kubernetes_goarch`}}",
     "kubernetes_http_package_url": "",
@@ -40,7 +41,7 @@
       "version": "{{user `vmx_version`}}",
       "cpus": 2,
       "memory": 4096,
-      "disk_size": 81920,
+      "disk_size": "{{user `disk_size`}}",
       "disk_type_id": "{{user `disk_type_id`}}",
       "disk_adapter_type": "scsi",
       "boot_wait": "{{user `boot_wait`}}",
@@ -118,7 +119,7 @@
 
       "storage": [
         {
-          "disk_size": 81920,
+          "disk_size": "{{user `disk_size`}}",
           "disk_thin_provisioned": "{{user `disk_thin_provisioned`}}"
         }
       ],
@@ -180,7 +181,8 @@
         "kubernetes_semver": "{{user `kubernetes_semver`}}",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
         "os_name": "{{user `os_display_name`}}",
-        "disable_hypervisor": "{{user `disable_hypervisor`}}"
+        "disable_hypervisor": "{{user `disable_hypervisor`}}",
+        "disk_size": "{{user `disk_size`}}"
       }
     },
     {


### PR DESCRIPTION
What this PR does / why we need it:
Add the ability to set a variable to define the disk size of ova files.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #428 

**Additional context**
I have set defaults to the initial values 20GB for Linux and 80GB for Windows but this can be overridden using PACKER_FLAGS=-var=disk_size="40926" (size is in MB)