### PR TITLE
Add image builder version to Azure metadata

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -17,6 +17,7 @@
     "cloudbase_plugins_unattend": "cloudbaseinit.plugins.common.mtu.MTUPlugin",
     "containerd_version": null,
     "containerd_url": "",
+    "ib_version": "{{env `IB_VERSION`}}",
     "image_offer": null,
     "image_publisher": null,
     "image_sku": null,
@@ -26,7 +27,7 @@
     "nssm_url": null,
     "prepull": null,
     "subscription_id": null,
-    "vm_size": "", 
+    "vm_size": "",
     "windows_updates_kbs": null,
     "windows_service_manager": null,
     "wins_url": "https://github.com/rancher/wins/releases/download/v{{user `wins_version`}}/wins.exe"
@@ -58,8 +59,9 @@
         "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
         "creationTimestamp": "{{isotime \"2006-01-02T15:04:05Z\"}}",
-        "os_version": "{{user `image_sku`}}",
-        "kubernetes_version": "{{user `kubernetes_semver`}}"
+        "image_builder_version": "{{user `ib_version`}}",
+        "kubernetes_version": "{{user `kubernetes_semver`}}",
+        "os_version": "{{user `image_sku`}}"
       }
     },
     {
@@ -94,8 +96,9 @@
         "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
         "creationTimestamp": "{{isotime \"2006-01-02T15:04:05Z\"}}",
-        "os_version": "{{user `image_sku`}}",
-        "kubernetes_version": "{{user `kubernetes_semver`}}"
+        "image_builder_version": "{{user `ib_version`}}",
+        "kubernetes_version": "{{user `kubernetes_semver`}}",
+        "os_version": "{{user `image_sku`}}"
       }
     }
   ],

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -16,6 +16,7 @@
     "distribution_release": null,
     "distribution_version": null,
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "ib_version": "{{env `IB_VERSION`}}",
     "image_offer": null,
     "image_publisher": null,
     "image_sku": null,
@@ -68,6 +69,7 @@
         "distribution": "{{user `distribution`}}",
         "distribution_release": "{{user `distribution_release`}}",
         "distribution_version": "{{user `distribution_version`}}",
+        "image_builder_version": "{{user `ib_version`}}",
         "kubernetes_version": "{{user `kubernetes_semver`}}"
       }
     },
@@ -102,6 +104,7 @@
         "distribution": "{{user `distribution`}}",
         "distribution_release": "{{user `distribution_release`}}",
         "distribution_version": "{{user `distribution_version`}}",
+        "image_builder_version": "{{user `ib_version`}}",
         "kubernetes_version": "{{user `kubernetes_semver`}}"
       }
     }

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -15,6 +15,7 @@
     "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "",
+    "ib_version": "{{env `IB_VERSION`}}",
     "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/binaries/node/windows/{{user `kubernetes_goarch`}}",
     "kubernetes_http_package_url": "",
     "manifest_output": "manifest.json",
@@ -46,7 +47,7 @@
       "iso_urls": [
         "{{user `os_iso_url`}}"
       ],
-      "iso_checksum": "{{user `iso_checksum` }}",  
+      "iso_checksum": "{{user `iso_checksum` }}",
       "floppy_files": [
         "./packer/ova/windows/{{user `distro_name`}}/autounattend.xml",
         "./packer/ova/windows/disable-network-discovery.cmd",
@@ -66,7 +67,7 @@
       "vmx_data": {
         "numvcpus": "2",
         "scsi0.virtualDev": "pvscsi"
-      } 
+      }
     },
     {
       "type": "vsphere-iso",
@@ -96,7 +97,7 @@
       "RAM": 8192,
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "guest_os_type": "{{user `vsphere_guest_os_type`}}",
-      "firmware": "bios",  
+      "firmware": "bios",
       "boot_wait": "{{user `boot_wait`}}",
       "iso_paths": [
         "{{user `os_iso_path`}}",
@@ -129,7 +130,7 @@
         "./packer/ova/windows/disable-winrm.ps1",
         "./packer/ova/windows/enable-winrm.ps1",
         "./packer/ova/windows/install-vm-tools.cmd",
-        "./packer/ova/windows/sysprep.ps1"  
+        "./packer/ova/windows/sysprep.ps1"
       ],
       "floppy_dirs": [
         "./packer/ova/windows/pvscsi"


### PR DESCRIPTION
What this PR does / why we need it:
After creating the VM image, add a tag that has the version of the image
builder that was used to create the image. This was already present for
AMIs and OVAs, this patch adds it for Azure as well.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**

This also fixes an error for Windows node OVAs where the version would have been blank.

/assign @CecileRobertMichon 