### PR TITLE
docs: add proper path for make deps-qemu

### DIFF
--- a/docs/book/src/capi/providers/openstack.md
+++ b/docs/book/src/capi/providers/openstack.md
@@ -37,6 +37,7 @@ The build [prerequisites](../capi.md#prerequisites) for using `image-builder` fo
 building qemu images are managed by running:
 
 ```bash
+cd image-builder/images/capi
 make deps-qemu
 ```
 


### PR DESCRIPTION
`make deps-qemu` has to be run in folder image-builder/images/capi.
