### PR TITLE
capi: fix curl and URLs to Flatcar Container Linux

### DIFF
--- a/images/capi/README-flatcar.md
+++ b/images/capi/README-flatcar.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This is a Cluster API image builder for [Flatcar Container Linux](https://www.flatcar-linux.org).
+This is a Cluster API image builder for [Flatcar Container Linux](https://kinvolk.io/flatcar-container-linux).
 
 On the Packer side it includes `packer/qemu/flatcar.json` and `packer/qemu/packer.json`.
 In `packer/config/` it also includes some other JSON files with configuration for
@@ -47,7 +47,7 @@ Start a new build with
 
 Flatcar Container Linux maintains four distinct
 channels: `alpha`, `beta`, `stable`, and `edge`. For details please refer to
-the [releases page](https://www.flatcar-linux.org/releases/).
+the [releases page](https://kinvolk.io/flatcar-container-linux/releases/).
 
 The build script will default to the latest release of the `stable` channel.
 

--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -18,8 +18,8 @@ usage() {
 check_for_release() {
     channel="$1"
     release="$2"
-    curl -s \
-         "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
+    curl -L -s \
+         "https://kinvolk.io/flatcar-container-linux/releases-json/releases-$channel.json" \
         | jq -r 'to_entries[] | "\(.key)"' \
         | grep -q "$release"
 }

--- a/images/capi/hack/image-grok-latest-flatcar-version.sh
+++ b/images/capi/hack/image-grok-latest-flatcar-version.sh
@@ -4,8 +4,8 @@
 
 channel="$1"
 
-curl -s \
-     "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
+curl -L -s \
+     "https://kinvolk.io/flatcar-container-linux/releases-json/releases-$channel.json" \
     | jq -r 'to_entries[] | "\(.key)"' \
     | grep -v "current" \
     | sort --version-sort \


### PR DESCRIPTION
Recently the website of Flatcar Container Linux has moved to https://kinvolk.io/flatcar-container-linux/, and the old URL https://www.flatcar-linux.org/ gets redirected to the new URL.

We need to update the old URLs to the new ones.
We should also add `-L` to `curl` commands, so that the redirects get properly handled in the future.
