### PR TITLE
cluster-api-provider-digitalocean: Update OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -48,7 +48,6 @@ aliases:
     - cpanato
     - MorrisLaw
     - prksu
-    - xmudrii
   cluster-api-openstack-maintainers:
     - chaosaffe
     - chrigl

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -48,6 +48,7 @@ aliases:
     - cpanato
     - MorrisLaw
     - prksu
+    - timoreimann
   cluster-api-openstack-maintainers:
     - chaosaffe
     - chrigl


### PR DESCRIPTION
What this PR does / why we need it:

As per https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/234:

* Remove Marko Mudrinić (@xmudrii) from OWNERS
* Add Timo Reimann (@timoreimann) to OWNERS

/assign @cpanato @MorrisLaw @prksu @timoreimann
