### PR TITLE
Use OVFTool to create OVAs

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -87,6 +87,7 @@ deps-ova:
 	hack/ensure-ansible-windows.sh
 	hack/ensure-packer.sh
 	hack/ensure-goss.sh
+	hack/ensure-ovftool.sh
 
 .PHONY: deps-qemu
 deps-qemu: ## Installs/checks dependencies for QEMU builds

--- a/images/capi/hack/ensure-ovftool.sh
+++ b/images/capi/hack/ensure-ovftool.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+source hack/utils.sh
+
+if command -v ovftool >/dev/null 2>&1; then exit 0; fi
+
+echo "ovftool must be present to build OVAs. If already installed" >&2
+echo "make sure to add it to the PATH env var. If not installed, please" >&2
+echo "install latest from https://code.vmware.com/tool/ovf." >&2
+exit 1


### PR DESCRIPTION

What this PR does / why we need it:
This patch is a major change for users who are building OVAs. With
recent versions of vSphere and Fusion (and likely Workstation, but that
was untested), the OVAs created by image-builder were no longer
importable from local disk (but oddly the worked if referenced as a
URL). The root cause of this remains a bit of a mystery -- the problem
lies with the OVA file, not the OVF. A problematic OVA could be
untarred, then the OVF used as a source for import and the import was
successful.

It has long been discussed and disired that ovftool should be used to
create the OVA instead of using `tarfile` from Python. These recent
errors are reason enough to make the switch. Using ovftool has the
advantage of validating the OVF file itself as well, such that if there
are any issues with the file then the OVA will not get created.

Installing ovftool requires accepting a EULA and must be installed by a
user on their system. The `deps-ova` target has been updated to reflect
this, and directs users where to download from.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Once the container docs (#495), we will need to update them clarifying that OVA builds can only happen from Linux hosts, and show how to map in the `ovftool` binary since we can't distribute the tool in the container image.

/assign @kkeshavamurthy 
/cc @perithompson 