### PR TITLE
No longer install cloud-initramfs-growroot Ubuntu

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -23,7 +23,6 @@
     - cloud-guest-utils
     - cloud-initramfs-copymods
     - cloud-initramfs-dyn-netconf
-    - cloud-initramfs-growroot
   when: ansible_os_family == "Debian"
 
 - name: Install cloud-init packages

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -159,7 +159,6 @@ ubuntu:
       cloud-guest-utils:
       cloud-initramfs-copymods:
       cloud-initramfs-dyn-netconf:
-      cloud-initramfs-growroot:
 photon:
   common-kernel-param:
     net.ipv4.tcp_limit_output_bytes:


### PR DESCRIPTION
What this PR does / why we need it:
This package is not needed with kernels > 3.18, and cloud-init will
handle growing the root partition and filesystem. For Ubuntu 20.04
specifically, it was observed that recent images would hang on bootup
when the initramfs tried to grow the root partition. Leaving it to
cloud-init proceeds as expected.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #464 

**Additional context**
This was a bit weird to track down. I was able to recreate it locally with images built with Fusion, and saw the same behavior as described in #464. There is very little info out there about other people running into similar problems, but I did eventually stumble on https://bugs.launchpad.net/cloud-images/+bug/1678669/comments/1, where Scott (who maintains a lot of cloud-init related items) mentioned that the referenced package is not even needed for kernels > 3.18. Ubuntu 18.04 is currently installing a 4.15 kernel, and 20.04 is 5+, so I tried this out with both distros and they worked fine!

/assign @kkeshavamurthy 
/cc  @farodin91 @darc1