### PR TITLE
Windows defender exclusions and missing ova generation fixes

### DIFF
--- a/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
+++ b/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
@@ -75,6 +75,11 @@
     containerd.exe --register-service
   when: containerd_service.exists == false
 
+- name: Create Windows Defender Exclusions
+  win_shell: |
+    Add-MpPreference -ExclusionProcess "$env:ProgramFiles\containerd\containerd.exe"
+    Add-MpPreference -ExclusionProcess "$env:ProgramFiles\containerd\ctr.exe"
+
 - name: Ensure Containerd Service is running
   win_service:
     name: containerd

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -1,33 +1,33 @@
 {
   "variables": {
-    "additional_prepull_images": null,
     "additional_debug_files": null,
+    "additional_prepull_images": null,
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
     "build_name": null,
-    "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "build_timestamp": "{{timestamp}}",
+    "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/{{user `cloudbase_init_version`}}/CloudbaseInitSetup_{{user `cloudbase_init_version` | replace_all `.` `_` }}_x64.msi",
     "cloudbase_metadata_services": "cloudbaseinit.metadata.services.vmwareguestinfoservice.VMwareGuestInfoService",
     "cloudbase_metadata_services_unattend": "cloudbaseinit.metadata.services.vmwareguestinfoservice.VMwareGuestInfoService",
     "cloudbase_plugins": "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin, cloudbaseinit.plugins.common.mtu.MTUPlugin, cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin,  cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin, cloudbaseinit.plugins.common.userdata.UserDataPlugin, cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin, cloudbaseinit.plugins.windows.createuser.CreateUserPlugin, cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin",
     "cloudbase_plugins_unattend": "cloudbaseinit.plugins.common.mtu.MTUPlugin",
-    "containerd_version": null,
     "containerd_sha256": null,
     "containerd_url": "",
+    "containerd_version": null,
+    "disable_hypervisor": null,
     "ib_version": "{{env `IB_VERSION`}}",
     "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/binaries/node/windows/{{user `kubernetes_goarch`}}",
     "kubernetes_http_package_url": "",
     "manifest_output": "manifest.json",
+    "netbios_host_name_compatibility": null,
     "nssm_url": null,
     "output_dir": "./output/{{user `build_version`}}",
     "prepull": null,
     "windows_service_manager": null,
-    "windows_updates_kbs": null,
     "windows_updates_categories": null,
-    "wins_url": "https://github.com/rancher/wins/releases/download/v{{user `wins_version`}}/wins.exe",
-    "disable_hypervisor" : null,
-    "netbios_host_name_compatibility": null
+    "windows_updates_kbs": null,
+    "wins_url": "https://github.com/rancher/wins/releases/download/v{{user `wins_version`}}/wins.exe"
   },
   "builders": [
     {
@@ -49,7 +49,7 @@
       ],
       "iso_checksum": "{{user `iso_checksum` }}",
       "floppy_files": [
-        "./packer/ova/windows/{{user `distro_name`}}/autounattend.xml",
+        "./packer/ova/windows/{{user `build_name`}}/autounattend.xml",
         "./packer/ova/windows/disable-network-discovery.cmd",
         "./packer/ova/windows/disable-winrm.ps1",
         "./packer/ova/windows/enable-winrm.ps1",
@@ -125,7 +125,7 @@
 
 
       "floppy_files": [
-        "./packer/ova/windows/{{user `distro_name`}}/autounattend.xml",
+        "./packer/ova/windows/{{user `build_name`}}/autounattend.xml",
         "./packer/ova/windows/disable-network-discovery.cmd",
         "./packer/ova/windows/disable-winrm.ps1",
         "./packer/ova/windows/enable-winrm.ps1",
@@ -164,6 +164,9 @@
       "output": "{{user `output_dir`}}/packer-manifest.json",
       "strip_path": true,
       "custom_data": {
+        "distro_name": "{{user `distro_name` }}",
+        "distro_version": "{{user `distro_version` }}",
+        "distro_arch": "{{user `distro_arch` }}",
         "build_name": "{{user `build_name`}}",
         "build_timestamp": "{{user `build_timestamp`}}",
         "build_date": "{{isotime}}",
@@ -187,7 +190,7 @@
         "cd {{user `output_dir`}}",
         "tar xf {{user `build_version`}}.ova",
         "rm {{user `build_version`}}.ova",
-        "../../hack/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk1.vmdk"
+        "../../hack/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --ovf_template ../../hack/ovf_template.xml  --vmdk_file {{user `build_version`}}-disk1.vmdk"
       ]
     },
     {
@@ -195,14 +198,14 @@
       "type": "shell-local",
       "inline": [
         "cd {{user `output_dir`}}",
-        "../../hack/image-build-ova.py --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --vmdk_file {{user `build_version`}}-disk-0.vmdk"
+        "../../hack/image-build-ova.py --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --ovf_template ../../hack/ovf_template.xml --vmdk_file {{user `build_version`}}-disk-0.vmdk"
       ]
     },
     {
       "name": "local",
       "type": "shell-local",
       "inline": [
-        "./hack/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt {{user `output_dir`}}",
+        "./hack/image-build-ova.py --stream_vmdk --node --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt --ovf_template ./hack/ovf_template.xml {{user `output_dir`}}",
         "./hack/image-post-create-config.sh {{user `output_dir`}}"
       ]
     }

--- a/images/capi/packer/ova/windows-2004.json
+++ b/images/capi/packer/ova/windows-2004.json
@@ -1,6 +1,8 @@
 {
   "build_name": "windows-2004",
-  "distro_name": "windows-2004",
+  "distro_name": "windows",
+  "distro_version": "2004",
+  "distro_arch": "amd64",
   "os_display_name": "Windows Server 2004",
   "guest_os_type": "Windows2004Server-64",
   "vsphere_guest_os_type": "windows9Server64Guest",

--- a/images/capi/packer/ova/windows-2019.json
+++ b/images/capi/packer/ova/windows-2019.json
@@ -1,6 +1,8 @@
 {
   "build_name": "windows-2019",
-  "distro_name": "windows-2019",
+  "distro_name": "windows",
+  "distro_version": "2019",
+  "distro_arch": "amd64",
   "os_display_name": "Windows Server 2019",
   "guest_os_type": "Windows2019Server-64",
   "vsphere_guest_os_type": "windows9Server64Guest",


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds a required Windows Defender exclusions for containerd.exe and ctr.exe and also fixes some missing updates from recent PRs by registering a distro_name and version and uses the shared OVF template

Which issue(s) this PR fixes #508

**Additional context**
