### PR TITLE
Makes the kubernetes typed version configurable

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -154,7 +154,8 @@ def main():
         data['PRODUCT'] = "%s and Kubernetes %s" % (build_data['os_name'], build_data['kubernetes_semver'])
         data['ANNOTATION'] = "Cluster API vSphere image - %s - %s" % (data['PRODUCT'], capv_url)
         data['WAKEONLANENABLED'] = "false"
-        data['TYPED_VERSION'] = "kube-%s" % (build_data['kubernetes_semver'])
+        data['TYPED_VERSION'] = build_data['kubernetes_typed_version']
+
         data['PROPERTIES'] = Template('''
       <Property ovf:userConfigurable="false" ovf:value="${DISTRO_NAME}" ovf:type="string" ovf:key="DISTRO_NAME"/>
       <Property ovf:userConfigurable="false" ovf:value="${DISTRO_VERSION}" ovf:type="string" ovf:key="DISTRO_VERSION"/>

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -37,7 +37,8 @@
     "output_dir": "./output/{{user `build_version`}}",
     "base_output_dir": "./output/{{user `base_build_version`}}",
     "username": "",
-    "vcenter_server": ""
+    "vcenter_server": "",
+    "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}"
   },
   "builders": [
     {
@@ -396,7 +397,8 @@
         "kubernetes_cni_semver": "{{user `kubernetes_cni_semver`}}",
         "kubernetes_semver": "{{user `kubernetes_semver`}}",
         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
-        "os_name": "{{user `os_display_name`}}"
+        "os_name": "{{user `os_display_name`}}",
+        "kubernetes_typed_version": "{{user `kubernetes_typed_version`}}"
       }
     },
     {


### PR DESCRIPTION
* The kubernetes typed version seen in the created ovf as
  the FullVersion and Version xml tags can now be set
  on the command line in packer variable files. The original
  "kube" prefix logic still remains for backwards compatibility 

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers