### PR TITLE
Brings back mf file generation for vsphere

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -196,6 +196,9 @@ def main():
     # Create OVF
     create_ovf(ovf, data, ovf_template)
 
+    # Create the OVA manifest
+    create_ova_manifest(ova_manifest, [ovf, vmdk['stream_name']])
+
     # Create the OVA.
     create_ova(ova, ovf)
 
@@ -239,6 +242,11 @@ def get_vmdk_files(inlist):
             outlist.append(f)
     return outlist
 
+def create_ova_manifest(path, infile_paths):
+    print("image-build-ova: create ova manifest %s" % path)
+    with open(path, 'w') as f:
+        for i in infile_paths:
+            f.write('SHA256(%s)= %s\n' % (i, sha256(i)))
 
 def stream_optimize_vmdk_files(inlist):
     for f in inlist:


### PR DESCRIPTION
* Not sure if this was intentional but image building for vsphere
  no longer generates an mf file starting from this commit 064ade4491659be11b731d3a8039225b21b1c2e4

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers