### PR TITLE
Allow overriding the instance type used during the AMI build process.

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -10,12 +10,13 @@
     "aws_profile": "",
     "aws_region": "us-east-1",
     "aws_secret_key": "",
-    "containerd_version": null,
+    "build_timestamp": "{{timestamp}}",
+    "builder_instance_type": "t3.small",
     "containerd_sha256": null,
     "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
-    "crictl_version": null,
+    "containerd_version": null,
     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
-    "build_timestamp": "{{timestamp}}",
+    "crictl_version": null,
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "iam_instance_profile": "",
@@ -44,9 +45,8 @@
     "snapshot_groups": "all",
     "snapshot_users": "",
     "subnet_id": "",
-    "vpc_id": "",
     "volume_size": "8",
-    "builder_instance_type": "t3.small"
+    "vpc_id": ""
   },
   "builders": [
     {

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -45,13 +45,14 @@
     "snapshot_users": "",
     "subnet_id": "",
     "vpc_id": "",
-    "volume_size": "8"
+    "volume_size": "8",
+    "builder_instance_type": "t3.small"
   },
   "builders": [
     {
       "name": "{{user `build_name`}}",
       "type": "amazon-ebs",
-      "instance_type": "t3.small",
+      "instance_type": "{{user `builder_instance_type`}}",
       "source_ami": "{{user `source_ami`}}",
       "source_ami_filter": {
         "filters": {


### PR DESCRIPTION
What this PR does / why we need it:

In the past we had an issue where this was hardcoded to t2.small and regions that didn't have the t2 generation would fail.  This goes one step further and actually allows changing the instance type used for building.  This is important for AMI that might need special underlying hardware on AWS that fail when that hardware is not present during image building -- for example GPU enabled instances.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers