### PR TITLE
Remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,7 +41,6 @@ aliases:
     - gab-satchi
     - justinsb
     - krousey
-    - maisem
     - rsmitty
     - vincepri
   cluster-api-digitalocean-maintainers:


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/351
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months), this commit removes maisem from the capg maintainer
alias.

/kind cleanup