### PR TITLE
Update CAPZ maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,10 +30,8 @@ aliases:
     - rudoi
     - vincepri
   cluster-api-azure-maintainers:
-    - awesomenix
     - CecileRobertMichon
     - devigned
-    - justaugustus
     - nader-ziada
   cluster-api-gcp-maintainers:
     - cpanato


### PR DESCRIPTION
What this PR does / why we need it: update capz maintainer aliases following update to OWNERS file in the CAPZ repo: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/OWNERS_ALIASES

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers