### PR TITLE
ova: use tar by default to create OVA

### DIFF
--- a/docs/book/src/capi/providers/vsphere.md
+++ b/docs/book/src/capi/providers/vsphere.md
@@ -21,9 +21,9 @@ The `esxi` builder supports building against a remote VMware ESX server with [sp
 The `vsphere` builder supports building against a remote VMware vSphere using standard API.
 
 ### vmware-vmx builder
-During the dev process it's uncommon for the base OS image to change, but the image building process builds the base image from the ISO every time and thus adding a significant amount of time to the build process. 
+During the dev process it's uncommon for the base OS image to change, but the image building process builds the base image from the ISO every time and thus adding a significant amount of time to the build process.
 
-To reduce the image building times during development, one can use the `build-node-ova-local-base-<OS>` target to build the base image from the ISO. By setting `source_path` variable in `vmx.json` to the `*.vmx` file from the output, it can then be re-used with the `build-node-ova-local-vmx-<OS>` build target to speed up the process. 
+To reduce the image building times during development, one can use the `build-node-ova-local-base-<OS>` target to build the base image from the ISO. By setting `source_path` variable in `vmx.json` to the `*.vmx` file from the output, it can then be re-used with the `build-node-ova-local-vmx-<OS>` build target to speed up the process.
 
 
 ### vsphere-clone builder
@@ -62,6 +62,16 @@ make deps-ova
 ```
 
 From the `images/capi` directory, run `make build-node-ova-<hypervisor>-<OS>`, where `<hypervisor>` is your target hypervisor (`local`, `vsphere` or `esx`) and `<OS>` is the desired operating system. The available choices are listed via `make help`.
+
+### OVA Creation
+
+When the final OVA is created, there are two methods that can be used for creation. By default, an OVF file is created, the manifest is created using SHA256 sums of the OVF and VMDK, and then `tar` is used to create an OVA containing the OVF, VMDK, and the manifest.
+
+Optionally, `ovftool` can be used to create the OVA. This has the advantage of validating the created OVF, and has greater chances of producing OVAs that are compliant with more versions of VMware targets of Fusion, Workstation, and vSphere. To use `ovftool` for OVA creation, set the env variable IB_OVFTOOL to any non-empty value, like the following:
+
+```bash
+IB_OVFTOOL=1 make build-node-ova-<hypervisor>-<OS>
+```
 
 ### Configuration
 

--- a/images/capi/hack/ensure-ovftool.sh
+++ b/images/capi/hack/ensure-ovftool.sh
@@ -20,6 +20,8 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
+[[ -z ${IB_OVFTOOL:-} ]] && exit 0
+
 source hack/utils.sh
 
 if command -v ovftool >/dev/null 2>&1; then exit 0; fi


### PR DESCRIPTION
What this PR does / why we need it:
This commit makes the use of ovftool to create the OVA optional, going
back to using tar as the default.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
This was agreed to in the latest image-builder office hours as the preferred method going forward.

/hold
/assign @moshloop @MaxRink @kkeshavamurthy 