### PR TITLE
ova: don't use K8s version in base naming

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -2,9 +2,10 @@
   "variables": {
     "ansible_common_vars": "",
     "ansible_extra_vars": "guestinfo_datasource_slug={{user `guestinfo_datasource_slug`}} guestinfo_datasource_ref={{user `guestinfo_datasource_ref`}} guestinfo_datasource_script={{user `guestinfo_datasource_script`}}",
+    "base_build_version": "base-{{user `build_name`}}",
+    "base_output_dir": "./output/{{user `base_build_version`}}",
     "build_timestamp": "{{timestamp}}",
     "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
-    "base_build_version": "base-{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "cluster": "",
     "containerd_version": null,
     "containerd_sha256": null,
@@ -35,7 +36,6 @@
     "kubernetes_rpm_gpg_check": null,
     "kubernetes_container_registry": null,
     "output_dir": "./output/{{user `build_version`}}",
-    "base_output_dir": "./output/{{user `base_build_version`}}",
     "username": "",
     "vcenter_server": "",
     "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}"


### PR DESCRIPTION
I've finally started using a base image to speed up  my local builds. Ran across this little quirk when doing that and wanted to change. A huge shoutout to @EleanorRigby and @kkeshavamurthy for getting this feature in a few months back -- speeds things up immensely!

**What this PR does / why we need it:**
When building base images for use with OVAs, the base image is solely
based on the OS install ISO and does not include anything for
Kubernetes. The only time the base image needs to change is if the ISO
changes or the kickstart/preseed changes. We were previously naming the
base image with the K8s version included. This change removes that,
such that the base names are only as "base-<OS>".

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**


/assign @kkeshavamurthy @EleanorRigby 