### PR TITLE
Added some info to docs for building windows nodes

### DIFF
--- a/docs/book/src/capi/windows/windows.md
+++ b/docs/book/src/capi/windows/windows.md
@@ -12,6 +12,18 @@ The `images/capi/packer/config/windows` directory includes several JSON files th
 | `packer/config/windows/kubernetes.json` | The version of Kubernetes to install and it's install path |
 | `packer/config/windows/containerd.json` | The version of containerd to install |
 
+## Service Manager
+
+Image-builder provides you two ways to configure windows services. The default is setup using [nssm](https://nssm.cc/) which configures a windows service for kubelet by running `{{ kubernetes_install_path }}\StartKubelet.ps1` allowing easy editing of command arguments in the startup file.  The alternate is to use the windows native [sc.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sc-config) which uses the kubelet argument `--windows-service` to install kubelet as a native windows service with the command line arguments configured on the service. Nssm handles service restarts, if you are using sc.exe you may wish to configure the service restart options on kubelet. To avoid starting kubelet to early, image-builder sets the kubelet service to *manual* which you should consider changing once the node has joined a cluster.
+
+**Important: sc.exe does not support kubeadm KUBELET_KUBEADM_ARGS which is used by Cluster API to pass extra user args**
+
+## Wins (by rancher)
+
+As a workaround for the lack of privileged containers on windows nodes, SIG Windows utilise [Wins](https://github.com/rancher/wins/) to allow pods to run processes on hosts, an example is when you are using kube-proxy or a cni provider in a pod. This means that by default we install wins using image-builder. This may be undesirable, if you do not need pod to have the ability to run processes on the host. Additionally, Alpha support for Windows [Host Processes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support), which is the windows equivalent for privileged containers, will be introduced in 1.22 which negates the need for wins entirely. To skip installing wins on the host you can add `"wins_url": ""` to your variables.  
+
+When using containerd, due to lack of host networking, there is currently no way to run cni inside a pod.   To work around this, containerd needs to be installed with an additional custom Ansible module or after the image has been created.  With CAPI, the addtional configuration can be done with pre/postKubeadm scripts when the node is created.
+
 ## Windows Updates
 
 When building Windows images it is necessary to install OS and Security updates.  Image Builder provides two variables to allow choosing which updates get installed which can be used together or seperately (with individual KBs installed first).


### PR DESCRIPTION
What this PR does / why we need it:
This adds some information on building windows nodes and helping to skip installing wins and configuring windows services with alternate service manager

Which issue(s) this PR fixes: Fixes #523 
