### PR TITLE
Sort json files

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -611,3 +611,13 @@ test-azure: ## Run the tests for Azure builders
 .PHONY: release-staging
 release-staging: ## Builds and push container images to the staging bucket.
 	TAG=$(IB_VERSION) REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build docker-push
+
+## --------------------------------------
+## Sort JSON
+## --------------------------------------
+##@ Sort JSON
+
+.PHONY: json-sort
+json_files = $(shell find . -type f -name "*.json" | sort -u)
+json-sort: ## Sort all JSON files alphabetically
+	@for f in $(json_files); do (cat "$$f" | jq -S '.' >> "$$f".sorted && mv "$$f".sorted "$$f") || exit 1 ; done

--- a/images/capi/hack/ci-json-sort.sh
+++ b/images/capi/hack/ci-json-sort.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/../../..
+cd "${CAPI_ROOT}" || exit 1
+
+cleanup() {
+    returnCode="$?"
+    exit "${returnCode}"
+}
+
+trap cleanup EXIT
+
+json_files=$(find . -type f -name "*.json" | sort -u)
+for f in ${json_files}
+do
+  if ! diff <(jq -S . ${f}) ${f} >> /dev/null; then
+    echo "json files are not sorted!! Please sort them with \"make sort\" before commit"
+    echo "Unsorted file: ${f}"
+    exit 1
+  fi
+done


### PR DESCRIPTION
What this PR does / why we need it:
- `make json-sort` to sort all the json files
- `./hack/ci-json-sort.sh` to run from CI to check if all json files are sorted. 
- presubmit job [PR](https://github.com/kubernetes/test-infra/pull/21112). 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers