### PR TITLE
Preseed cleanup

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/debian.yml
@@ -19,10 +19,11 @@
 
 - name: Add the Kubernetes repo
   apt_repository:
-    repo: "{{ 'deb ' ~ kubernetes_deb_repo ~ ' main' }}"
+    repo: "deb {{ kubernetes_deb_repo }} main"
     update_cache: True
     state: present
     mode: 0644
+    filename: kubernetes
 
 - name: Install Kubernetes
   apt:

--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -122,4 +122,6 @@ d-i preseed/late_command string \
     in-target swapoff -a ; \
     in-target rm -f /swapfile ; \
     in-target sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab ; \
-    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules
+    in-target rm -f /etc/udev/rules.d/70-persistent-net.rules ; \
+    in-target apt-get purge --auto-remove -y ; \
+    in-target rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
What this PR does / why we need it:

I recently started using a local, docker-hosted, instance of `apt-cacher-ng` to speed up my builds of Ubuntu nodes and to stop downloading new `.deb` files for each build. This doesn't speed up builds all that much (only about 90s), but it does save gigs of bandwidth if you do several builds a week, which I do.

I ran into two issues that tripped up this approach, and this PR fixes them both while introducing no changes when not using a caching repo proxy.

1. In the Ubuntu preseed file, clear out the existing apt cache at the very end. This prevents later issues when downloading new repo metadata and producing checksum mismatches.
2. The syntax we were using to write the K8s deb repo path was weird and made it hard to point to a different location. I don't even know what the ` ~ ` syntax is for, and it doesn't serve a purpose that I could tell. The end result is the same with the change.

here's the former:

```sh
root@capi:/etc/apt/sources.list.d# cat apt_kubernetes_io.list
deb https://apt.kubernetes.io/ kubernetes-xenial main
```

and after:

```sh
root@capi:/etc/apt/sources.list.d# cat kubernetes.list
deb https://apt.kubernetes.io/ kubernetes-xenial main
```

I think the changed syntax is more understandable, and it also makes it easier for me to change that repo location.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
If anyone wants details on the apt-cacher setup I'm using, I'm happy to share.

/assing @kkeshavamurthy 