### PR TITLE
Do not display skipped ansible tasks

### DIFF
--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -14,6 +14,7 @@
 
 [defaults]
 remote_tmp = /tmp/.ansible
+display_skipped_hosts = False
 
 [ssh_connection]
 pipelining = False


### PR DESCRIPTION
What this PR does / why we need it:
Ansible output is very cluttered by displaying all the skipped tasks. This PR add `ANSIBLE_DISPLAY_SKIPPED_HOSTS=no` env variable to ansible provisioner and the output is much better

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

Before

```
    amazon-2:
    amazon-2: PLAY [all] *********************************************************************
    amazon-2:
    amazon-2: TASK [Gathering Facts] *********************************************************
    amazon-2: ok: [default]
    amazon-2: [WARNING]: Platform linux on host default is using the discovered Python
    amazon-2: interpreter at /usr/bin/python, but future installation of another Python
    amazon-2: interpreter could change the meaning of that path. See https://docs.ansible.com
    amazon-2: /ansible/2.10/reference_appendices/interpreter_discovery.html for more
    amazon-2: information.
    amazon-2:
    amazon-2: TASK [include_role : node] *****************************************************
    amazon-2:
    amazon-2: TASK [setup : Put templated sources.list in place] *****************************
    amazon-2: skipping: [default]
    amazon-2:
    amazon-2: TASK [setup : Put templated apt.conf.d/90proxy in place when defined] **********
    amazon-2: skipping: [default]
30 more lines
    .....
    amazon-2: TASK [setup : add epel repo] ***************************************************
    amazon-2: changed: [default]
```

After
```
    amazon-2:
    amazon-2: PLAY [all] *********************************************************************
    amazon-2:
    amazon-2: [WARNING]: Platform linux on host default is using the discovered Python
    amazon-2: TASK [Gathering Facts] *********************************************************
    amazon-2: interpreter at /usr/bin/python, but future installation of another Python
    amazon-2: ok: [default]
    amazon-2: interpreter could change the meaning of that path. See https://docs.ansible.com
    amazon-2: /ansible/2.10/reference_appendices/interpreter_discovery.html for more
    amazon-2: information.
    amazon-2:
    amazon-2: TASK [setup : add epel repo] ***************************************************
    amazon-2: changed: [default]
    amazon-2:
    amazon-2: TASK [setup : perform a yum update] ********************************************
    amazon-2: changed: [default]
```