### PR TITLE
GOSS test fix for load_additional_imgs flag

### DIFF
--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -18,7 +18,7 @@ command:
     stdout: ["coredns", "etcd", "kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler", "pause"]
 {{end}}
 {{end}}
-{{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (not .Vars.kubernetes_load_additional_imgs)}}
+{{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (eq .Vars.kubernetes_load_additional_imgs "false")}}
 # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
   crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0
@@ -26,7 +26,7 @@ command:
     timeout: 0
     stdout: ["kube-apiserver", "kube-controller-manager", "kube-proxy", "kube-scheduler"]
 {{end}}
-{{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (.Vars.kubernetes_load_additional_imgs)}}
+{{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (eq .Vars.kubernetes_load_additional_imgs "true")}}
 # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
   crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-{{ .Vars.arch }}//g' | sort:
     exit-status: 0


### PR DESCRIPTION
Fixes an error in GOSS test conditions that caused a wrong GOSS test to run and fail when `load_additional_imgs="true"` 

/cc @kkeshavamurthy  