### PR TITLE
Set kernel param for strict reverse packet filtering for Ubuntu images

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -83,3 +83,12 @@
     group: root
     mode: 0644
   when: ansible_os_family != "Flatcar"
+
+- name: Ensure reverse packet filtering is set as strict
+  sysctl:
+    name: net.ipv4.conf.all.rp_filter
+    value: "1"
+    state: present
+    sysctl_set: yes
+    reload: yes
+  when: ansible_distribution == "Ubuntu"

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -121,6 +121,9 @@ rhel:
       cloud-utils-growpart:
       python2-pip:
 ubuntu:
+  common-kernel-param:
+    net.ipv4.conf.all.rp_filter:
+      value: "1"
   common-package:
     <<: *common_debs
   azure:


### PR DESCRIPTION
Sets `net.ipv4.conf.all.rp_filter=1` for Ubuntu images.
Includes corresponding GOSS test.

/cc @codenrhoden 