### PR TITLE
Add iops & throughput params to ami builder

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -46,7 +46,9 @@
     "snapshot_users": "",
     "subnet_id": "",
     "volume_size": "8",
-    "vpc_id": ""
+    "vpc_id": "",
+    "throughput": "125",
+    "iops": "3000"
   },
   "builders": [
     {
@@ -100,6 +102,8 @@
           "device_name": "{{ user `root_device_name` }}",
           "volume_size": "{{ user `volume_size` }}",
           "volume_type": "gp3",
+          "throughput": "{{ user `throughput` }}",
+          "iops": "{{ user `iops`}}",
           "delete_on_termination": true
         }
       ]


### PR DESCRIPTION
What this PR does / why we need it:
Fixes #500 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #
Ami building with packer 1.6.6 fails due to a packer bug requiring to specify `iops` and `throughput` params, even though they are optional. I'm setting the default to the min values. 

**Additional context**
Add any other context for the reviewers