### PR TITLE
bump containerd to 1.4.4

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,7 +1,7 @@
 {
-    "containerd_version": "1.4.3",
-    "containerd_sha256": "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d",
-    "containerd_sha256_windows": "4464dc16978b6e984c442e17cfcc0826e1aebd8e12cb64a3ce2bdb89affa2138",
+    "containerd_version": "1.4.4",
+    "containerd_sha256": "96641849cb78a0a119223a427dfdc1ade88412ef791a14193212c8c8e29d447b",
+    "containerd_sha256_windows": "0b668d28ec7ffda3d1930ed729ff8591540278a56539ae0bd682dea8c9964483",
     "containerd_pause_image": "k8s.gcr.io/pause:3.2",
     "containerd_additional_settings": null,
     "containerd_cri_socket": "/var/run/containerd/containerd.sock"


### PR DESCRIPTION
What this PR does / why we need it:

This addresses a containerd [CVE](https://github.com/containerd/containerd/security/advisories/GHSA-6g2q-w5j3-fwh4)