### PR TITLE
Set systemd cgroup driver for K8s >= 1.21

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -37,7 +37,11 @@ version = 2
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ containerd_pause_image }}"
+  {% if kubernetes_semver is version('v1.21.0', '>=') %}
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+      SystemdCgroup = true
+  {% endif %}
 
 {% endif %}
-    
+
 {{containerd_additional_settings | b64decode}}


### PR DESCRIPTION
What this PR does / why we need it:
When Kubernetes is 1.21.0 or greater, we want to make sure we configure
containerd to use the SystemD cgroup driver, not the default cgroupfs.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #471

**Additional context**
The built-in `version` comparison for Ansible seems to handle this just fine.

The resulting config file with this change looks like this:

```toml
## template: jinja

# Use config version 2 to enable new configuration fields.
# Config file is parsed as version 1 by default.
version = 2

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    sandbox_image = "k8s.gcr.io/pause:3.2"
    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
      SystemdCgroup = true
```

/cc @neolit123 @fabriziopandini 

I've verified that this gets populated correctly with < 1.21.0, and with >= 1.21.0