### PR TITLE
Fix validate make targets

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -216,7 +216,6 @@ FLATCAR_VERSION ?= 2605.10.0
 export FLATCAR_CHANNEL FLATCAR_VERSION
 
 PLATFORMS_AND_VERSIONS	:=	$(CENTOS_VERSIONS) \
-							$(FLATCAR_VERSIONS) \
 							$(PHOTON_VERSIONS) \
 							$(RHEL_VERSIONS) \
 							$(UBUNTU_VERSIONS) \
@@ -361,7 +360,7 @@ $(AZURE_BUILD_SIG_GEN2_TARGETS): deps-azure
 
 .PHONY: $(AZURE_VALIDATE_SIG_TARGETS)
 $(AZURE_VALIDATE_SIG_TARGETS): deps-azure
-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring windows,$@).json
+	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
 
 .PHONY: $(AZURE_VALIDATE_SIG_GEN2_TARGETS)
 $(AZURE_VALIDATE_SIG_GEN2_TARGETS): deps-azure
@@ -532,6 +531,7 @@ build-raw-all: $(RAW_BUILD_TARGETS) ## Builds all RAW images
 ##@ Validate packer config
 validate-ami-amazon-2: ## Validates Amazon-2 Linux AMI Packer config
 validate-ami-centos-7: ## Validates CentOS 7 AMI Packer config
+validate-ami-flatcar: ## Validates Flatcar AMI Packer config
 validate-ami-ubuntu-1804: ## Validates Ubuntu 18.04 AMI Packer config
 validate-ami-ubuntu-2004: ## Validates Ubuntu 20.04 AMI Packer config
 validate-ami-windows-2019: ## Validates Windows Server 2019 AMI Packer config
@@ -586,7 +586,7 @@ validate-node-ova-local-base-ubuntu-2004: ## Validates Ubuntu 20.04 Base Node OV
 validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
-validate-qemu-all: $(QEMU_VALIDATE_TARGETS) ## Validates all Qemu Packer config
+validate-qemu-all: $(QEMU_VALIDATE_TARGETS) validate-qemu-flatcar ## Validates all Qemu Packer config
 
 validate-raw-ubuntu-1804: ## Validates Ubuntu 18.04 RAW image packer config
 validate-raw-ubuntu-2004: ## Validates Ubuntu 20.04 RAW image packer config

--- a/images/capi/scripts/ci-packer-validate.sh
+++ b/images/capi/scripts/ci-packer-validate.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-# Copyright 2020 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,23 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+###############################################################################
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-source hack/utils.sh
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${CAPI_ROOT}" || exit 1
 
-_version="2.10.0"
+export PATH=${PWD}/.local/bin:$PATH
+export PATH=${PYTHON_BIN_DIR:-"${HOME}/.local/bin"}:$PATH
 
-# Change directories to the parent directory of the one in which this
-# script is located.
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
-
-if command -v ansible >/dev/null 2>&1; then exit 0; fi
-
-ensure_py3
-pip3 install --user "ansible==${_version}"
-ensure_py3_bin ansible
-ensure_py3_bin ansible-playbook
+AZURE_LOCATION=fake RESOURCE_GROUP_NAME=fake STORAGE_ACCOUNT_NAME=fake \
+  DIGITALOCEAN_ACCESS_TOKEN=fake GCP_PROJECT_ID=fake \
+  make validate-all


### PR DESCRIPTION
What this PR does / why we need it:
There were a few problems with the validate make targets. Flatcar had
been added to the list of OS's supported for OVA builds, which is
incorrect. The Azure windows-sig target had a typo in it. The QEMU
target was missing flatcar, and the AMI target wasn't documented. This
patch fixes all those things and `make validate-all` can work again,
presubming you supply the needed ENV vars.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
To run this on my local machine, I use the following:
```commandline
$ AZURE_LOCATION=fake RESOURCE_GROUP_NAME=fake STORAGE_ACCOUNT_NAME=fake DIGITALOCEAN_ACCESS_TOKEN=fake GCP_PROJECT_ID=fake make validate-all
```

That provides fake vars that will allow the check to pass. I'm going to add this test to CI.

@perithompson I know you were interested in this. Unfortunately it would not have caught the Windows+OVA issue you say, as this doesn't test the interface between the Packer manifest file and the Python script that generates the OVA.