### PR TITLE
Updates packer patch version.

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.6.0"
+_version="1.6.6"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Avoids this error with building AMI images:

```
Right version of binary present
packer build -var-file="/home/imagebuilder/packer/config/kubernetes.json"  -var-file="/home/imagebuilder/packer/config/cni.json"  -var-file="/home/imagebuilder/packer/config/containerd.json"  -var-file="/home/imagebuilder/packer/config/ansible-args.json"  -var-file="/home/imagebuilder/packer/config/goss-args.json"  -var-file="/home/imagebuilder/packer/config/common.json"  -color=true -var-file="/home/imagebuilder/packer/ami/ubuntu-1804.json" -var-file="/tmp/build.json"  -var-file="/tmp/aws_settings.json"  -var-file="/tmp/additional_settings.json"  packer/ami/packer.json
Error: Failed to prepare build: "ubuntu-18.04"
1 error occurred:
	* unknown configuration key: '"launch_block_device_mappings[0].throughput"'
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers