### PR TITLE
Temporarily disable windows defender updates

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -60,12 +60,20 @@
     reboot: yes
   when: windows_updates_category_names|length > 0
   
-- name: Update Windows Defender signatures
-  win_shell: |
-    # https://github.com/microsoft/azure-pipelines-image-generation/pull/1259/files
-    $service = Get-Service "Windefend"
-    $service.WaitForStatus("Running","00:5:00")
-    Update-MpSignature
+# Temporarily disabling: https://github.com/kubernetes-sigs/image-builder/issues/549
+# These will be updated periodically on the host once it is running so not an issue for now
+# - name: Update Windows Defender signatures
+#   win_shell: |
+    # Updating windows defender signatures sometimes fails
+    # $service = Get-Service "Windefend"
+    # $service.WaitForStatus("Running","00:5:00")
+    # try {
+    #     Update-MpSignature
+    # }
+    # catch {
+    #     Write-Host "Error occurred during signature update $_"
+    # }
+    
 
 # Requires admin rights to install 
 # https://docs.ansible.com/ansible/latest/user_guide/become.html#become-and-windows


### PR DESCRIPTION
What this PR does / why we need it:

Make windows defender best effort during build. Defender is running  on the host so the updates will be run periodically once the machine is running.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 

Mitigates #549

**Additional context**
Add any other context for the reviewers

I am going to connect with the Windows defender team to figure out why it might be failing occasionally and will follow up.  