### PR TITLE
Added SMB registry flag for Windows registry nodes

### DIFF
--- a/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
+++ b/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
@@ -75,6 +75,16 @@
     containerd.exe --register-service
   when: containerd_service.exists == false
 
+# Enables DNS resolution of SMB shares
+# https://github.com/kubernetes-sigs/windows-gmsa/issues/30#issuecomment-802240945
+- name: Apply SMB Resolution Fix for containerd
+  win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+    state: present
+    name: EnableCompartmentNamespace
+    data: 1
+    type: dword
+
 - name: Create Windows Defender Exclusions
   win_shell: |
     Add-MpPreference -ExclusionProcess "$env:ProgramFiles\containerd\containerd.exe"


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds a registry key to all Windows nodes that use the containerd runtime. During the validation of SMB file share access using containerd pods, it was [pointed out](https://github.com/kubernetes-sigs/windows-gmsa/issues/30#issuecomment-802240945) that a registry key exists that gates DNS resolutions of SMB Shares. This needs to be added onto all Windows nodes using containerd.  

Which issue(s) this PR fixes: 
Fixes #555 