### PR TITLE
No longer install cloud-initramfs-growroot Ubuntu qemu

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -23,7 +23,6 @@
     - cloud-guest-utils
     - cloud-initramfs-copymods
     - cloud-initramfs-dyn-netconf
-    - cloud-initramfs-growroot
   when: ansible_os_family == "Debian"
 
 - name: Install cloud-init packages


### PR DESCRIPTION
What this PR does / why we need it:
PR [510](https://github.com/kubernetes-sigs/image-builder/pull/510) removed `cloud-initramfs-growroot` in [vmware.yml](https://github.com/codenrhoden/image-builder/blob/master/images/capi/ansible/roles/providers/tasks/vmware.yml).  This PR is make the same change in qemu.yml.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #561

**Additional context**
None