### PR TITLE
Adding Windows Goss support

### DIFF
--- a/docs/book/src/capi/goss/goss.md
+++ b/docs/book/src/capi/goss/goss.md
@@ -14,8 +14,9 @@ to test if the images have all requisite components to work with cluster API.
 |----|---------|
 | Amazon Linux | aws
 | PhotonOS | ova
-| Ubuntu | aws , ova, azure
+| Ubuntu | aws, azure, ova
 | CentOS | aws, ova 
+| Windows | aws, azure, ova
 
 
 ### Prerequisites for Running GOSS

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -184,7 +184,8 @@ COMMON_WINDOWS_VAR_FILES :=	packer/config/kubernetes.json \
 					packer/config/windows/docker.json \
 					packer/config/windows/ansible-args-windows.json \
 					packer/config/windows/common.json \
-					packer/config/windows/cloudbase-init.json
+					packer/config/windows/cloudbase-init.json \
+					packer/config/goss-args.json 
 
 # Initialize a list of flags to pass to Packer. This includes any existing flags
 # specified by PACKER_FLAGS, as well as prefixing the list with the variable

--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -92,6 +92,36 @@
       "type": "windows-restart"
     },
     {
+      "arch": "{{user `goss_arch`}}",
+      "format": "{{user `goss_format`}}",
+      "format_options": "{{user `goss_format_options`}}",
+      "goss_file": "{{user `goss_entry_file`}}",
+      "inspect": "{{user `goss_inspect_mode`}}",
+      "target_os": "Windows",
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
+      "type": "goss",
+      "url": "{{user `goss_url`}}",
+      "use_sudo": false,
+      "vars_env": {
+        "GOSS_MAX_CONCURRENT": "5",
+        "GOSS_USE_ALPHA": "1"
+      },
+      "vars_file": "{{user `goss_vars_file`}}",
+      "vars_inline": {
+        "OS": "{{user `distribution` | lower}}",
+        "PROVIDER": "ami",
+        "containerd_version": "{{user `containerd_version`}}",
+        "distribution_version": "{{user `distribution_version`}}",
+        "docker_ee_version": "{{user `docker_ee_version`}}",
+        "kubernetes_version": "{{user `kubernetes_semver`}}",
+        "pause_image": "{{user `pause_image`}}",
+        "runtime": "{{user `runtime`}}"
+      },
+      "version": "{{user `goss_version`}}"
+    },
+    {
       "elevated_password": "{{.WinRMPassword}}",
       "elevated_user": "Administrator",
       "script": "packer/ami/scripts/sysprep_prerequisites.ps1",

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -115,6 +115,36 @@
       "type": "windows-restart"
     },
     {
+      "arch": "{{user `goss_arch`}}",
+      "format": "{{user `goss_format`}}",
+      "format_options": "{{user `goss_format_options`}}",
+      "goss_file": "{{user `goss_entry_file`}}",
+      "inspect": "{{user `goss_inspect_mode`}}",
+      "target_os": "Windows",
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
+      "type": "goss",
+      "url": "{{user `goss_url`}}",
+      "use_sudo": false,
+      "vars_env": {
+        "GOSS_MAX_CONCURRENT": "5",
+        "GOSS_USE_ALPHA": "1"
+      },
+      "vars_file": "{{user `goss_vars_file`}}",
+      "vars_inline": {
+        "OS": "{{user `distribution` | lower}}",
+        "PROVIDER": "azure",
+        "containerd_version": "{{user `containerd_version`}}",
+        "distribution_version": "{{user `distribution_version`}}",
+        "docker_ee_version": "{{user `docker_ee_version`}}",
+        "kubernetes_version": "{{user `kubernetes_semver`}}",
+        "pause_image": "{{user `pause_image`}}",
+        "runtime": "{{user `runtime`}}"
+      },
+      "version": "{{user `goss_version`}}"
+    },
+    {
       "elevated_password": "{{.WinRMPassword}}",
       "elevated_user": "packer",
       "script": "packer/azure/scripts/sysprep.ps1",

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -1,4 +1,5 @@
 command:
+{{ if ne .Vars.OS "windows" }} # Linux Only
   containerd --version | awk -F' ' '{print substr($3,2); }':
     exit-status: 0
     stdout: []
@@ -64,3 +65,77 @@ command:
     {{$key}}: {{$val}}
   {{end}}
 {{end}}
+{{end}} #End linux only 
+
+{{ if eq .Vars.OS "windows" }} # Windows
+  kubectl version --client:
+    exit-status: 0
+    stdout:
+    - {{.Vars.kubernetes_version}}
+    - "windows"
+    - {{.Vars.arch}}
+    timeout: 10000
+  kubeadm version:
+    exit-status: 0
+    stdout:
+    - {{.Vars.kubernetes_version}}
+    - "windows"
+    - {{.Vars.arch}}
+    timeout: 10000
+  kubelet --version:
+    exit-status: 0
+    stdout:
+    - {{.Vars.kubernetes_version}}
+    timeout: 10000
+  Check Symbolic link to /etc/kubernetes/pki:
+    exit-status: 0
+    exec: powershell -command "(Get-item -path $env:SystemDrive\var\lib\kubelet\etc\kubernetes\pki| select LinkType,Target)"
+    stdout:
+    - SymbolicLink 
+    - C:\etc\kubernetes\pki\
+{{ if eq .Vars.distribution_version "2019" }}
+  Windows build version is high enough:
+    exit-status: 0
+    exec: powershell -command "(Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' -Name UBR).UBR -ge 1817"
+    stdout:
+    - "True"
+    timeout: 30000
+{{end}}
+{{ if eq .Vars.runtime "containerd" }}
+  Correct Containerd Version:
+    exec: "\"/Program Files/containerd/containerd.exe\" --version"
+    exit-status: 0
+    stdout:
+    - "{{.Vars.containerd_version}}"
+    timeout: 30000
+  Correct Containerd cni config:
+    exec: "\"/Program Files/containerd/containerd.exe\" config dump"
+    exit-status: 0
+    stdout:
+    - "sandbox_image = \"{{.Vars.pause_image}}\""
+    - "conf_dir = \"C:/etc/cni/net.d\""
+    - "bin_dir = \"C:/opt/cni/bin\""
+    timeout: 30000
+  Check Windows Defender Exclusions are in place:
+    exit-status: 0
+    exec: powershell -command "(Get-MpPreference | select ExclusionProcess)"
+    stdout:
+    - \Program Files\containerd\containerd.exe, 
+    - \Program Files\containerd\ctr.exe
+  Check SMB CompartmentNamespace Flag:
+    exit-status: 0
+    exec: powershell -command "(Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\hns\State' -Name EnableCompartmentNamespace).EnableCompartmentNamespace -eq 1"
+    stdout:
+    - True
+    timeout: 30000
+{{end}}
+
+{{ if eq .Vars.runtime "docker_ee" }}
+  Correct Docker Version:
+    exec: "docker.exe version"
+    exit-status: 0
+    stdout:
+    - "{{.Vars.docker_ee_version}}"
+    timeout: 30000
+{{end}}
+{{end}} #end windows

--- a/images/capi/packer/goss/goss-files.yaml
+++ b/images/capi/packer/goss/goss-files.yaml
@@ -1,0 +1,17 @@
+file:
+{{range $name, $vers := index .Vars .Vars.OS "common-files"}}
+  {{ $name }}:
+    exists: {{ $vers.exists }}
+    filetype: {{ $vers.filetype }}
+    contains: {{ range $vers.contains}}
+    - {{.}}
+  {{end}}
+{{end}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "files"}}
+  {{ $name }}:
+    exists: {{ $vers.exists }}
+    filetype: {{ $vers.filetype }}
+    contains: {{ range $vers.contains}}
+    - {{.}}
+  {{end}}
+{{end}}

--- a/images/capi/packer/goss/goss-kernel-params.yaml
+++ b/images/capi/packer/goss/goss-kernel-params.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Vars.OS "windows" }}
 kernel-param:
   net.bridge.bridge-nf-call-iptables:
     value: "1"
@@ -20,4 +21,5 @@ kernel-param:
   {{range $key, $val := $vers}}
     {{$key}}: "{{$val}}"
   {{end}}
+{{end}}
 {{end}}

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -1,3 +1,4 @@
+{{ if ne .Vars.OS "windows"}}
 kubernetes_version: &kubernetes_version
   versions:
     or:
@@ -50,4 +51,19 @@ package:
   {{range $key, $val := $vers}}
     {{$key}}: {{$val}}
   {{end}}
+{{end}}
+
+{{end}}
+{{ if eq .Vars.OS "windows"}} # Windows
+# Workaround until windows features are added to goss
+command:
+{{range $name, $vers := index .Vars .Vars.OS "common-windows-features"}}
+  "Windows Feature - {{ $name }}":
+    exec: powershell -command "(Get-WindowsFeature {{ $name }} | select *)"
+    exit-status: 0
+    stdout: {{range $vers.expected}}
+    - {{.}}
+    timeout: 30000
+    {{end}}
+{{end}}
 {{end}}

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -1,4 +1,5 @@
 service:
+{{ if ne .Vars.OS "windows"}} # Linux
   containerd:
     enabled: true
     running: true
@@ -28,4 +29,46 @@ service:
   {{range $key, $val := $vers}}
     {{$key}}: {{$val}}
   {{end}}
+{{end}}
+{{end}}
+
+{{ if eq .Vars.OS "windows"}} # Windows
+# Workaround until windows services are added to goss
+command:
+{{range $name, $vers := index .Vars .Vars.OS "common-windows-service"}}
+  "Windows Service - {{ $name }}":
+    exec: powershell -command "(Get-Service {{ $name }} | select *)"
+    exit-status: 0
+    stdout: {{range $vers.expected}}
+    - {{.}}
+    {{end}}
+{{end}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "windows-service"}}
+  "Windows Service - {{ $name }}":
+    exec: powershell -command "(Get-Service {{ $name }} | select *)"
+    exit-status: 0
+    stdout: {{range $vers.expected}}
+    - {{.}}
+    {{end}}
+{{end}}
+
+{{ if eq .Vars.runtime "docker_ee" }}
+
+  "Windows Service - docker":
+    exec: powershell -command "(Get-Service docker | select *)"
+    exit-status: 0
+    stdout: 
+    - Automatic
+    - Running
+{{end}}
+
+{{ if eq .Vars.runtime "containerd"}}
+  "Windows Service - containerd":
+    exec: powershell -command "(Get-Service containerd | select *)"
+    exit-status: 0
+    stdout: 
+    - Automatic
+    - Running
+{{end}}
+
 {{end}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -70,6 +70,12 @@ kubernetes_cni_rpm_version: ""
 # When k8s and k8s cni source is http
 kubernetes_load_additional_imgs: false
 
+#windows variables
+kubernetes_install_path: ""
+windows_service_manager: ""
+distribution_version: ""
+runtime: ""
+
 # OS Specific package/Command/Kernal Params etc...
 # Structured in below format
 # OS_NAME
@@ -177,3 +183,101 @@ ubuntu:
       cloud-guest-utils:
       cloud-initramfs-copymods:
       cloud-initramfs-dyn-netconf:
+
+# Windows specific variables
+windows:
+  common-windows-features:
+    Hyper-V-PowerShell:
+      expected:
+      - Installed
+    Containers:
+      expected:
+      - Installed
+
+  common-files:
+    c:/etc/kubernetes/pki:
+      exists: true
+      filetype: directory
+      contains:
+    c:/var/lib/kubelet/etc/kubernetes:
+      exists: true
+      filetype: directory
+      contains:
+    c:/var/lib/kubelet/etc/kubernetes/manifests:
+      exists: true
+      filetype: directory
+      contains:
+    c:/var/log/kubelet:
+      exists: true
+      filetype: directory
+      contains:
+
+  common-windows-service:
+    cloudbase-init:
+      expected:
+      - Manual
+      - Stopped
+    kubelet:
+      expected: 
+      - Manual 
+      - Stopped
+      - "/RequiredServices.+:.+(containerd|docker)/"
+    sshd:
+      expected:
+      - Automatic
+      - Running
+
+  azure:
+    windows-service:
+
+    files: 
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+        exists: true
+        filetype: file
+        contains:
+        - "COM1,115200,N,8"
+        - "metadata_services=cloudbaseinit.metadata.services.azureservice.AzureService"
+        - "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin"
+        - "cloudbaseinit.plugins.windows.azureguestagent.AzureGuestAgentPlugin"
+        - "cloudbaseinit.plugins.common.mtu.MTUPlugin"
+        - "cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin"
+  ova:
+    windows-service:
+      vmtools:
+        expected: 
+        - Automatic 
+        - Running
+    files:
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+        exists: true
+        filetype: file
+        contains:
+        - "!/logging_serial_port=COM1,115200,N,8/"
+        - "cloudbaseinit.metadata.services.vmwareguestinfoservice.VMwareGuestInfoService"
+        - "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin"
+        - "cloudbaseinit.plugins.common.mtu.MTUPlugin"
+        - "cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin"
+        - "cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin"
+        - "cloudbaseinit.plugins.common.userdata.UserDataPlugin"
+        - "cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin"
+        - "cloudbaseinit.plugins.windows.createuser.CreateUserPlugin"
+        - "cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin"
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init-unattend.conf': 
+        exists: true
+        filetype: file
+        contains:
+        - "metadata_services=cloudbaseinit.metadata.services.vmwareguestinfoservice.VMwareGuestInfoService"
+  amazon:
+    windows-service:
+
+    files:
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+        exists: true
+        filetype: file
+        contains:
+        - "!/logging_serial_port=COM1,115200,N,8/"
+        - "metadata_services=cloudbaseinit.metadata.services.ec2service.EC2Service"
+        - "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin"
+        - "cloudbaseinit.plugins.common.mtu.MTUPlugin"
+        - "cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin"
+  

--- a/images/capi/packer/goss/goss.yaml
+++ b/images/capi/packer/goss/goss.yaml
@@ -3,3 +3,4 @@ gossfile:
   goss-kernel-params.yaml: {}
   goss-service.yaml: {}
   goss-package.yaml: {}
+  goss-files.yaml: {}

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -3,7 +3,7 @@
     {
       "boot_wait": "{{user `boot_wait`}}",
       "communicator": "winrm",
-      "cpus": 2,
+      "cpus": 4,
       "disk_adapter_type": "scsi",
       "disk_size": "{{user `disk_size`}}",
       "disk_type_id": "{{user `disk_type_id`}}",
@@ -32,7 +32,7 @@
       "vm_name": "{{user `build_version`}}",
       "vmdk_name": "{{user `build_version`}}",
       "vmx_data": {
-        "numvcpus": "2",
+        "numvcpus": "4",
         "scsi0.virtualDev": "pvscsi"
       },
       "winrm_password": "S3cr3t0!",
@@ -174,6 +174,36 @@
       "restart_check_command": "powershell -command \"& {if ((get-content C:\\ProgramData\\lastboot.txt) -eq (Get-WmiObject win32_operatingsystem).LastBootUpTime) {Write-Output 'Sleeping for 600 seconds to wait for reboot'; start-sleep 600} else {Write-Output 'Reboot complete'}}\"",
       "restart_command": "powershell \"& {(Get-WmiObject win32_operatingsystem).LastBootUpTime > C:\\ProgramData\\lastboot.txt; Restart-Computer -force}\"",
       "type": "windows-restart"
+    },
+    {
+      "arch": "{{user `goss_arch`}}",
+      "format": "{{user `goss_format`}}",
+      "format_options": "{{user `goss_format_options`}}",
+      "goss_file": "{{user `goss_entry_file`}}",
+      "inspect": "{{user `goss_inspect_mode`}}",
+      "target_os": "Windows",
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
+      "type": "goss",
+      "url": "{{user `goss_url`}}",
+      "use_sudo": false,
+      "vars_env": {
+        "GOSS_MAX_CONCURRENT": "5",
+        "GOSS_USE_ALPHA": "1"
+      },
+      "vars_file": "{{user `goss_vars_file`}}",
+      "vars_inline": {
+        "OS": "{{user `distro_name` | lower}}",
+        "PROVIDER": "ova",
+        "containerd_version": "{{user `containerd_version`}}",
+        "distribution_version": "{{user `distro_version`}}",
+        "docker_ee_version": "{{user `docker_ee_version`}}",
+        "kubernetes_version": "{{user `kubernetes_semver`}}",
+        "pause_image": "{{user `pause_image`}}",
+        "runtime": "{{user `runtime`}}"
+      },
+      "version": "{{user `goss_version`}}"
     }
   ],
   "variables": {


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds the Goss components needed to run Goss checks on windows images built for Azure, AWS and VSphere(OVA), and is based on groundwork done in Goss by @jsturtevant 

Which issue(s) this PR fixes: Fixes #532

**Additional context**
Due to a number of fixes in the packer goss provisioned and the Goss CLI this requires an update to the latest Goss and Packer versions.  The intention here is to provide a starting point to carry on adding more checks are more functionality is added and also to stay aligned to the checks done on Linux nodes.  There are some gaps in feature parity for Goss that we need to work out but I think this lays the groundwork for more additions

/sig windows
/cc @jsturtevant 