### PR TITLE
Include Windows hns fix for WS 2019 - 2c+ (Feb 2021 feature update)

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -104,6 +104,16 @@
     start_mode: auto
     state: started
 
+# If multiple LB policies are included for same endpoint then HNS hangs and requires restart
+# this fix forces an error instead of locking up (Fix is available in 2021-2C+)
+- name: Apply HNS fix for Multple LB policies
+  win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
+    state: present
+    name: HNSControlFlag
+    data: 1
+    type: dword
+
 - name: Add required Windows Features
   win_feature:
     name:


### PR DESCRIPTION
What this PR does / why we need it:
We found a bug in HNS Windows component when multiple LB policies are included for same endpoint then HNS hangs.  The only solution is to restart HNS.

This sets a registry key that causes HNS to throw an error instead of hanging.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

This was first reported in aks and aks-engine: https://github.com/Azure/aks-engine/pull/4315

/sig windows
/cc @perithompson 