### PR TITLE
Containerd 1.4.4 fails with new SystemdCgroup changes with k8s master/1.21

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -38,8 +38,10 @@ version = 2
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pause_image }}"
   {% if kubernetes_semver is version('v1.21.0', '>=') %}
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-      SystemdCgroup = true
+    SystemdCgroup = true
   {% endif %}
 
 {% endif %}


### PR DESCRIPTION
Fixes #572

https://github.com/kubernetes-sigs/image-builder/commit/d7b14e32fbff4ba8885b428220cf0a129e24e365 was not enough, We need to add some additional information for this to work. 

Future work: we should `containerd config default > /etc/containerd/config.tom` and replace the values for this to work long term (hat tip to @mikebrow)