### PR TITLE
Add image-builder support to build qcow2 images for IBM Cloud VPC

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,6 +16,10 @@ aliases:
     - randomvariable
   image-builder-azure-reviewers:
     - jsturtevant
+  image-builder-ibmcloud-reviewers
+    - wentao-zh
+    - emmayang
+    - yiwenh
   image-builder-openstack-reviewers:
     - hidekazuna
   image-builder-raw-maintainers:
@@ -52,6 +56,10 @@ aliases:
     - MorrisLaw
     - prksu
     - timoreimann
+  cluster-api-ibmcloud-maintainers:
+    - gyliu513
+    - jichenjc
+    - xunpan
   cluster-api-openstack-maintainers:
     - chaosaffe
     - chrigl

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -10,6 +10,6 @@
   - [OpenStack](./capi/providers/openstack.md)
   - [raw](./capi/providers/raw.md)
   - [vSphere](./capi/providers/vsphere.md)
+  - [IBM Cloud VPC](./capi/providers/ibmcloudvpc.md)
   - [Testing the Images](./capi/goss/goss.md)
-  - [Using Container Images](./capi/container-image.md)
 - [Glossary](./glossary.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -12,4 +12,5 @@
   - [vSphere](./capi/providers/vsphere.md)
   - [IBM Cloud VPC](./capi/providers/ibmcloudvpc.md)
   - [Testing the Images](./capi/goss/goss.md)
+  - [Using Container Images](./capi/container-image.md)
 - [Glossary](./glossary.md)

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -12,5 +12,4 @@
   - [vSphere](./capi/providers/vsphere.md)
   - [IBM Cloud VPC](./capi/providers/ibmcloudvpc.md)
   - [Testing the Images](./capi/goss/goss.md)
-  - [Using Container Images](./capi/container-image.md)
 - [Glossary](./glossary.md)

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -18,10 +18,10 @@ If any needed binaries are not present, they can be installed to `images/capi/.b
 * [Azure](./providers/azure.md)
 * [DigitalOcean](./providers/digitalocean.md)
 * [GCP](./providers/gcp.md)
+* [IBM Cloud VPC](./providers/ibmcloudvpc.md)
 * [OpenStack](./providers/openstack.md)
 * [Raw](./providers/raw.md)
 * [vSphere](./providers/vsphere.md)
-* [IBM Cloud VPC](./providers/ibmcloudvpc.md)
 
 ## Make targets
 

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -21,6 +21,7 @@ If any needed binaries are not present, they can be installed to `images/capi/.b
 * [OpenStack](./providers/openstack.md)
 * [Raw](./providers/raw.md)
 * [vSphere](./providers/vsphere.md)
+* [IBM Cloud VPC](./providers/ibmcloudvpc.md)
 
 ## Make targets
 
@@ -58,7 +59,7 @@ Several variables can be used to customize the image build.
 | `no_proxy` | This can be set to a comma-delimited list of domains that should be exluded from proxying during the Ansible stage of building | `""` |
 | `reenable_public_repos` | If set to `"false"`, the package repositories disabled by setting `disable_public_repos` will remain disabled at the end of the build. | `"true"` |
 | `remove_extra_repos` | If set to `"true"`, the package repositories added to the OS through the use of `extra_repos` will be removed at the end of the build. | `"false"` |
-| `pause_image` | This can be used to override the default pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.4.1"` |
+| `containerd_pause_image` | This can be used to override the default containerd pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.2"` |
 | `containerd_additional_settings` | This is a string, base64 encoded, that contains additional configuration for containerd. It must be version 2 and not contain the pause image configuration block. See `image-builder/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml` for the template. | `null` |
 
 The variables found in `packer/config/*.json` or `packer/<provider>/*.json` should not need to be modified directly. For customization it is better to create a JSON file with your changes and provide it via the `PACKER_VAR_FILES` environment variable. Variables set in this file will override any previous values. Multiple files can be passed via `PACKER_VAR_FILES`, with the last file taking precedence over any others.

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -59,7 +59,7 @@ Several variables can be used to customize the image build.
 | `no_proxy` | This can be set to a comma-delimited list of domains that should be exluded from proxying during the Ansible stage of building | `""` |
 | `reenable_public_repos` | If set to `"false"`, the package repositories disabled by setting `disable_public_repos` will remain disabled at the end of the build. | `"true"` |
 | `remove_extra_repos` | If set to `"true"`, the package repositories added to the OS through the use of `extra_repos` will be removed at the end of the build. | `"false"` |
-| `pause_image` | This can be used to override the default pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.4.1"` |
+| `containerd_pause_image` | This can be used to override the default containerd pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.2"` |
 | `containerd_additional_settings` | This is a string, base64 encoded, that contains additional configuration for containerd. It must be version 2 and not contain the pause image configuration block. See `image-builder/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml` for the template. | `null` |
 
 The variables found in `packer/config/*.json` or `packer/<provider>/*.json` should not need to be modified directly. For customization it is better to create a JSON file with your changes and provide it via the `PACKER_VAR_FILES` environment variable. Variables set in this file will override any previous values. Multiple files can be passed via `PACKER_VAR_FILES`, with the last file taking precedence over any others.

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -59,7 +59,7 @@ Several variables can be used to customize the image build.
 | `no_proxy` | This can be set to a comma-delimited list of domains that should be exluded from proxying during the Ansible stage of building | `""` |
 | `reenable_public_repos` | If set to `"false"`, the package repositories disabled by setting `disable_public_repos` will remain disabled at the end of the build. | `"true"` |
 | `remove_extra_repos` | If set to `"true"`, the package repositories added to the OS through the use of `extra_repos` will be removed at the end of the build. | `"false"` |
-| `containerd_pause_image` | This can be used to override the default containerd pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.2"` |
+| `pause_image` | This can be used to override the default pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.4.1"` |
 | `containerd_additional_settings` | This is a string, base64 encoded, that contains additional configuration for containerd. It must be version 2 and not contain the pause image configuration block. See `image-builder/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml` for the template. | `null` |
 
 The variables found in `packer/config/*.json` or `packer/<provider>/*.json` should not need to be modified directly. For customization it is better to create a JSON file with your changes and provide it via the `PACKER_VAR_FILES` environment variable. Variables set in this file will override any previous values. Multiple files can be passed via `PACKER_VAR_FILES`, with the last file taking precedence over any others.

--- a/docs/book/src/capi/providers/ibmcloudvpc.md
+++ b/docs/book/src/capi/providers/ibmcloudvpc.md
@@ -1,0 +1,54 @@
+# Building Images for IBM Cloud VPC
+
+## Hypervisor
+
+The image is built using KVM hypervisor.
+
+### Prerequisites for QCOW2
+
+Execute the following command to install qemu-kvm and other packages if you are running Ubuntu 18.04 LTS.
+
+#### Installing packages to use qemu-img
+
+```bash
+$ sudo -i
+# apt install qemu-kvm libvirt-bin qemu-utils
+```
+
+If you're on Ubuntu 20.04 LTS, then execute the following command to install qemu-kvm packages.
+
+```bash
+$ sudo -i
+# apt install qemu-kvm libvirt-daemon-system libvirt-clients virtinst cpu-checker libguestfs-tools libosinfo-bin
+```
+
+#### Adding your user to the kvm group
+
+```bash
+$ sudo usermod -a -G kvm <yourusername>
+$ sudo chown root:kvm /dev/kvm
+```
+
+Then exit and log back in to make the change take place.
+
+## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building qemu images are managed by running:
+
+```bash
+cd image-builder/images/capi
+make deps-qemu
+```
+
+### Building QCOW2 Image
+
+From the `images/capi` directory, run `make build-qemu-ibmcloud-ubuntu-2004`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION.
+
+For building a ubuntu-2004 based capi image, run the following commands -
+
+```bash
+$ git clone https://github.com/kubernetes-sigs/image-builder.git
+$ cd image-builder/images/capi/
+$ make build-qemu-ibmcloud-ubuntu-2004
+```

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -243,6 +243,8 @@ DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 QEMU_FLATCAR_BUILD_NAMES	?=	qemu-flatcar
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004
 
+QEMU_IBMCLOUD_BUILD_NAMES       ?= qemu-ibmcloud-ubuntu-2004
+
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004
 
 ## --------------------------------------
@@ -275,6 +277,8 @@ QEMU_FLATCAR_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_FLATCAR_BUILD_NAMES))
 QEMU_FLATCAR_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_FLATCAR_BUILD_NAMES))
 QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 QEMU_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_BUILD_NAMES))
+QEMU_IBMCLOUD_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_IBMCLOUD_BUILD_NAMES))
+QEMU_IBMCLOUD_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_IBMCLOUD_BUILD_NAMES))
 RAW_BUILD_TARGETS      := $(addprefix build-,$(RAW_BUILD_NAMES))
 RAW_VALIDATE_TARGETS   := $(addprefix validate-,$(RAW_BUILD_NAMES))
 
@@ -390,6 +394,14 @@ $(QEMU_BUILD_TARGETS): deps-qemu
 $(QEMU_VALIDATE_TARGETS): deps-qemu
 	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/qemu/packer.json
 
+.PHONY: $(QEMU_IBMCLOUD_BUILD_TARGETS)
+$(QEMU_IBMCLOUD_BUILD_TARGETS): deps-qemu
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/ibmcloud/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/ibmcloud/packer.json
+
+.PHONY: $(QEMU_IBMCLOUD_VALIDATE_TARGETS)
+$(QEMU_IBMCLOUD_VALIDATE_TARGETS): deps-qemu
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/ibmcloud/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/ibmcloud/packer.json
+
 .PHONY: $(RAW_BUILD_TARGETS)
 $(RAW_BUILD_TARGETS): deps-raw
 	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/raw/packer.json
@@ -416,6 +428,11 @@ QEMU_CLEAN_TARGETS := $(subst build-,clean-,$(QEMU_BUILD_TARGETS))
 .PHONY: $(QEMU_CLEAN_TARGETS)
 $(QEMU_CLEAN_TARGETS):
 	rm -fr output/$(subst clean-qemu-,,$@)-kube*
+
+QEMU_IBMCLOUD_CLEAN_TARGETS := $(subst build-,clean-,$(QEMU_IBMCLOUD_BUILD_TARGETS))
+.PHONY: $(QEMU_IBMCLOUD_CLEAN_TARGETS)
+$(QEMU_IBMCLOUD_CLEAN_TARGETS):
+	rm -fr output/$(subst clean-qemu-ibmcloud-,,$@)-ibmcloud-kube*
 
 RAW_CLEAN_TARGETS := $(subst build-,clean-,$(RAW_CLEAN_TARGETS))
 .PHONY: $(RAW_CLEAN_TARGETS)
@@ -521,6 +538,8 @@ build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-all: $(QEMU_BUILD_TARGETS) ## Builds all Qemu images
 
+build-qemu-ibmcloud-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image for ibmcloud
+
 build-raw-ubuntu-1804: ## Builds Ubuntu 18.04 RAW image
 build-raw-ubuntu-2004: ## Builds Ubuntu 20.04 RAW image
 build-raw-all: $(RAW_BUILD_TARGETS) ## Builds all RAW images
@@ -592,6 +611,8 @@ validate-raw-ubuntu-1804: ## Validates Ubuntu 18.04 RAW image packer config
 validate-raw-ubuntu-2004: ## Validates Ubuntu 20.04 RAW image packer config
 validate-raw-all: $(RAW_VALIDATE_TARGETS) ## Validates all RAW Packer config
 
+validate-qemu-ibmcloud-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image for ibmcloud
+
 validate-all: validate-ami-all \
 	validate-azure-all \
 	validate-do-all \
@@ -618,6 +639,10 @@ clean-ova: $(NODE_OVA_LOCAL_CLEAN_TARGETS) $(HAPROXY_OVA_LOCAL_CLEAN_TARGETS)
 .PHONY: clean-qemu
 clean-qemu: ## Removes all qemu image output directories (see NOTE at top of help)
 clean-qemu: $(QEMU_CLEAN_TARGETS)
+
+.PHONY: clean-qemu-ibmcloud
+clean-qemu-ibmcloud: ## Removes all qemu image output directories (see NOTE at top of help)
+clean-qemu-ibmcloud: $(QEMU_IBMCLOUD_CLEAN_TARGETS)
 
 .PHONY: clean-raw
 clean-raw: ## Removes all raw image output directories (see NOTE at top of help)

--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -14,6 +14,7 @@
 
 [defaults]
 remote_tmp = /tmp/.ansible
+display_skipped_hosts = False
 
 [ssh_connection]
 pipelining = False

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -133,6 +133,13 @@
     src: etc/containerd/config.toml
     mode: 0644
 
+- name: Copy in containerd config overrides
+  template:
+    dest: /etc/containerd/config.toml
+    src: etc/containerd/config_ibmcloud.toml
+    mode: 0644
+  when: is_ibmcloud is defined
+
 - name: Copy in crictl config
   template:
     dest: /etc/crictl.yaml

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config_ibmcloud.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config_ibmcloud.toml
@@ -1,0 +1,82 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins.cgroups]
+    no_prometheus = false
+  [plugins.cri]
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    enable_selinux = false
+    sandbox_image = "k8s.gcr.io/pause:3.1"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins.cri.containerd]
+      snapshotter = "overlayfs"
+      no_pivot = false
+      [plugins.cri.containerd.default_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/sbin/runc"
+        runtime_root = ""
+      [plugins.cri.containerd.untrusted_workload_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/bin/runsc"
+        runtime_root = "/usr/local/bin/runsc"
+      [plugins.cri.containerd.gvisor]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/bin/runsc"
+        runtime_root = "/run/containerd/runsc"
+    [plugins.cri.cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+        [plugins.cri.registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+        [plugins.cri.registry.mirrors."k8s-support-cluster1"]
+          endpoint = ["https://k8s-support-cluster1.fyre.ibm.com"]
+    [plugins.cri.x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins.diff-service]
+    default = ["walking"]
+  [plugins.linux]
+    shim = "containerd-shim"
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins.opt]
+    path = "/opt/containerd"
+  [plugins.restart]
+    interval = "10s"
+  [plugins.scheduler]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/images/capi/hack/README.md
+++ b/images/capi/hack/README.md
@@ -1,0 +1,21 @@
+# Hack
+
+This directory has a collection of scripts that dont belong elsewhere and may go away some day.
+
+## serve-artifacts.go
+
+This script finds all relevant k8s artifacts (i.e. like the kubelet.exe) in a directory , serves them on an endpoint.
+
+It prints out the values corresponding to this endpoint so you can use it in input to image builder, i.e.
+
+
+```
+jayunit100@kcp-1:~/SOURCE/image-builder/images/capi/hack$ go run serve_artifacts.go 
+kubernetes_base_url: http://127.0.0.1:8080/my/k8s
+cloudbase_init_url: http://127.0.0.1:8080/**none**
+wins_url: http://127.0.0.1:8080/**none**
+nssm_url: http://127.0.0.1:8080/**none**
+``` 
+
+It has no dependencies, and this is intentional - it is just an example script for surfacing artifacts to image builder,
+to be adopted by vendors as needed

--- a/images/capi/hack/ensure-goss.sh
+++ b/images/capi/hack/ensure-goss.sh
@@ -23,9 +23,9 @@ set -o pipefail
 source hack/utils.sh
 
 # SHA are for amd64 arch.
-_version="2.0.0"
-darwin_sha256="be09a793cb63e898895e9d371eb9015ab2ca7c8b5e929c1d79bafc7e23e871e0"
-linux_sha256="97ed6de22ba8f1f7d9cefa6234e771121c2918563057c44a0615c47de98391e4"
+_version="3.0.3"
+darwin_sha256="279a33eb3102385ff3c0577b0d35c4f218e54dddb53e549c626aed1741c93f34"
+linux_sha256="687fda0873028fb60443339f47412856d08eea1007d274bda25078df426b21bc"
 _bin_url="https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${_version}/packer-provisioner-goss-v${_version}-${HOSTOS}-${HOSTARCH}.tar.gz"
 _tarfile="${HOME}/.packer.d/plugins/packer-provisioner-goss.tar.gz"
 _binfile="${HOME}/.packer.d/plugins/packer-provisioner-goss"

--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.6.6"
+_version="1.7.2"
 
 # Change directories to the parent directory of the one in which this
 # script is located.

--- a/images/capi/hack/serve_artifacts.go
+++ b/images/capi/hack/serve_artifacts.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"path/filepath"
+	"fmt"
+	"strings"
+)
+
+var (
+	dir     = flag.String("b", "", "base directory where kubelet, kube-proxy, containerd, and other binaries live")
+	port    = flag.String("p", "8080", "port to serve files on")
+	verbose = flag.Bool("v", false, "verbose logging")
+	ip = flag.String("ip", "127.0.0.1", "ip address to print for url default")
+)
+
+// This will be printed out as a YAML file that can serve as the input to the image
+// builder process...
+
+func main() {
+	artifacts := map[string]string {
+	   "kubelet.exe": "kubernetes_base_url",
+	   //"kubernetes_base_url": "https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/windows/amd64",
+	   "CloudbaseInit*": "cloudbase_init_url",  
+	   // "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/1.1.2/CloudbaseInitSetup_1_1_2_x64.msi",
+	   "wins.exe": "wins_url", //: "https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe",
+	   "nssm.exe": "nssm_url",
+	   // "nssm_url": "https://azurek8scishared.blob.core.windows.net/nssm/nssm.exe",
+	   //"additional_debug_files": "https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hack/DebugWindowsNode.ps1",
+	}
+
+	flag.Parse()
+
+	if _, err := strconv.Atoi(*port); err != nil {
+		log.Fatal("port provided must be a valid integer")
+	}
+
+	curr, err := os.Getwd()
+	if err != nil {
+		log.Fatal("os.Getwd(): ", err)
+	}
+
+	if len(*dir) > 0 {
+		if _, err := os.Stat(*dir); err != nil {
+			log.Fatal("failed to detect dir, err: ", err)
+		}
+		curr = *dir
+	}
+
+	fs := http.FileServer(http.Dir(curr))
+
+	http.Handle("/", http.StripPrefix("/", LoggerHandler{fs}))
+	addr := ":" + *port
+
+	// print out the relative path of each artifact so that we can make the right kind of
+	// input example.vars file... TODO print these as JSON...
+	for name,artifact := range artifacts {
+		path := findFile("./", name)
+		// this stuff can be copied out as a yaml input to image builder...
+		fmt.Println(fmt.Sprintf("%v: http://%v:8080/%v", artifact, *ip, path))
+	}
+
+	log.Println("Listening on", addr)
+
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}
+
+
+func findFile(targetDir string, artifact string) string {
+	result := "**none**"
+	err := filepath.Walk(targetDir,
+    func(path string, info os.FileInfo, err error) error {
+    if err != nil {
+        return err
+    }
+	if strings.Contains(path, artifact) {
+		result = filepath.Dir(path)
+	}
+	return nil
+	})
+	if err != nil {
+		log.Println(err)
+	}
+	return result
+}
+
+type LoggerHandler struct {
+	fs http.Handler
+}
+
+func (l LoggerHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	args := []interface{}{req.Method, req.RequestURI}
+	if *verbose {
+		args = append(args, req.RemoteAddr)
+	}
+
+	log.Println(args...)
+	l.fs.ServeHTTP(resp, req)
+}

--- a/images/capi/packer/azure/sku-template.json
+++ b/images/capi/packer/azure/sku-template.json
@@ -16,7 +16,7 @@
   "microsoft-azure-corevm.imageVisibility": true,
   "microsoft-azure-corevm.isPremiumThirdParty": false,
   "microsoft-azure-corevm.largeLogo": "https://capiofferlogos.blob.core.windows.net/logos/large216x216",
-  "microsoft-azure-corevm.mediumLogo": "hhttps://capiofferlogos.blob.core.windows.net/logos/medium90x90",
+  "microsoft-azure-corevm.mediumLogo": "https://capiofferlogos.blob.core.windows.net/logos/medium90x90",
   "microsoft-azure-corevm.migratedOffer": false,
   "microsoft-azure-corevm.operatingSystemFamily": "{{OS_FAMILY}}",
   "microsoft-azure-corevm.osType": "{{OS_TYPE}}",
@@ -36,5 +36,6 @@
   "microsoft-azure-corevm.supportsSriov": false,
   "microsoft-azure-corevm.termsOfUseURL": "https://github.com/cncf/foundation/blob/master/copyright-notices.md",
   "microsoft-azure-corevm.vmImagesPublicAzure": {},
+  "microsoft-azure-corevm.wideLogo": "https://capiofferlogos.blob.core.windows.net/logos/wide255x115",
   "planId": "{{ID}}"
 }

--- a/images/capi/packer/ibmcloud/OWNERS
+++ b/images/capi/packer/ibmcloud/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-ibmcloud-maintainers
+
+reviewers:
+  - cluster-api-ibmcloud-maintainers
+  - image-builder-ibmcloud-reviewers

--- a/images/capi/packer/ibmcloud/packer.json
+++ b/images/capi/packer/ibmcloud/packer.json
@@ -1,0 +1,133 @@
+{
+  "variables": {
+    "ansible_common_vars": "",
+    "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3 is_ibmcloud",
+    "boot_wait": "10s",
+    "build_timestamp": "{{timestamp}}",
+    "containerd_version": null,
+    "containerd_sha256": null,
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
+    "crictl_version": null,
+    "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
+    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "accelerator": "kvm",
+    "cpus": "1",
+    "disk_size": "20480",
+    "memory": "2048",
+    "format": "qcow2",
+    "headless": "true",
+    "kubernetes_cni_deb_version": null,
+    "kubernetes_cni_semver": null,
+    "kubernetes_cni_source_type": null,
+    "kubernetes_cni_http_source": null,
+    "kubernetes_series": null,
+    "kubernetes_semver": null,
+    "kubernetes_source_type": null,
+    "kubernetes_load_additional_imgs": null,
+    "kubernetes_http_source": null,
+    "kubernetes_rpm_version": null,
+    "kubernetes_deb_version": null,
+    "kubernetes_rpm_repo": null,
+    "kubernetes_rpm_gpg_key": null,
+    "kubernetes_deb_repo": null,
+    "kubernetes_deb_gpg_key": null,
+    "kubernetes_rpm_gpg_check": null,
+    "kubernetes_container_registry": null,
+    "machine_id_mode": "444",
+    "python_path": "",
+    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+    "qemu_binary": "qemu-system-x86_64",
+    "ssh_password": "builder",
+    "ssh_username": "builder"
+  },
+  "builders": [
+    {
+      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "output_directory": "{{user `output_directory`}}",
+      "type": "qemu",
+      "accelerator": "{{user `accelerator`}}",
+      "cpus": "{{user `cpus`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "memory": "{{user `memory`}}",
+      "boot_wait": "{{user `boot_wait`}}",
+      "disk_interface": "virtio-scsi",
+      "format": "{{user `format`}}",
+      "headless": "{{user `headless`}}",
+      "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_command_suffix`}}"
+      ],
+      "net_device": "virtio-net",
+      "qemu_binary": "{{user `qemu_binary`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "2h"
+    },
+    {
+      "name": "flatcar",
+      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "output_directory": "{{user `output_directory`}}",
+      "type": "qemu",
+      "accelerator": "{{user `accelerator`}}",
+      "cpus": "{{user `cpus`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "memory": "{{user `memory`}}",
+      "boot_wait": "{{user `boot_wait`}}",
+      "disk_interface": "virtio-scsi",
+      "format": "{{user `format`}}",
+      "headless": "{{user `headless`}}",
+      "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_command_suffix`}}"
+      ],
+      "net_device": "virtio-net",
+      "qemu_binary": "{{user `qemu_binary`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "2h"
+    }
+
+  ],
+  "provisioners": [
+    {
+      "only": ["flatcar"],
+      "type": "shell",
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "script": "./packer/files/bootstrap-flatcar.sh",
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
+    },
+    {
+      "type": "ansible",
+      "playbook_file": "./ansible/node.yml",
+      "user": "builder",
+      "ansible_env_vars": [
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
+        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "{{user `ansible_common_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_extra_vars`}}"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "only": ["flatcar"],
+      "type": "vagrant"
+    }
+  ]
+}

--- a/images/capi/packer/ibmcloud/qemu-ibmcloud-ubuntu-2004.json
+++ b/images/capi/packer/ibmcloud/qemu-ibmcloud-ubuntu-2004.json
@@ -1,0 +1,13 @@
+{
+  "build_name": "ubuntu-2004-ibmcloud",
+  "distro_name": "ubuntu",
+  "os_display_name": "Ubuntu 20.04",
+  "guest_os_type": "ubuntu-64",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+  "iso_checksum_type": "sha256",
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
+  "boot_command_suffix": "/20.04/preseed.cfg -- <wait><enter><wait>",
+  "shutdown_command": "shutdown -P now",
+  "is_ibmcloud": "true"
+}


### PR DESCRIPTION
What this PR does / why we need it:
The [Cluster API Provider IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud) project requires an image that can be deployed to IBM Cloud VPC. The images is of qcow2 format, similar to the qemu image that already exists for OpenStack, with a different containerd toml config.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #576

