### PR TITLE
Do not export manifest for vsphere and vsphere-clone builders

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -191,6 +191,7 @@
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "export": {
         "force": true,
+        "manifest": "{{ user `export_manifest`}}",
         "output_directory": "{{user `output_dir`}}"
       },
       "floppy_dirs": "{{ user `floppy_dirs`}}",
@@ -237,6 +238,7 @@
       "datastore": "{{user `datastore`}}",
       "export": {
         "force": true,
+        "manifest": "{{ user `export_manifest`}}",
         "output_directory": "{{user `output_dir`}}"
       },
       "folder": "{{user `folder`}}",
@@ -427,6 +429,7 @@
     "datastore": "",
     "disk_size": "20480",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "export_manifest": "none",
     "folder": "",
     "guest_os_type": null,
     "ib_version": "{{env `IB_VERSION`}}",


### PR DESCRIPTION
What this PR does / why we need it:
When components are exported from packer, a manifest file is also exported. This manifest file become invalid as we modify the OVF. When building the OVA using ovftool, it looks at this manifest file instead of generating it’s own and errors out.
The correct way to do it is not to export the manifest from packer anymore. Since when building with
- ovftool: It generates its own
- tar: mf is created in the post-processing. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers
Successful run output:

```
...
==> vsphere: Goss render ran successfully
==> vsphere:
==> vsphere:
==> vsphere:
==> vsphere: Downloading spec file and debug info
    vsphere: Downloading Goss specs from, /tmp/goss-spec.yaml and /tmp/debug-goss-spec.yaml to current dir
==> vsphere: Executing shutdown command...
==> vsphere: Deleting Floppy drives...
==> vsphere: Deleting Floppy image...
==> vsphere: Eject CD-ROM drives...
==> vsphere: Convert VM into template...
    vsphere: Starting export...
    vsphere: Downloading: ubuntu-2004-kube-v1.18.15-disk-0.vmdk
    vsphere: Exporting file: ubuntu-2004-kube-v1.18.15-disk-0.vmdk
    vsphere: Writing ovf...
==> vsphere: Clear boot order...
==> vsphere: Running post-processor: manifest
==> vsphere: Running post-processor: vsphere (type shell-local)
==> vsphere (shell-local): Running local shell script: /tmp/packer-shell265799257
    vsphere (shell-local): Opening OVF source: ubuntu-2004-kube-v1.18.15.ovf
    vsphere (shell-local): Opening OVA target: ubuntu-2004-kube-v1.18.15.ova
    vsphere (shell-local): Writing OVA package: ubuntu-2004-kube-v1.18.15.ova
    vsphere (shell-local): Transfer Completed
    vsphere (shell-local): Warning:
    vsphere (shell-local):  - No manifest file found.
    vsphere (shell-local):  - No supported manifest(sha1, sha256, sha512) entry found for: 'ubuntu-2004-kube-v1.18.15-disk-0.vmdk'.
    vsphere (shell-local): Completed successfully
    vsphere (shell-local): image-build-ova: cd .
    vsphere (shell-local): image-build-ova: loaded ubuntu-2004-kube-v1.18.15
    vsphere (shell-local): image-build-ova: create ovf ubuntu-2004-kube-v1.18.15.ovf
    vsphere (shell-local): image-build-ova: creating OVA from ubuntu-2004-kube-v1.18.15.ovf using ovftool
    vsphere (shell-local): image-build-ova: create ova checksum ubuntu-2004-kube-v1.18.15.ova.sha256
==> vsphere: Running post-processor: custom-post-processor (type shell-local)
==> vsphere (shell-local): Running local shell script: /tmp/packer-shell958684968
Build 'vsphere' finished after 17 minutes 29 seconds.
```