### PR TITLE
Add burrito server and README

### DIFF
--- a/images/capi/hack/README.md
+++ b/images/capi/hack/README.md
@@ -1,0 +1,21 @@
+# Hack
+
+This directory has a collection of scripts that dont belong elsewhere and may go away some day.
+
+## serve-artifacts.go
+
+This script finds all relevant k8s artifacts (i.e. like the kubelet.exe) in a directory , serves them on an endpoint.
+
+It prints out the values corresponding to this endpoint so you can use it in input to image builder, i.e.
+
+
+```
+jayunit100@kcp-1:~/SOURCE/image-builder/images/capi/hack$ go run serve_artifacts.go 
+kubernetes_base_url: http://127.0.0.1:8080/my/k8s
+cloudbase_init_url: http://127.0.0.1:8080/**none**
+wins_url: http://127.0.0.1:8080/**none**
+nssm_url: http://127.0.0.1:8080/**none**
+``` 
+
+It has no dependencies, and this is intentional - it is just an example script for surfacing artifacts to image builder,
+to be adopted by vendors as needed

--- a/images/capi/hack/serve_artifacts.go
+++ b/images/capi/hack/serve_artifacts.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"path/filepath"
+	"fmt"
+	"strings"
+)
+
+var (
+	dir     = flag.String("b", "", "base directory where kubelet, kube-proxy, containerd, and other binaries live")
+	port    = flag.String("p", "8080", "port to serve files on")
+	verbose = flag.Bool("v", false, "verbose logging")
+	ip = flag.String("ip", "127.0.0.1", "ip address to print for url default")
+)
+
+// This will be printed out as a YAML file that can serve as the input to the image
+// builder process...
+
+func main() {
+	artifacts := map[string]string {
+	   "kubelet.exe": "kubernetes_base_url",
+	   //"kubernetes_base_url": "https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/windows/amd64",
+	   "CloudbaseInit*": "cloudbase_init_url",  
+	   // "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/1.1.2/CloudbaseInitSetup_1_1_2_x64.msi",
+	   "wins.exe": "wins_url", //: "https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe",
+	   "nssm.exe": "nssm_url",
+	   // "nssm_url": "https://azurek8scishared.blob.core.windows.net/nssm/nssm.exe",
+	   //"additional_debug_files": "https://raw.githubusercontent.com/kubernetes-sigs/sig-windows-tools/master/hack/DebugWindowsNode.ps1",
+	}
+
+	flag.Parse()
+
+	if _, err := strconv.Atoi(*port); err != nil {
+		log.Fatal("port provided must be a valid integer")
+	}
+
+	curr, err := os.Getwd()
+	if err != nil {
+		log.Fatal("os.Getwd(): ", err)
+	}
+
+	if len(*dir) > 0 {
+		if _, err := os.Stat(*dir); err != nil {
+			log.Fatal("failed to detect dir, err: ", err)
+		}
+		curr = *dir
+	}
+
+	fs := http.FileServer(http.Dir(curr))
+
+	http.Handle("/", http.StripPrefix("/", LoggerHandler{fs}))
+	addr := ":" + *port
+
+	// print out the relative path of each artifact so that we can make the right kind of
+	// input example.vars file... TODO print these as JSON...
+	for name,artifact := range artifacts {
+		path := findFile("./", name)
+		// this stuff can be copied out as a yaml input to image builder...
+		fmt.Println(fmt.Sprintf("%v: http://%v:8080/%v", artifact, *ip, path))
+	}
+
+	log.Println("Listening on", addr)
+
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}
+
+
+func findFile(targetDir string, artifact string) string {
+	result := "**none**"
+	err := filepath.Walk(targetDir,
+    func(path string, info os.FileInfo, err error) error {
+    if err != nil {
+        return err
+    }
+	if strings.Contains(path, artifact) {
+		result = filepath.Dir(path)
+	}
+	return nil
+	})
+	if err != nil {
+		log.Println(err)
+	}
+	return result
+}
+
+type LoggerHandler struct {
+	fs http.Handler
+}
+
+func (l LoggerHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	args := []interface{}{req.Method, req.RequestURI}
+	if *verbose {
+		args = append(args, req.RemoteAddr)
+	}
+
+	log.Println(args...)
+	l.fs.ServeHTTP(resp, req)
+}


### PR DESCRIPTION
This mostly  allows you to take an imgpkg bundle, find the artifacts in it, and host them on an endpoint .  It has no external dependencies, just go run it.    It'll reverse engineer the 'base_url" fields by finding the root directory, thus it allows any arbitrary packaging of binaries to be surfaced to output an image builder compatible input  file... 

Output:

```
jayunit100@kcp-1:~/SOURCE/image-builder/images/capi/hack$ go run serve_artifacts.go 
kubernetes_base_url: http://127.0.0.1:8080/my/k8s
cloudbase_init_url: http://127.0.0.1:8080/**none**
wins_url: http://127.0.0.1:8080/**none**
nssm_url: http://127.0.0.1:8080/**none**
```
assuming @perithompson will have fun with this tomorrow :) :) :) 
Fixes #571 