### PR TITLE
Clean up and *use* the ansible.cfg file

### DIFF
--- a/images/capi/.dockerignore
+++ b/images/capi/.dockerignore
@@ -3,6 +3,7 @@
 
 # Exceptions
 !ansible
+!ansible.cfg
 !cloudinit
 !hack
 !packer

--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -28,6 +28,7 @@ USER imagebuilder
 WORKDIR /home/imagebuilder/
 
 COPY --chown=imagebuilder:imagebuilder ansible ansible/
+COPY --chown=imagebuilder:imagebuilder ansible.cfg ansible.cfg
 COPY --chown=imagebuilder:imagebuilder cloudinit cloudinit/
 COPY --chown=imagebuilder:imagebuilder hack hack/
 COPY --chown=imagebuilder:imagebuilder packer packer/

--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[default]
-remote_tmp = /tmp/.ansible/
-filter_plugins = ./filter_plugins
-retry_files_enabled = False
+[defaults]
+remote_tmp = /tmp/.ansible
 
 [ssh_connection]
-pipelining = True
+pipelining = False

--- a/images/capi/ansible/playbook.retry
+++ b/images/capi/ansible/playbook.retry
@@ -1,1 +1,0 @@
-default

--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -75,9 +75,6 @@
   ],
   "provisioners": [
     {
-      "ansible_env_vars": [
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
-      ],
       "extra_arguments": [
         "-e",
         "ansible_winrm_server_cert_validation=ignore",

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -91,8 +91,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -98,9 +98,6 @@
       "type": "powershell"
     },
     {
-      "ansible_env_vars": [
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
-      ],
       "extra_arguments": [
         "-e",
         "ansible_winrm_server_cert_validation=ignore ansible_winrm_operation_timeout_sec=120 ansible_winrm_read_timeout_sec=150",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -100,8 +100,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/images/capi/packer/digitalocean/packer.json
+++ b/images/capi/packer/digitalocean/packer.json
@@ -31,8 +31,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -33,8 +33,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/images/capi/packer/ova/packer-haproxy.json
+++ b/images/capi/packer/ova/packer-haproxy.json
@@ -143,8 +143,7 @@
   "provisioners": [
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -332,8 +332,7 @@
   "provisioners": [
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "except": [
         "vmware-iso-base",
@@ -362,8 +361,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "except": [
         "vmware-iso-base",

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -157,9 +157,6 @@
   ],
   "provisioners": [
     {
-      "ansible_env_vars": [
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
-      ],
       "extra_arguments": [
         "-e",
         "ansible_winrm_server_cert_validation=ignore",

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -78,8 +78,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -83,8 +83,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
-        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
       "extra_arguments": [
         "--extra-vars",


### PR DESCRIPTION
What this PR does / why we need it:
The `ansible.cfg` file that is present in `images/capi/ansible` is not used
in any way because the Ansible commands won't pick it up in that
location. Since Ansible is run with a PWD of `images/cap`i, put it there
instead.

Additionally, the .cfg file mistakenly had 'default' instead of
'defaults', meaning that all entries were being ignored. We no longer
need to specify a search path for filter plugins since we haven't used
any in a while, and the setting for retry files is already the default
in Ansible.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
This makes what is being sought in #531 a *lot* easier (I tested it, it works, but wanted to leave that PR separate).

/hold

With this change in place, SSH Pipeline **will** be used. This is a change that can significantly speed up builds. I've got the `/hold` in place because we at least need to make sure that every OS we currently build works with this change. If any OS has `requiretty` set by default in `/etc/sudoers`, it won't work. This is becoming less common, but I have no idea who sets it and who doesn't at this point.

/assign @kkeshavamurthy @detiber @CecileRobertMichon 
if anyone does get a chance to take this for a spin, mind putting in a note what OS/provider combintation you tried to make sure the SSH pipelining worked?