### PR TITLE
Add CI script for populating GOSS tests

### DIFF
--- a/images/capi/hack/generate-goss-specs.py
+++ b/images/capi/hack/generate-goss-specs.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import itertools
+import json
+import os
+import subprocess
+import sys
+
+root_path = os.path.abspath(os.path.join(sys.argv[0], '..', '..'))
+
+# Define what OS's are supported on which providers
+builds = {'amazon': ['amazon linux', 'centos', 'flatcar', 'ubuntu'],
+          'azure':  ['centos', 'ubuntu'],
+          'ova': ['centos', 'photon', 'rhel', 'ubuntu']}
+
+
+def generate_goss(provider, system, versions, dryrun=False, save=False):
+
+    cmd = ['goss', '-g', 'packer/goss/goss.yaml', '--vars', 'packer/goss/goss-vars.yaml']
+    vars = {'OS': system, 'PROVIDER': provider,
+            'containerd_version': versions['containerd'],
+            'kubernetes_version': versions['k8s'],
+            'kubernetes_deb_version': versions['k8s_deb'],
+            'kubernetes_rpm_version': versions['k8s_rpm'],
+            'kubernetes_source_type': 'pkg',
+            'kubernetes_cni_version': versions['cni'],
+            'kubernetes_cni_deb_version': versions['cni_deb'],
+            'kubernetes_cni_rpm_version': versions['cni_rpm'],
+            'kubernetes_cni_source_type': 'pkg'}
+
+    # Build command
+    cmd.extend(['--vars-inline', json.dumps(vars), 'render'])
+    print('generating os: %s, provider: %s' % (system, provider))
+    print(cmd)
+
+    # Run command with output going to file
+    if not dryrun:
+        if save:
+            out_dir = os.path.join(root_path, 'packer', 'goss')
+            out_filename = '%s-%s-%s-goss-spec.yaml' % (provider,
+                                                        system.replace(' ', '-'), versions['k8s'])
+            out_filename = os.path.join(out_dir, out_filename)
+            with open(out_filename, 'w') as f:
+                subprocess.run(cmd, cwd=root_path, stdout=f, check=True)
+        else:
+            subprocess.run(cmd, cwd=root_path, check=True)
+
+
+def read_json_file(filename):
+    j = None
+    with open(filename, 'r') as f:
+        j = json.load(f)
+    return j
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generates GOSS specs. By default, generates all '
+                    'possible specs to stdout.',
+        usage='%(prog)s [-h] [--provider {amazon,azure,ova}] '
+              '[--os {al2,centos,flatcar,photon,rhel,ubuntu}]')
+    parser.add_argument('--provider',
+                        choices=['amazon', 'azure', 'ova'],
+                        action='append',
+                        default=None,
+                        help='One provider. Can be used multiple times')
+    parser.add_argument('--os',
+                        choices=['al2', 'centos', 'flatcar', 'photon', 'rhel', 'ubuntu'],
+                        action='append',
+                        default=None,
+                        help='One OS. Can be used multiple times')
+    parser.add_argument('--dry-run',
+                        action='store_true',
+                        help='Do not run GOSS, just print GOSS commands')
+    parser.add_argument('--write',
+                        action='store_true',
+                        help='Write GOSS specs to file')
+    args = parser.parse_args()
+
+    versions = {}
+    # Load JSON files with Version info
+    cni = read_json_file(os.path.join(root_path, 'packer', 'config', 'cni.json'))
+    versions['cni'] = cni['kubernetes_cni_semver'].lstrip('v')
+    versions['cni_deb'] = cni['kubernetes_cni_deb_version']
+    versions['cni_rpm'] = cni['kubernetes_cni_rpm_version'].split('-')[0]
+
+    k8s = read_json_file(os.path.join(root_path, 'packer', 'config', 'kubernetes.json'))
+    versions['k8s'] = k8s['kubernetes_semver'].lstrip('v')
+    versions['k8s_deb'] = k8s['kubernetes_deb_version']
+    versions['k8s_rpm'] = k8s['kubernetes_rpm_version'].split('-')[0]
+
+    containerd = read_json_file(os.path.join(root_path, 'packer', 'config', 'containerd.json'))
+    versions['containerd'] = containerd['containerd_version']
+
+    providers = builds.keys()
+    if args.provider is not None:
+        providers = args.provider
+
+    # Generate a unique list of all possible OS's if a choice wasn't made
+    oss = args.os
+    if args.os is None:
+        oss = []
+        for x in list(builds.values()):
+            for o in x:
+                oss.append(o)
+        oss = list(set(oss))
+    oss = [sub.replace('al2', 'amazon linux') for sub in oss]
+
+    # Generate spec for each valid permutation
+    for provider, system in itertools.product(providers, oss):
+        if system in builds[provider]:
+            generate_goss(provider, system, versions, args.dry_run, args.write)
+
+
+if __name__ == '__main__':
+    main()

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -58,12 +58,6 @@ command:
     stderr: []
     timeout: 0
 {{end}}
-{{range $name, $vers := index .Vars .Vars.OS "common-command"}}
-  {{ $name }}:
-  {{range $key, $val := $vers}}
-    {{$key}}: {{$val}}
-  {{end}}
-{{end}}
 {{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "command"}}
   {{ $name }}:
   {{range $key, $val := $vers}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -75,7 +75,6 @@ kubernetes_load_additional_imgs: false
 # OS_NAME
 #   common-package:
 #   common-kernel-params:
-#   common-commands:
 #   common-services:
 #   PROVIDER_NAME:
 #     package:
@@ -112,6 +111,22 @@ centos:
       cloud-init:
       cloud-utils-growpart:
       python2-pip:
+flatcar:
+  amazon:
+    command:
+photon:
+  common-kernel-param:
+    net.ipv4.tcp_limit_output_bytes:
+      value: "524288"
+  common-package:
+    <<: *common_photon_rpms
+    audit:
+  ova:
+    package:
+      open-vm-tools:
+      cloud-init:
+      cloud-utils:
+      python3-netifaces:
 rhel:
   common-package: *common_rpms
   ova:
@@ -162,16 +177,3 @@ ubuntu:
       cloud-guest-utils:
       cloud-initramfs-copymods:
       cloud-initramfs-dyn-netconf:
-photon:
-  common-kernel-param:
-    net.ipv4.tcp_limit_output_bytes:
-      value: "524288"
-  common-package:
-    <<: *common_photon_rpms
-    audit:
-  ova:
-    package:
-      open-vm-tools:
-      cloud-init:
-      cloud-utils:
-      python3-netifaces:

--- a/images/capi/scripts/ci-goss-populate.sh
+++ b/images/capi/scripts/ci-goss-populate.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${CAPI_ROOT}" || exit 1
+
+source hack/utils.sh
+ensure_py3
+
+_version="v0.3.16"
+_bin_url="https://github.com/aelsabbahy/goss/releases/download/${_version}/goss-linux-amd64"
+
+if ! command -v goss >/dev/null 2>&1; then
+  if [[ ${HOSTOS} == "linux" ]]; then
+    curl -SsL "${_bin_url}" -o goss
+    chmod +x goss
+    mkdir -p "${PWD}/.local/bin"
+    mv goss "${PWD}/.local/bin"
+    export PATH=${PWD}/.local/bin:$PATH
+  fi
+fi
+
+export GOSS_USE_ALPHA=1
+hack/generate-goss-specs.py


### PR DESCRIPTION
What this PR does / why we need it:
The GOSS tests that run are generated dynamically from a combination of
a GOSS vars file, and inline vars from the Packer files. Since the GOSS
files have loops in them that look for specific keys, it is possible
that missing keys cause a failure in test generation. This CI test
ensures that the GOSS vars file has all required keys and that the
templates render successfully.

Right now, Flatcar does not use the same mechanism as all other OS's,
but this CI job tests it as if it does, so that that transition is
possible if we ever try that.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
/hold

I need to open a PR in `test-infra` to call this test, and we should do that first to test the test.

I thought this was a good idea to get into place before we pull in Windows GOSS tests.