### PR TITLE
Allow CI tests to be called from images/capi/scripts dir

### DIFF
--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -16,28 +16,7 @@
 
 ###############################################################################
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
-[[ -n ${DEBUG:-} ]] && set -o xtrace
-
 CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
-cleanup() {
-    returnCode="$?"
-    exit "${returnCode}"
-}
-
-trap cleanup EXIT
-
-json_files=$(find . -type f -name "*.json" | sort -u)
-for f in ${json_files}
-do
-  if ! diff <(jq -S . ${f}) ${f} >> /dev/null; then
-    echo "json files are not sorted!! Please sort them with \"make json-sort\" in \"images/capi\" before commit"
-    echo "Unsorted file: ${f}"
-    exit 1
-  fi
-done
+packer/azure/scripts/ci-azure-e2e.sh

--- a/images/capi/scripts/ci-json-sort.sh
+++ b/images/capi/scripts/ci-json-sort.sh
@@ -1,0 +1,1 @@
+../hack/ci-json-sort.sh


### PR DESCRIPTION
What this PR does / why we need it:
All CI scripts are being relocated into images/capi/scripts. This commit creates symlinks to those that can be symlink'd easily, and for the Azure CI test, creates an intermediate script file that calls the original. Once CI jobs are updated to reference new locations, files will be moved for real.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**