### PR TITLE
Custom role names comma delimeter

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -48,7 +48,7 @@ Several variables can be used to customize the image build.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `custom_role` | If set to `"true"`, this will cause `image-builder` to run a custom Ansible role right before the `sysprep` role to allow for further customization. | `"false"` |
-| `custom_role_names` | This must be set if `custom_role` is set to `"true"`, and is the space delimited string of the roles to run. If the role is placed in the `ansible/roles` directory, it can be referenced by name. Otherwise, it must be a fully qualified path to the role. | `""` |
+| `custom_role_names` | This must be set if `custom_role` is set to `"true"`, and is the comma delimited string of the roles to run. If the role is placed in the `ansible/roles` directory, it can be referenced by name. Otherwise, it must be a fully qualified path to the role. | `""` |
 | `disable_public_repos` | If set to `"true"`, this will disable all existing package repositories defined in the OS before doing any package installs. The `extra_repos` variable *must* be set for package installs to succeed. | `"false"` |
 | `extra_debs` | This can be set to a space delimited string containing the names of additional deb packages to install | `""` |
 | `extra_repos` | A space delimited string containing the names of files to add to the image containing repository definitions. The files should be given as absolute paths. | `""` |

--- a/images/capi/ansible/haproxy.yml
+++ b/images/capi/ansible/haproxy.yml
@@ -24,7 +24,7 @@
         name: pki
     - include_role:
         name: "{{ role }}"
-      loop: "{{ custom_role_names.split() }}"
+      loop: "{{ custom_role_names.split(',') }}"
       loop_control:
         loop_var: role
       when: custom_role | default(false)|bool

--- a/images/capi/ansible/node.yml
+++ b/images/capi/ansible/node.yml
@@ -26,7 +26,7 @@
         name: kubernetes
     - include_role:
         name: "{{ role }}"
-      loop: "{{ custom_role_names.split() }}"
+      loop: "{{ custom_role_names.split(',') }}"
       loop_control:
         loop_var: role
       when: custom_role | default(false)|bool

--- a/images/capi/ansible/windows/node_windows.yml
+++ b/images/capi/ansible/windows/node_windows.yml
@@ -36,7 +36,7 @@
         name: debug
     - include_role:
         name: "{{ role }}"
-      loop: "{{ custom_role_names.split() }}"
+      loop: "{{ custom_role_names.split(',') }}"
       loop_control:
         loop_var: role
       when: custom_role | default(false)|bool


### PR DESCRIPTION
What this PR does / why we need it:

This PR is required because, we found out during our testing that second ansible roles is being ignored when using `custom_role_names` delimited by spaces. I think this most likely due to the way packer is passing the variable values to ansible. 

Anyway it is probably easier to use commas as delimiters. 

