### PR TITLE
Fix typo and add wide version of Azure logo

### DIFF
--- a/images/capi/packer/azure/sku-template.json
+++ b/images/capi/packer/azure/sku-template.json
@@ -16,7 +16,7 @@
   "microsoft-azure-corevm.imageVisibility": true,
   "microsoft-azure-corevm.isPremiumThirdParty": false,
   "microsoft-azure-corevm.largeLogo": "https://capiofferlogos.blob.core.windows.net/logos/large216x216",
-  "microsoft-azure-corevm.mediumLogo": "hhttps://capiofferlogos.blob.core.windows.net/logos/medium90x90",
+  "microsoft-azure-corevm.mediumLogo": "https://capiofferlogos.blob.core.windows.net/logos/medium90x90",
   "microsoft-azure-corevm.migratedOffer": false,
   "microsoft-azure-corevm.operatingSystemFamily": "{{OS_FAMILY}}",
   "microsoft-azure-corevm.osType": "{{OS_TYPE}}",
@@ -36,5 +36,6 @@
   "microsoft-azure-corevm.supportsSriov": false,
   "microsoft-azure-corevm.termsOfUseURL": "https://github.com/cncf/foundation/blob/master/copyright-notices.md",
   "microsoft-azure-corevm.vmImagesPublicAzure": {},
+  "microsoft-azure-corevm.wideLogo": "https://capiofferlogos.blob.core.windows.net/logos/wide255x115",
   "planId": "{{ID}}"
 }


### PR DESCRIPTION
What this PR does / why we need it:

There was a typo in #564 when we attempted to comply with new Azure Marketplace logo requirements. Additionally, the "wide" version of the logo does appear to be required when submitting an offer programmatically, so this adds that back in.

I've tested this change directly on the Azure repo synced with image-builder and our offer pipeline to verify this fix.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers