### PR TITLE
Add image-builder support to build qcow2 images for IBM Cloud VPC

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,6 +16,10 @@ aliases:
     - randomvariable
   image-builder-azure-reviewers:
     - jsturtevant
+  image-builder-ibmcloud-reviewers
+    - wentao-zh
+    - emmayang
+    - yiwenh
   image-builder-openstack-reviewers:
     - hidekazuna
   image-builder-raw-maintainers:
@@ -52,6 +56,10 @@ aliases:
     - MorrisLaw
     - prksu
     - timoreimann
+  cluster-api-ibmcloud-maintainers:
+    - gyliu513
+    - jichenjc
+    - xunpan
   cluster-api-openstack-maintainers:
     - chaosaffe
     - chrigl

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Azure](./capi/providers/azure.md)
   - [DigitalOcean](./capi/providers/digitalocean.md)
   - [GCP](./capi/providers/gcp.md)
+  - [IBM Cloud VPC](./capi/providers/ibmcloudvpc.md)
   - [OpenStack](./capi/providers/openstack.md)
   - [raw](./capi/providers/raw.md)
   - [vSphere](./capi/providers/vsphere.md)

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -18,6 +18,7 @@ If any needed binaries are not present, they can be installed to `images/capi/.b
 * [Azure](./providers/azure.md)
 * [DigitalOcean](./providers/digitalocean.md)
 * [GCP](./providers/gcp.md)
+* [IBM Cloud VPC](./providers/ibmcloudvpc.md)
 * [OpenStack](./providers/openstack.md)
 * [Raw](./providers/raw.md)
 * [vSphere](./providers/vsphere.md)

--- a/docs/book/src/capi/providers/ibmcloudvpc.md
+++ b/docs/book/src/capi/providers/ibmcloudvpc.md
@@ -1,0 +1,54 @@
+# Building Images for IBM Cloud VPC
+
+## Hypervisor
+
+The image is built using KVM hypervisor.
+
+### Prerequisites for QCOW2
+
+Execute the following command to install qemu-kvm and other packages if you are running Ubuntu 18.04 LTS.
+
+#### Installing packages to use qemu-img
+
+```bash
+$ sudo -i
+# apt install qemu-kvm libvirt-bin qemu-utils
+```
+
+If you're on Ubuntu 20.04 LTS, then execute the following command to install qemu-kvm packages.
+
+```bash
+$ sudo -i
+# apt install qemu-kvm libvirt-daemon-system libvirt-clients virtinst cpu-checker libguestfs-tools libosinfo-bin
+```
+
+#### Adding your user to the kvm group
+
+```bash
+$ sudo usermod -a -G kvm <yourusername>
+$ sudo chown root:kvm /dev/kvm
+```
+
+Then exit and log back in to make the change take place.
+
+## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building qemu images are managed by running:
+
+```bash
+cd image-builder/images/capi
+make deps-qemu
+```
+
+### Building QCOW2 Image
+
+From the `images/capi` directory, run `make build-qemu-ibmcloud-ubuntu-2004`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION.
+
+For building a ubuntu-2004 based capi image, run the following commands -
+
+```bash
+$ git clone https://github.com/kubernetes-sigs/image-builder.git
+$ cd image-builder/images/capi/
+$ make build-qemu-ibmcloud-ubuntu-2004
+```

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -243,6 +243,8 @@ DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 QEMU_FLATCAR_BUILD_NAMES	?=	qemu-flatcar
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004
 
+QEMU_IBMCLOUD_BUILD_NAMES       ?= qemu-ibmcloud-ubuntu-2004
+
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004
 
 ## --------------------------------------
@@ -275,6 +277,8 @@ QEMU_FLATCAR_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_FLATCAR_BUILD_NAMES))
 QEMU_FLATCAR_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_FLATCAR_BUILD_NAMES))
 QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 QEMU_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_BUILD_NAMES))
+QEMU_IBMCLOUD_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_IBMCLOUD_BUILD_NAMES))
+QEMU_IBMCLOUD_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_IBMCLOUD_BUILD_NAMES))
 RAW_BUILD_TARGETS      := $(addprefix build-,$(RAW_BUILD_NAMES))
 RAW_VALIDATE_TARGETS   := $(addprefix validate-,$(RAW_BUILD_NAMES))
 
@@ -390,6 +394,14 @@ $(QEMU_BUILD_TARGETS): deps-qemu
 $(QEMU_VALIDATE_TARGETS): deps-qemu
 	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/qemu/packer.json
 
+.PHONY: $(QEMU_IBMCLOUD_BUILD_TARGETS)
+$(QEMU_IBMCLOUD_BUILD_TARGETS): deps-qemu
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/ibmcloud/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/ibmcloud/packer.json
+
+.PHONY: $(QEMU_IBMCLOUD_VALIDATE_TARGETS)
+$(QEMU_IBMCLOUD_VALIDATE_TARGETS): deps-qemu
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/ibmcloud/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/ibmcloud/packer.json
+
 .PHONY: $(RAW_BUILD_TARGETS)
 $(RAW_BUILD_TARGETS): deps-raw
 	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/raw/packer.json
@@ -416,6 +428,11 @@ QEMU_CLEAN_TARGETS := $(subst build-,clean-,$(QEMU_BUILD_TARGETS))
 .PHONY: $(QEMU_CLEAN_TARGETS)
 $(QEMU_CLEAN_TARGETS):
 	rm -fr output/$(subst clean-qemu-,,$@)-kube*
+
+QEMU_IBMCLOUD_CLEAN_TARGETS := $(subst build-,clean-,$(QEMU_IBMCLOUD_BUILD_TARGETS))
+.PHONY: $(QEMU_IBMCLOUD_CLEAN_TARGETS)
+$(QEMU_IBMCLOUD_CLEAN_TARGETS):
+	rm -fr output/$(subst clean-qemu-ibmcloud-,,$@)-ibmcloud-kube*
 
 RAW_CLEAN_TARGETS := $(subst build-,clean-,$(RAW_CLEAN_TARGETS))
 .PHONY: $(RAW_CLEAN_TARGETS)
@@ -521,6 +538,8 @@ build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-all: $(QEMU_BUILD_TARGETS) ## Builds all Qemu images
 
+build-qemu-ibmcloud-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image for ibmcloud
+
 build-raw-ubuntu-1804: ## Builds Ubuntu 18.04 RAW image
 build-raw-ubuntu-2004: ## Builds Ubuntu 20.04 RAW image
 build-raw-all: $(RAW_BUILD_TARGETS) ## Builds all RAW images
@@ -592,6 +611,8 @@ validate-raw-ubuntu-1804: ## Validates Ubuntu 18.04 RAW image packer config
 validate-raw-ubuntu-2004: ## Validates Ubuntu 20.04 RAW image packer config
 validate-raw-all: $(RAW_VALIDATE_TARGETS) ## Validates all RAW Packer config
 
+validate-qemu-ibmcloud-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image for ibmcloud
+
 validate-all: validate-ami-all \
 	validate-azure-all \
 	validate-do-all \
@@ -618,6 +639,10 @@ clean-ova: $(NODE_OVA_LOCAL_CLEAN_TARGETS) $(HAPROXY_OVA_LOCAL_CLEAN_TARGETS)
 .PHONY: clean-qemu
 clean-qemu: ## Removes all qemu image output directories (see NOTE at top of help)
 clean-qemu: $(QEMU_CLEAN_TARGETS)
+
+.PHONY: clean-qemu-ibmcloud
+clean-qemu-ibmcloud: ## Removes all qemu image output directories (see NOTE at top of help)
+clean-qemu-ibmcloud: $(QEMU_IBMCLOUD_CLEAN_TARGETS)
 
 .PHONY: clean-raw
 clean-raw: ## Removes all raw image output directories (see NOTE at top of help)

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -133,6 +133,13 @@
     src: etc/containerd/config.toml
     mode: 0644
 
+- name: Copy in containerd config overrides
+  template:
+    dest: /etc/containerd/config.toml
+    src: etc/containerd/config_ibmcloud.toml
+    mode: 0644
+  when: is_ibmcloud is defined
+
 - name: Copy in crictl config
   template:
     dest: /etc/crictl.yaml

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config_ibmcloud.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config_ibmcloud.toml
@@ -1,0 +1,82 @@
+root = "/var/lib/containerd"
+state = "/run/containerd"
+oom_score = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+
+[debug]
+  address = ""
+  uid = 0
+  gid = 0
+  level = ""
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[cgroup]
+  path = ""
+
+[plugins]
+  [plugins.cgroups]
+    no_prometheus = false
+  [plugins.cri]
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    enable_selinux = false
+    sandbox_image = "k8s.gcr.io/pause:3.1"
+    stats_collect_period = 10
+    systemd_cgroup = false
+    enable_tls_streaming = false
+    max_container_log_line_size = 16384
+    [plugins.cri.containerd]
+      snapshotter = "overlayfs"
+      no_pivot = false
+      [plugins.cri.containerd.default_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/sbin/runc"
+        runtime_root = ""
+      [plugins.cri.containerd.untrusted_workload_runtime]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/bin/runsc"
+        runtime_root = "/usr/local/bin/runsc"
+      [plugins.cri.containerd.gvisor]
+        runtime_type = "io.containerd.runtime.v1.linux"
+        runtime_engine = "/usr/local/bin/runsc"
+        runtime_root = "/run/containerd/runsc"
+    [plugins.cri.cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+        [plugins.cri.registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+        [plugins.cri.registry.mirrors."k8s-support-cluster1"]
+          endpoint = ["https://k8s-support-cluster1.fyre.ibm.com"]
+    [plugins.cri.x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+  [plugins.diff-service]
+    default = ["walking"]
+  [plugins.linux]
+    shim = "containerd-shim"
+    runtime = "runc"
+    runtime_root = ""
+    no_shim = false
+    shim_debug = false
+  [plugins.opt]
+    path = "/opt/containerd"
+  [plugins.restart]
+    interval = "10s"
+  [plugins.scheduler]
+    pause_threshold = 0.02
+    deletion_threshold = 0
+    mutation_threshold = 100
+    schedule_delay = "0s"
+    startup_delay = "100ms"

--- a/images/capi/packer/ibmcloud/OWNERS
+++ b/images/capi/packer/ibmcloud/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-ibmcloud-maintainers
+
+reviewers:
+  - cluster-api-ibmcloud-maintainers
+  - image-builder-ibmcloud-reviewers

--- a/images/capi/packer/ibmcloud/packer.json
+++ b/images/capi/packer/ibmcloud/packer.json
@@ -1,0 +1,133 @@
+{
+  "variables": {
+    "ansible_common_vars": "",
+    "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3 is_ibmcloud",
+    "boot_wait": "10s",
+    "build_timestamp": "{{timestamp}}",
+    "containerd_version": null,
+    "containerd_sha256": null,
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
+    "crictl_version": null,
+    "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
+    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "accelerator": "kvm",
+    "cpus": "1",
+    "disk_size": "20480",
+    "memory": "2048",
+    "format": "qcow2",
+    "headless": "true",
+    "kubernetes_cni_deb_version": null,
+    "kubernetes_cni_semver": null,
+    "kubernetes_cni_source_type": null,
+    "kubernetes_cni_http_source": null,
+    "kubernetes_series": null,
+    "kubernetes_semver": null,
+    "kubernetes_source_type": null,
+    "kubernetes_load_additional_imgs": null,
+    "kubernetes_http_source": null,
+    "kubernetes_rpm_version": null,
+    "kubernetes_deb_version": null,
+    "kubernetes_rpm_repo": null,
+    "kubernetes_rpm_gpg_key": null,
+    "kubernetes_deb_repo": null,
+    "kubernetes_deb_gpg_key": null,
+    "kubernetes_rpm_gpg_check": null,
+    "kubernetes_container_registry": null,
+    "machine_id_mode": "444",
+    "python_path": "",
+    "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+    "qemu_binary": "qemu-system-x86_64",
+    "ssh_password": "builder",
+    "ssh_username": "builder"
+  },
+  "builders": [
+    {
+      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "output_directory": "{{user `output_directory`}}",
+      "type": "qemu",
+      "accelerator": "{{user `accelerator`}}",
+      "cpus": "{{user `cpus`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "memory": "{{user `memory`}}",
+      "boot_wait": "{{user `boot_wait`}}",
+      "disk_interface": "virtio-scsi",
+      "format": "{{user `format`}}",
+      "headless": "{{user `headless`}}",
+      "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_command_suffix`}}"
+      ],
+      "net_device": "virtio-net",
+      "qemu_binary": "{{user `qemu_binary`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "2h"
+    },
+    {
+      "name": "flatcar",
+      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "output_directory": "{{user `output_directory`}}",
+      "type": "qemu",
+      "accelerator": "{{user `accelerator`}}",
+      "cpus": "{{user `cpus`}}",
+      "disk_size": "{{user `disk_size`}}",
+      "memory": "{{user `memory`}}",
+      "boot_wait": "{{user `boot_wait`}}",
+      "disk_interface": "virtio-scsi",
+      "format": "{{user `format`}}",
+      "headless": "{{user `headless`}}",
+      "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
+      "iso_checksum": "{{user `iso_checksum_type`}}:{{user `iso_checksum`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+        "{{user `boot_command_suffix`}}"
+      ],
+      "net_device": "virtio-net",
+      "qemu_binary": "{{user `qemu_binary`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_timeout": "2h"
+    }
+
+  ],
+  "provisioners": [
+    {
+      "only": ["flatcar"],
+      "type": "shell",
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "script": "./packer/files/bootstrap-flatcar.sh",
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi"
+    },
+    {
+      "type": "ansible",
+      "playbook_file": "./ansible/node.yml",
+      "user": "builder",
+      "ansible_env_vars": [
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'",
+        "ANSIBLE_REMOTE_TEMP='/tmp/.ansible/'"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "{{user `ansible_common_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_extra_vars`}}"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "only": ["flatcar"],
+      "type": "vagrant"
+    }
+  ]
+}

--- a/images/capi/packer/ibmcloud/qemu-ibmcloud-ubuntu-2004.json
+++ b/images/capi/packer/ibmcloud/qemu-ibmcloud-ubuntu-2004.json
@@ -1,0 +1,13 @@
+{
+  "build_name": "ubuntu-2004-ibmcloud",
+  "distro_name": "ubuntu",
+  "os_display_name": "Ubuntu 20.04",
+  "guest_os_type": "ubuntu-64",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
+  "iso_checksum_type": "sha256",
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
+  "boot_command_suffix": "/20.04/preseed.cfg -- <wait><enter><wait>",
+  "shutdown_command": "shutdown -P now",
+  "is_ibmcloud": "true"
+}


### PR DESCRIPTION
What this PR does / why we need it:
The [Cluster API Provider IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud) project requires an image that can be deployed to IBM Cloud VPC. The images is of qcow2 format, similar to the qemu image that already exists for OpenStack, with a different containerd toml config.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #576

Note:
This is a re-submission of [this PR](https://github.com/kubernetes-sigs/image-builder/pull/577) due to problem with rebasing my branch.