### PR TITLE
Remove Windows updates default settings to avoid automatic updates

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -13,7 +13,23 @@
 # limitations under the License.
 ---
 # This file was adapted from https://github.com/Azure/aks-engine/blob/master/vhd/packer/configure-windows-vhd.ps1 for ansible
-- name: Disable automatic windows updates
+- name: Remove Windows updates default registry settings
+  win_regedit:
+    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\
+    state: absent
+    delete_key: yes
+
+- name: Add Windows update registry path
+  win_regedit:
+    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate
+    state: present
+
+- name: Add Windows automatic update registry path
+  win_regedit:
+    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
+    state: present
+
+- name: Disable Windows automatic updates in registry
   win_regedit:
     path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
     state: present


### PR DESCRIPTION
What this PR does / why we need it:
Windows updates where not actually disabled.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #599 

**Additional context**
Add any other context for the reviewers

This was oringinally adopted from  aks-engines script.  You can see it manually removes the path which is why it doesn't have the `AUOptions` https://github.com/Azure/aks-engine/blob/73d698122b3c2444c58b29b59c19547e77a01364/vhd/packer/configure-windows-vhd.ps1#L30-L32

/sig windows
/assign @perithompson 