### PR TITLE
Fix apt-daily services and add GOSS tests

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -73,9 +73,7 @@
     state: stopped
     enabled: false
   loop:
-  - apt-daily
   - apt-daily.timer
-  - apt-daily-upgrade
   - apt-daily-upgrade.timer
 
 - name: Get installed packages

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -147,6 +147,13 @@ ubuntu:
       value: "1"
   common-package:
     <<: *common_debs
+  common-service:
+    apt-daily.timer:
+      enabled: false
+      running: false
+    apt-daily-upgrade.timer:
+      enabled: false
+      running: false
   azure:
     command:
       pip3 list --format=columns | grep 'azure-cli' | awk -F' ' '{print $1}':


### PR DESCRIPTION
Remove ansible tasks of disabling `apt-daily` and `apt-daily-upgrade`. These are static services and cannot be enabled/disabled (it has no provisions for enabling in the [Install] unit file section). 
```
root@ip-172-31-77-217:/home/ubuntu# systemctl list-unit-files | grep 'apt'
apt-daily-upgrade.service                      static
apt-daily.service                              static
apt-daily-upgrade.timer                        disabled
apt-daily.timer                                disabled
```
Found an old, similar issue in GOSS - https://github.com/aelsabbahy/goss/issues/266

Adding GOSS tests to check if the daily timers are disabled will ensure that other ones will never run (since 
static services can only be run as a dependency of others - in this case the daily timers that we *do* disable).

/cc @codenrhoden 