### PR TITLE
Added missing firmware from windows ova post processors

### DIFF
--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -115,6 +115,7 @@
         "distro_arch": "{{user `distro_arch` }}",
         "distro_name": "{{user `distro_name` }}",
         "distro_version": "{{user `distro_version` }}",
+        "firmware": "{{user `firmware`}}",
         "guest_os_type": "{{user `guest_os_type`}}",
         "ib_version": "{{user `ib_version`}}",
         "kubernetes_cni_semver": "{{user `kubernetes_cni_semver`}}",


### PR DESCRIPTION
**What this PR does / why we need it:**
Adds missing post-processor option that prevented windows builds after the merge of https://github.com/kubernetes-sigs/image-builder/pull/482 