### PR TITLE
Disable GOSS inspect mode for CI tests

### DIFF
--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -63,7 +63,7 @@ make deps-azure
 
 # Pre-pulling windows images takes 10-20 mins
 # Disable them for CI runs so don't run into timeouts
-export PACKER_VAR_FILES=packer/azure/scripts/disable-windows-prepull.json
+export PACKER_VAR_FILES="packer/azure/scripts/disable-windows-prepull.json scripts/ci-disable-goss-inspect.json"
 
 if [[ "${AZURE_BUILD_FORMAT:-vhd}" == "sig" ]]; then
     make -j build-azure-sigs

--- a/images/capi/scripts/ci-disable-goss-inspect.json
+++ b/images/capi/scripts/ci-disable-goss-inspect.json
@@ -1,0 +1,3 @@
+{
+  "goss_inspect_mode": "false"
+}

--- a/images/capi/scripts/ci-gce.sh
+++ b/images/capi/scripts/ci-gce.sh
@@ -84,7 +84,7 @@ fi
 groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
 chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
 # use the packer user to run the build
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS make deps-gce build-gce-all'"
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=scripts/ci-disable-goss-inspect.json make deps-gce build-gce-all'"
 test_status="${?}"
 
 echo "Displaying the generated image information"


### PR DESCRIPTION
What this PR does / why we need it:
For both Azure and GCP CI tests, disable GOSS inspect mode. This means a
build will fail if the GOSS tests do not pass.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #608 

**Additional context**
None