### PR TITLE
add ansible_user_vars as a way to pass user defined variables to ansible

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -64,6 +64,7 @@ Several variables can be used to customize the image build.
 | `additional_url_images` | Set this to `"true"` to load addtional container images using a tar url. `additional_url_images_list` var should be set to a comma seperated string of tar urls of the container images. | `"false"` |
 | `additional_registry_images` | Set this to `"true"` to load addtional container images using their registry url. `additional_registry_images_list` var should be set to a comma seperated string of registry urls of the container images. | `"false"` |
 | `additional_executables` | Set this to `"true"` to load addtional executables from a url. `additional_executables_list` var should be set to a comma seperated string of urls. `additional_executables_destination_path` should be set to the destination path of the executables. | `"false"` |
+| `ansible_user_vars` | A space delimited string that the user can pass to use in the ansible roles  | `""` |
 
 The variables found in `packer/config/*.json` or `packer/<provider>/*.json` should not need to be modified directly. For customization it is better to create a JSON file with your changes and provide it via the `PACKER_VAR_FILES` environment variable. Variables set in this file will override any previous values. Multiple files can be passed via `PACKER_VAR_FILES`, with the last file taking precedence over any others.
 
@@ -155,5 +156,14 @@ PACKER_VAR_FILES=proxy.json make build-node-ova-local-photon-3
   "additional_url_images": "true",
   "additional_url_images_list": "http://path/to/image1.tar,http://path/to/image2.tar",
   "load_additional_components": "true"
+}
+```
+
+##### Using `ansible_user_vars` to pass custom variables
+
+```json
+{
+  "ansible_user_vars": "var1=value1 var2={{ user `myvar2`}}",
+  "myvar2": "value2"
 }
 ```

--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -81,7 +81,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "ansible/windows/node_windows.yml",
       "type": "ansible",
@@ -142,6 +144,7 @@
     "ami_users": "",
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
+    "ansible_user_vars": "",
     "aws_access_key": "",
     "aws_profile": "",
     "aws_region": "us-east-1",

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -97,7 +97,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible"
@@ -139,6 +141,7 @@
     "ami_users": "",
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
+    "ansible_user_vars": "",
     "aws_access_key": "",
     "aws_profile": "",
     "aws_region": "us-east-1",

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -104,7 +104,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "ansible/windows/node_windows.yml",
       "type": "ansible",
@@ -155,6 +157,7 @@
     "additional_debug_files": null,
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
+    "ansible_user_vars": "",
     "azure_location": null,
     "build_name": null,
     "build_timestamp": "{{timestamp}}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -106,7 +106,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
@@ -145,6 +147,7 @@
   "variables": {
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
+    "ansible_user_vars": "",
     "azure_location": null,
     "build_name": null,
     "build_timestamp": "{{timestamp}}",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -345,7 +345,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "./ansible/firstboot.yml",
       "type": "ansible",
@@ -374,7 +376,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
@@ -417,6 +421,7 @@
   "variables": {
     "ansible_common_vars": "",
     "ansible_extra_vars": "guestinfo_datasource_slug={{user `guestinfo_datasource_slug`}} guestinfo_datasource_ref={{user `guestinfo_datasource_ref`}} guestinfo_datasource_script={{user `guestinfo_datasource_script`}}",
+    "ansible_user_vars": "",
     "base_build_version": "base-{{user `build_name`}}",
     "base_output_dir": "./output/{{user `base_build_version`}}",
     "build_timestamp": "{{timestamp}}",

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -164,7 +164,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "ansible/windows/node_windows.yml",
       "type": "ansible",
@@ -211,6 +213,7 @@
     "additional_debug_files": null,
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
+    "ansible_user_vars": "",
     "build_name": null,
     "build_timestamp": "{{timestamp}}",
     "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",


### PR DESCRIPTION
What this PR does / why we need it:
Fixes #596 
- pass user defined ansible vars using `ansible_user_vars`. Useful when extra variables are needed in custom roles
- updated docs. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers