### PR TITLE
locked ansible base version

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -32,5 +32,6 @@ if command -v ansible >/dev/null 2>&1; then exit 0; fi
 
 ensure_py3
 pip3 install --user "ansible==${_version}"
+pip3 install --user "ansible-base==2.10.9" --force-reinstall
 ensure_py3_bin ansible
 ensure_py3_bin ansible-playbook


### PR DESCRIPTION
What this PR does / why we need it:
An issue has been identified in [ansible-base 2.10.10](https://github.com/ansible/ansible/issues/74887) that causes win_templates to fail to copy to a windows host.  As there is currently no way to lock the ansible base version I have added a downgrade to lock this until we are happy that the issue has been resolved in ansible

