### PR TITLE
Building ova using ovftool errors out when no args are set.

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -197,7 +197,7 @@ def main():
 
     if os.environ.get("IB_OVFTOOL"):
         # Create the OVA.
-        create_ova(ova, ovf, ovftool_args=os.environ.get("IB_OVFTOOL_ARGS"))
+        create_ova(ova, ovf, ovftool_args=os.environ.get("IB_OVFTOOL_ARGS", ""))
 
     else:
         # Create the OVA manifest.


### PR DESCRIPTION
What this PR does / why we need it:
I ran into this issue when working on #616 . But I guess I forgot to push the changes. 

When building using `ovftool` and `IB_OVFTOOL_ARGS` is unset, building ova fails with this error since it gets set to `None`. 

```
==> vmware-vmx (shell-local): subprocess.CalledProcessError: Command '['ovftool', 'None', 'photon-3-kube-v1.19.11.ovf', 'photon-3-kube-v1.19.11.ova']' returned non-zero exit status 1.
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers