### PR TITLE
Bump /tmp size on photon

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -37,3 +37,12 @@
 - name: install extra RPMs
   command: tdnf install {{ extra_rpms }} -y
   when: extra_rpms != ""
+
+# Default size of 1G is insufficient when downloading additional components
+- name: Increase tmpfs size
+  mount:
+    path: /tmp
+    src: "tmpfs"
+    fstype: tmpfs
+    opts: "size=5G"
+    state: remounted


### PR DESCRIPTION
On photon images the /tmp size gets automatically set to 1Gb and is insufficient to download additional components (tar, bin files etc) in the later roles. So, I'm increasing the size from 1Gb to 5Gb during image building process. On reboot, the size gets reset to the default value (1Gb). 

Existing partitions on photon-3

```builder@localhost [ ~ ]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        990M     0  990M   0% /dev
tmpfs           996M     0  996M   0% /dev/shm
tmpfs           996M  640K  996M   1% /run
tmpfs           996M     0  996M   0% /sys/fs/cgroup
/dev/sda3        20G  552M   18G   3% /
tmpfs           996M   17M  980M   2% /tmp
/dev/sda2        10M  2.2M  7.8M  22% /boot/efi
tmpfs           200M     0  200M   0% /run/user/1000
```

This issues is not seen on other OSes like ubuntu because tmp is on the same fs as root and gets access to the whole disk. (20Gb)

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers