### PR TITLE
Prevent custom iptables rules getting overwritten by sysprep

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -46,3 +46,15 @@
     fstype: tmpfs
     opts: "size=5G"
     state: remounted
+
+- name: reset iptables rules input
+  replace:
+    path: /etc/systemd/scripts/ip4save
+    regexp: 'INPUT DROP'
+    replace: 'INPUT ACCEPT'
+
+- name: reset ip6tables rules input
+  replace:
+    path: /etc/systemd/scripts/ip6save
+    regexp: 'INPUT DROP'
+    replace: 'INPUT ACCEPT'

--- a/images/capi/ansible/roles/sysprep/tasks/photon.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/photon.yml
@@ -20,18 +20,6 @@
 - name: set hostname
   command: hostnamectl set-hostname localhost.local
 
-- name: reset iptables rules input
-  replace:
-    path: /etc/systemd/scripts/ip4save
-    regexp: 'INPUT DROP'
-    replace: 'INPUT ACCEPT'
-
-- name: reset ip6tables rules input
-  replace:
-    path: /etc/systemd/scripts/ip6save
-    regexp: 'INPUT DROP'
-    replace: 'INPUT ACCEPT'
-
 - name: Remove the kickstart log
   file:
     state: absent


### PR DESCRIPTION
What this PR does / why we need it:
custom iptables rules get overwritten by sysprep stage. Avoid that by moving it to setup stage. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #
Fixes #632 

**Additional context**
Add any other context for the reviewers