### PR TITLE
Add more user configurable goss provisioner options

### DIFF
--- a/docs/book/src/capi/goss/goss.md
+++ b/docs/book/src/capi/goss/goss.md
@@ -25,9 +25,13 @@ Supported arguments are passed through file: `packer/config/goss-args.json`
 ```json
 {
   "goss_arch": "amd64",
+  "goss_download_path": "",
   "goss_entry_file": "goss/goss.yaml",
   "goss_format": "json",
   "goss_inspect_mode": "true",
+  "goss_remote_folder": "",
+  "goss_remote_path": "",
+  "goss_skip_install": "",
   "goss_tests_dir": "packer/goss",
   "goss_url": "",
   "goss_format_options": "pretty",

--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -95,10 +95,14 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "target_os": "Windows",
       "tests": [
         "{{user `goss_tests_dir`}}"

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -106,10 +106,14 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "tests": [
         "{{user `goss_tests_dir`}}"
       ],

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -118,10 +118,14 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "target_os": "Windows",
       "tests": [
         "{{user `goss_tests_dir`}}"

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -116,10 +116,14 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "tests": [
         "{{user `goss_tests_dir`}}"
       ],

--- a/images/capi/packer/config/goss-args.json
+++ b/images/capi/packer/config/goss-args.json
@@ -1,9 +1,13 @@
 {
   "goss_arch": "amd64",
+  "goss_download_path": "",
   "goss_entry_file": "goss/goss.yaml",
   "goss_format": "json",
   "goss_format_options": "pretty",
   "goss_inspect_mode": "true",
+  "goss_remote_folder": "",
+  "goss_remote_path": "",
+  "goss_skip_install": "false",
   "goss_tests_dir": "packer/goss",
   "goss_url": "",
   "goss_vars_file": "packer/goss/goss-vars.yaml",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -386,6 +386,7 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "except": [
         "vmware-iso-base",
         "vsphere-iso-base"
@@ -394,6 +395,9 @@
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "tests": [
         "{{user `goss_tests_dir`}}"
       ],

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -180,10 +180,14 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "target_os": "Windows",
       "tests": [
         "{{user `goss_tests_dir`}}"


### PR DESCRIPTION
What this PR does / why we need it:
Adds the following user configurable goss provisioner options 

```
  "goss_download_path": "",
  "goss_remote_folder": "",
  "goss_remote_path": "",
  "goss_skip_install": "",
```
It's useful in using a pre-downloaded goss binary to run tests in air gapped environments. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers