### PR TITLE
Fix for multiple lines returned for Azure OS_DISK_URI

### DIFF
--- a/images/capi/packer/azure/.pipelines/generate-sas.yaml
+++ b/images/capi/packer/azure/.pipelines/generate-sas.yaml
@@ -3,7 +3,7 @@ steps:
       set -o pipefail
       RESOURCE_GROUP_NAME=$(jq -r '.builds[-1].custom_data.resource_group_name' manifest.json | cut -d ":" -f2)
       STORAGE_ACCOUNT_NAME=$(jq -r '.builds[-1].custom_data.storage_account_name' manifest.json | cut -d ":" -f2)
-      OS_DISK_URI=$(cat packer/azure/packer.out | grep "OSDiskUri:" | cut -d " " -f 2)
+      OS_DISK_URI=$(cat packer/azure/packer.out | grep "OSDiskUri:" -m 1 | cut -d " " -f 2)
       printf "${OS_DISK_URI}?" | tee packer/azure/vhd-url.out
       az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
       az account set -s ${AZURE_SUBSCRIPTION_ID}


### PR DESCRIPTION
What this PR does / why we need it:

`make builder-azure-vhd-$os-$version` recently began returning more than one URL into the packer.out file, causing build failures when this code looks for `OSDiskURI:`. This change takes only the first match, which is the correct URI.

Which issue(s) this PR fixes: 

N/A

**Additional context**:

cc: @CecileRobertMichon @devigned 