### PR TITLE
Add OWNERS for Windows Ansible roles

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -24,6 +24,9 @@ aliases:
   image-builder-raw-reviewers:
     - detiber
     - thebsdbox
+  image-builder-windows-maintainers:
+    - jsturtevant
+    - perithompson
   cluster-api-maintainers:
     - justinsb
     - detiber

--- a/images/capi/ansible/windows/OWNERS
+++ b/images/capi/ansible/windows/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - image-builder-windows-maintainers


### PR DESCRIPTION
What this PR does / why we need it:
Adds an OWNERS file specifically for the Windows Ansible roles. Owners there would be @jsturtevant and @perithompson.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
None

/hold
/assign @jsturtevant @CecileRobertMichon @perithompson @jayunit100 