### PR TITLE
capg: add options to set a service account or disable the default one

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
@@ -3,5 +3,6 @@
   "kubernetes_deb_version": "1.18.18-00",
   "kubernetes_rpm_version": "1.18.18-0",
   "kubernetes_semver": "v1.18.18",
-  "kubernetes_series": "v1.18"
+  "kubernetes_series": "v1.18",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
@@ -3,5 +3,6 @@
   "kubernetes_deb_version": "1.19.10-00",
   "kubernetes_rpm_version": "1.19.10-0",
   "kubernetes_semver": "v1.19.10",
-  "kubernetes_series": "v1.19"
+  "kubernetes_series": "v1.19",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
@@ -3,5 +3,6 @@
   "kubernetes_deb_version": "1.20.6-00",
   "kubernetes_rpm_version": "1.20.6-0",
   "kubernetes_semver": "v1.20.6",
-  "kubernetes_series": "v1.20"
+  "kubernetes_series": "v1.20",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -1,6 +1,7 @@
 {
   "builders": [
     {
+      "disable_default_service_account": "{{ user `disable_default_service_account` }}",
       "image_family": "capi-{{user `build_name`}}-k8s-{{user `kubernetes_series` | clean_resource_name}}",
       "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver` | clean_resource_name}}-{{user `build_timestamp`}}",
       "labels": {
@@ -13,6 +14,7 @@
       "machine_type": "{{ user `machine_type` }}",
       "name": "{{user `build_name`}}",
       "project_id": "{{ user `project_id` }}",
+      "service_account_email": "{{ user `service_account_email` }}",
       "source_image_family": "{{ user `source_image_family` }}",
       "ssh_username": "ubuntu",
       "type": "googlecompute",
@@ -54,6 +56,7 @@
     "containerd_version": null,
     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
     "crictl_version": null,
+    "disable_default_service_account": "",
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "kubernetes_cni_deb_version": null,
@@ -76,6 +79,7 @@
     "kubernetes_source_type": null,
     "machine_type": "n1-standard-1",
     "project_id": "{{env `GCP_PROJECT_ID`}}",
+    "service_account_email": "",
     "source_image_family": "{{user `build_name`}}-lts",
     "zone": null
   }


### PR DESCRIPTION
What this PR does / why we need it:
As part of the investigations why the nightly job is not working properly after we drop some GCP permissions, see https://github.com/kubernetes/k8s.io/pull/2147

We are adding two more options in the GCE builder to allow to disable the default service account and another to use a specific service account.

In this PR we are using `service_account_email` to bound with the service account we setup for the gcp project.

/assign @spiffxp @ameukam @dims @codenrhoden 


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers