### PR TITLE
Fix k8s.gcr.io URLs for container images

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -14,35 +14,35 @@ Run the docker build target of Makefile
    ```
 
 ## Using a Container Image
-The latest container image can be pulled from GCR as below - 
+The latest container image can be pulled from GCR as below -
 ```commandline
-docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd64:v0.1.7
+docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd64:v0.1.9
 ```
 
-### Examples 
- 
-- AMI 
-    - If the AWS-CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials. 
+### Examples
+
+- AMI
+    - If the AWS-CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials.
 
     ```commandline
-    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.8 build-ami-ubuntu-2004
+    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-ami-ubuntu-2004
     ```
     - Another alternative is to use an `aws-creds.env` file to load the credentials and pass it during docker run.
-    
+
       ```commandline
       AWS_ACCESS_KEY_ID=xxxxxxx
       AWS_SECRET_ACCESS_KEY=xxxxxxxx
       AWS_DEFAULT_REGION=xxxxxx
       ```
-    
+
     ```commandline
-        docker run -it --rm --env-file aws-creds.env gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.8 build-ami-ubuntu-2004
+        docker run -it --rm --env-file aws-creds.env k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-ami-ubuntu-2004
     ```
 
-- AZURE 
-    
+- AZURE
+
     - You'll need an `az-creds.env` file to load environment variables `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`
-        
+
       ```commandline
       AZURE_SUBSCRIPTION_ID=xxxxxxx
       AZURE_TENANT_ID=xxxxxxx
@@ -51,16 +51,16 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
       ```
 
     ```commandline
-    docker run -it --rm --env-file az-creds.env gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.7 build-azure-sig-ubuntu-2004
+    docker run -it --rm --env-file az-creds.env k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-azure-sig-ubuntu-2004
     ```
 
-- vSphere OVA 
+- vSphere OVA
     - `vsphere.json` configuration file with user and hypervisor credentials. A template of this file can be found [here](https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/packer/ova/vsphere.json)
-    
+
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
-    
+
     ```commandline
-    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.7 build-node-ova-vsphere-ubuntu-2004
+    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-node-ova-vsphere-ubuntu-2004
     ```
-    
-In addition to this, further customizations can be done as discussed [here](./capi.md#customization). 
+
+In addition to this, further customizations can be done as discussed [here](./capi.md#customization).


### PR DESCRIPTION
What this PR does / why we need it:
The container docs were using the wrong path for production images. The prod images have a `k8s.gcr.io` URL, whereas the staging images are just at `gcr.io`. Since I was editing this anyway, went ahead and bumped the example versions to the latest.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
FYI @SanikaGawhane 