### PR TITLE
Update Azure "pub" tool to v0.3.2

### DIFF
--- a/images/capi/packer/azure/scripts/new-disk-version.sh
+++ b/images/capi/packer/azure/scripts/new-disk-version.sh
@@ -40,7 +40,7 @@ do
 done
 
 echo "Getting pub..."
-(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.2.6/pub_v0.2.6_linux_amd64.tar.gz -o pub; tar -xzf pub)
+(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.3.2/pub_v0.3.2_linux_amd64.tar.gz -o pub; tar -xzf pub)
 
 echo "SKU publishing info:"
 cat $SKU_INFO
@@ -91,7 +91,7 @@ sku=$(< $SKU_INFO jq -r ".sku_id")
 
 # TODO: Update pub versions put to take in version.json as a file
 echo "Create new disk version"
-set -x  
+set -x
 ./pub_linux_amd64 versions put corevm -p $publisher -o $offer -s $sku --version $image_version --vhd-uri $vhd_url --media-name $media_name --label "$label" --desc "$description" --published-date "$published_date"
 set +x
 echo -e "\nCreated disk version"

--- a/images/capi/packer/azure/scripts/new-sku.sh
+++ b/images/capi/packer/azure/scripts/new-sku.sh
@@ -63,11 +63,11 @@ cat sku.json
 
 echo
 echo "Getting pub..."
-(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.2.6/pub_v0.2.6_linux_amd64.tar.gz -o pub; tar -xzf pub)
+(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.3.2/pub_v0.3.2_linux_amd64.tar.gz -o pub; tar -xzf pub)
 
 echo "Creating new SKU"
-set -x 
-./pub_linux_amd64 skus put -p $PUBLISHER -o "$OFFER" -f sku.json 
+set -x
+./pub_linux_amd64 skus put -p $PUBLISHER -o "$OFFER" -f sku.json
 set +x
 echo -e "\nCreated sku"
 


### PR DESCRIPTION
What this PR does / why we need it:
This fixes a formatting bug that mangled logo URLs when submitting to Azure marketplace.
See https://github.com/devigned/pub/releases/tag/v0.3.2

Which issue(s) this PR fixes: 
N/A

**Additional context**
cc: @devigned @CecileRobertMichon 