### PR TITLE
Skip ovf/vmdk export in vsphere-iso-base builder

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -136,10 +136,6 @@
       "datacenter": "{{user `datacenter`}}",
       "datastore": "{{user `datastore`}}",
       "disk_controller_type": "{{user `disk_controller_type`}}",
-      "export": {
-        "force": true,
-        "output_directory": "{{user `base_output_dir`}}"
-      },
       "firmware": "{{user `firmware`}}",
       "floppy_dirs": "{{ user `floppy_dirs`}}",
       "folder": "{{user `folder`}}",
@@ -285,7 +281,8 @@
         "vsphere_guest_os_type": "{{user `vsphere_guest_os_type`}}"
       },
       "except": [
-        "vmware-iso-base"
+        "vmware-iso-base",
+        "vsphere-iso-base"
       ],
       "output": "{{user `output_dir`}}/packer-manifest.json",
       "strip_path": true,
@@ -302,6 +299,9 @@
       "type": "shell-local"
     },
     {
+      "except": [
+        "vsphere-iso-base"
+      ],
       "inline": [
         "cd {{user `output_dir`}}",
         "../../hack/image-build-ova.py --node --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --ovf_template ../../hack/ovf_template.xml --vmdk_file {{user `build_version`}}-disk-0.vmdk"


### PR DESCRIPTION
What this PR does / why we need it:
The idea of a `vsphere-iso-base` builder is to create a base vm template on the vCenter and build images on top of that using the `vsphere-clone` builder. In this process exporting the ovf & vmdk from the vC to the build VM seems like an unnecessary step. So this PR removes that. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers