### PR TITLE
Expose env var for setting container base image

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/ubuntu:focal
+ARG BASE_IMAGE=docker.io/library/ubuntu:focal
+FROM $BASE_IMAGE
 
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates python3-pip curl wget git rsync vim unzip build-essential \
     && useradd -ms /bin/bash imagebuilder \

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -110,6 +110,7 @@ IMAGE_NAME ?= cluster-node-image-builder
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
 ARCH ?= amd64
+BASE_IMAGE ?= docker.io/library/ubuntu:focal
 
 ## --------------------------------------
 ## Packer flags
@@ -644,11 +645,11 @@ clean-packer-cache:
 docker-pull-prerequisites:
 	# We must pre-pull images https://github.com/moby/buildkit/issues/1271
 	docker pull docker/dockerfile:1.1-experimental
-	docker pull docker.io/library/ubuntu:focal
+	docker pull $(BASE_IMAGE)
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the docker image


### PR DESCRIPTION
What this PR does / why we need it:
Instead of having the container base image hardcoded to
docker.io/library/ubuntu:focal, expose a BASE_IMAGE env var that
can be set to an alternate base image. This is useful for those
building behind proxies.

Example:
`BASE_IMAGE=myproxy.io/ubuntu:focal make docker-build`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #626 

**Additional context**
/assign @kkeshavamurthy @jayunit100 
FYI @SanikaGawhane 