### PR TITLE
Add CI script for container build

### DIFF
--- a/images/capi/scripts/ci-container-image.sh
+++ b/images/capi/scripts/ci-container-image.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${CAPI_ROOT}" || exit 1
+
+make docker-build


### PR DESCRIPTION
What this PR does / why we need it:
This adds a simple CI script to run the docker build. With this in place, we should be able to selectively run this CI job to verify the container image can be built. This makes sure that all the versions being called out in the `hack/ensure-*` scripts install correctly.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
/assign @kkeshavamurthy @CecileRobertMichon 