### PR TITLE
capg: make capg node images available to use in another accounts

### DIFF
--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -56,3 +56,7 @@ echo "Displaying the generated image information"
 filter="name~cluster-api-ubuntu-*"
 gcloud compute images list --project "$GCP_PROJECT" \
   --no-standard-images --filter="${filter}"
+
+echo "Making images public to use in CI"
+(gcloud compute images list --project "$GCP_PROJECT" --no-standard-images --filter="${filter}" --format="value(name[])" | \
+awk '{print "gcloud compute images add-iam-policy-binding --project '"$GCP_PROJECT"' " $1 " --member='"'allAuthenticatedUsers'"' --role='"'roles/compute.imageUser'"' \n"}' | bash)


### PR DESCRIPTION
What this PR does / why we need it:
Now the job is building again (https://prow.k8s.io/?job=periodic-image-builder-gcp-all-nightly) and we resolve all issues regarding permissions

The next step is make those images available to use in CI to accelerate the testing time for CAPG (because in the existing jobs we build the image from scratch all the time)

GCP reference to make the images public: https://cloud.google.com/compute/docs/images/managing-access-custom-images#share-images-publicly

Slack 🧵  https://kubernetes.slack.com/archives/CCK68P2Q2/p1626358090270500

/assign @dims @spiffxp @codenrhoden 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers