### PR TITLE
Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/images/capi/ansible/windows/example.vars.yml
+++ b/images/capi/ansible/windows/example.vars.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-kubernetes_base_url: https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/windows/amd64
+kubernetes_base_url: https://dl.k8s.io/release/v1.19.2/bin/windows/amd64
 cloudbase_init_url: https://github.com/cloudbase/cloudbase-init/releases/download/1.1.2/CloudbaseInitSetup_1_1_2_x64.msi
 wins_url: https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
 nssm_url: https://azurek8scishared.blob.core.windows.net/nssm/nssm.exe

--- a/images/capi/hack/image-new-kube.py
+++ b/images/capi/hack/image-new-kube.py
@@ -37,8 +37,8 @@ class KubeVersionResolver(object):
     # Resolve accepts a Kubernetes version string and returns a dictionary with
     # information that can be used to deploy the provided version.
     def Resolve(self, version):
-        if version == "":
-            raise Exception("version is required")
+        if version == '':
+            raise Exception('version is required')
 
         result = {
             KUBE_RESOLVED_SEM: version,
@@ -46,32 +46,33 @@ class KubeVersionResolver(object):
             KUBE_RESOLVED_VER: version,
         }
 
-        # When version is "latest" then the returned dictionary points
+        # When version is 'latest' then the returned dictionary points
         # to the latest package for Kubernetes.
-        if version == "latest":
+        if version == 'latest':
             return result
         # Otherwise check to see if the provided version matches a
         # managed package format. Technically the else clause could be
         # descoped one level, but by placing the logic in the scope of
-        # the else clause, the scope of "match" is isolated from the
+        # the else clause, the scope of 'match' is isolated from the
         # rest of this function.
         else:
             match = re.match(r'^(\d+\.\d+.\d+)\-\d+$', version)
             if match:
-                result[KUBE_RESOLVED_SEM] = 'v%s' % match.groups(1)[0]
+                version = match.groups(1)[0]
+                result[KUBE_RESOLVED_SEM] = f'v{version}'
                 return result
 
-        url = ""
+        url = ''
         if re.match(r'(?i)^https?:', version):
             url = version
         elif re.match(r'^v?\d+(?:\.\d+){0,3}(?:[.+-].+)?$', version):
             if not version.startswith('v'):
-                version = "v%s" % version
-            url = "%s/release/%s" % (KUBE_SRC, version)
+                version = f'v{version}'
+            url = f'{KUBE_SRC}/release/{version}'
         elif re.match(r'^(ci|release)/.+$', version):
             url = self.__resolve_build_url(version)
         else:
-            raise Exception("Invalid Kubernetes version: %s" % version)
+            raise Exception(f'Invalid Kubernetes version: {version}')
         result[KUBE_RESOLVED_SRC] = url
 
         version = self.__read_version_from_kube_tarball(url)
@@ -81,9 +82,9 @@ class KubeVersionResolver(object):
         return result
 
     def __resolve_build_url(self, buildID):
-        url = "%s/%s" % (KUBE_SRC, buildID)
+        url = f'{KUBE_SRC}/{buildID}'
 
-        # If the URL doesn't end with ".txt" then see if the URL is already valid.
+        # If the URL doesn't end with '.txt' then see if the URL is already valid.
         if not url.endswith('.txt'):
             # If there is a kubernetes tarball available at the root of the URL
             # then it is already a valid URL.
@@ -93,9 +94,9 @@ class KubeVersionResolver(object):
                     return url
             except:
                 pass
-            # The URL wasn't valid, so add ".txt" to the end and let's see if the
+            # The URL wasn't valid, so add '.txt' to the end and let's see if the
             # URL points to a valid build.
-            url = "%s.txt" % url
+            url = f'{url}.txt'
 
         # Do an HTTP GET on the txt file to get the actual Kubernetes version.
         version = requests.get(url).text
@@ -103,22 +104,22 @@ class KubeVersionResolver(object):
 
         if buildID.startswith('ci/'):
             version = f'ci/{version}'
-        url = "%s/%s" % (KUBE_SRC, version)
+        url = f'{KUBE_SRC}/{version}'
 
         return url
 
     def __read_version_from_kube_tarball(self, url):
-        url = "%s/kubernetes.tar.gz" % url
+        url = f'{url}/kubernetes.tar.gz'
         r = requests.get(url)
         if not r.status_code == 200:
-            raise Exception("HTTP GET %s failed: %d" % (url, r.status_code))
+            raise Exception(f'HTTP GET {url} failed: {r.status_code}')
         b = BytesIO(r.content)
         t = tarfile.open(fileobj=b, mode='r')
-        v = t.extractfile("kubernetes/version")
-        return v.read().strip().decode("utf-8")
+        v = t.extractfile('kubernetes/version')
+        return v.read().strip().decode('utf-8')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     import argparse
     import textwrap
     parser = argparse.ArgumentParser(

--- a/images/capi/hack/image-new-kube.py
+++ b/images/capi/hack/image-new-kube.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Copyright 2019 The Kubernetes Authors.
 #
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import requests
 import sys
@@ -122,7 +123,7 @@ class KubeVersionResolver(object):
         b = BytesIO(r.content)
         t = tarfile.open(fileobj=b, mode='r')
         v = t.extractfile("kubernetes/version")
-        return v.read().strip()
+        return v.read().strip().decode("utf-8")
 
 
 if __name__ == "__main__":
@@ -195,6 +196,5 @@ if __name__ == "__main__":
     resolver = KubeVersionResolver()
     result = resolver.Resolve(args.version[0])
 
-    import json
     data = json.dumps(result, indent=2)
     print(data)

--- a/images/capi/hack/serve_artifacts.go
+++ b/images/capi/hack/serve_artifacts.go
@@ -24,7 +24,7 @@ var (
 func main() {
 	artifacts := map[string]string {
 	   "kubelet.exe": "kubernetes_base_url",
-	   //"kubernetes_base_url": "https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/windows/amd64",
+	   //"kubernetes_base_url": "https://dl.k8s.io/release/v1.19.2/bin/windows/amd64",
 	   "CloudbaseInit*": "cloudbase_init_url",  
 	   // "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/1.1.2/CloudbaseInitSetup_1_1_2_x64.msi",
 	   "wins.exe": "wins_url", //: "https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe",

--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -7,7 +7,7 @@
   "kubernetes_deb_gpg_key": "https://packages.cloud.google.com/apt/doc/apt-key.gpg",
   "kubernetes_deb_repo": "\"https://apt.kubernetes.io/ kubernetes-xenial\"",
   "kubernetes_deb_version": "1.19.11-00",
-  "kubernetes_http_source": "https://storage.googleapis.com/kubernetes-release/release",
+  "kubernetes_http_source": "https://dl.k8s.io/release",
   "kubernetes_load_additional_imgs": "false",
   "kubernetes_rpm_gpg_check": "True",
   "kubernetes_rpm_gpg_key": "\"https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg\"",

--- a/images/kube-deploy/imagebuilder/templates/1.11-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.11-stretch.yml
@@ -155,8 +155,8 @@ plugins:
        - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
 
-       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
+       - [ 'wget', 'https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.12-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.12-stretch.yml
@@ -155,8 +155,8 @@ plugins:
        - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
 
-       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
+       - [ 'wget', 'https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.13-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.13-stretch.yml
@@ -155,8 +155,8 @@ plugins:
        - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
 
-       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
+       - [ 'wget', 'https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)

--- a/images/kube-deploy/imagebuilder/templates/1.14-stretch.yml
+++ b/images/kube-deploy/imagebuilder/templates/1.14-stretch.yml
@@ -155,8 +155,8 @@ plugins:
        - [ 'wget', 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.3-ce.tgz', '-O', '{root}/var/cache/nodeup/sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz' ]
        - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822  sha256:346f9394393ee8db5f8bd1e229ee9d90e5b36931bdd754308b2ae68884dd6822_https___download_docker_com_linux_static_stable_x86_64_docker-18_06_3-ce_tgz" | sha256sum -c -' ]
 
-       - [ 'wget', 'https://storage.googleapis.com/kubernetes-release/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
-       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___storage_googleapis_com_kubernetes-release_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
+       - [ 'wget', 'https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz', '-O', '{root}/var/cache/nodeup/sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz' ]
+       - [ '/bin/sh', '-c', 'cd {root}/var/cache/nodeup; echo "3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64  sha256:3ca15c0a18ee830520cf3a95408be826cbd255a1535a38e0be9608b25ad8bf64_https___dl_k8s_io_network-plugins_cni-plugins-amd64-v0_7_5_tgz" | sha256sum -c -' ]
 
        # We perform a full replacement of some grub conf variables:
        #   GRUB_CMDLINE_LINUX_DEFAULT (add memory cgroup)


### PR DESCRIPTION
**What this PR does / why we need it:**

The only time a kubernetes GCS bucket name should be showing up in a
hardcoded URI is if `gsutil` is being used (e.g. gsutil cp gs://foo/bar .)

Otherwise, for tools like `curl` or `wget`, dl.k8s.io is much nicer for us
as a project, since we can transparently change where that redirects to
without having to change code everywhere

These changes will mean no changes will be necessary to accommodate a
`gs://kubernetes-release` -> `gs://k8s-release` migration equivalent of
the CI migration we're going through right now

These changes also address the `gs://kubernetes-release-dev` references
currently used by this repo (ref:
https://github.com/kubernetes/k8s.io/issues/2318)

While I was here, I updated `images/capi/hack/image-new-kube.py` to run
with `python3`. I assumed this was OK since I saw sibling scripts using
`python3`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
This is similar to the PR I've opened for cluster-api: https://github.com/kubernetes-sigs/cluster-api/pull/4958