### PR TITLE
Use 1.7 ansible galaxy package for Windows

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -32,6 +32,6 @@ if command -v ansible >/dev/null 2>&1; then exit 0; fi
 
 ensure_py3
 pip3 install --user "ansible==${_version}"
-pip3 install --user "ansible-base==2.10.9" --force-reinstall
 ensure_py3_bin ansible
 ensure_py3_bin ansible-playbook
+ansible-galaxy collection install ansible.windows:==1.7.0


### PR DESCRIPTION
What this PR does / why we need it:

Ansible windows package broke win_templates in https://github.com/ansible/ansible/issues/74887 and has been [fixed](https://github.com/ansible-collections/ansible.windows/issues/212#issuecomment-823524227) in the package which is not avaliable via standard 2.10.11 ansible package.

This ensures we have the latest windows package with the fixes

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes https://github.com/kubernetes-sigs/image-builder/pull/624

**Additional context**
Add any other context for the reviewers

/sig windows
/cc @perithompson @mboersma 