### PR TITLE
Added vmware-vmx reference

### DIFF
--- a/docs/book/src/capi/providers/vsphere.md
+++ b/docs/book/src/capi/providers/vsphere.md
@@ -23,7 +23,7 @@ The `vsphere` builder supports building against a remote VMware vSphere using st
 ### vmware-vmx builder
 During the dev process it's uncommon for the base OS image to change, but the image building process builds the base image from the ISO every time and thus adding a significant amount of time to the build process.
 
-To reduce the image building times during development, one can use the `build-node-ova-local-base-<OS>` target to build the base image from the ISO. By setting `source_path` variable in `vmx.json` to the `*.vmx` file from the output, it can then be re-used with the `build-node-ova-local-vmx-<OS>` build target to speed up the process.
+To reduce the image building times during development, one can use the `build-node-ova-local-base-<OS>` target to build the base image from the ISO. By setting `source_path` variable in `vmx.json` to the `*.vmx` file from the output, it can then be re-used with the `build-node-ova-local-vmx-<OS>` build target to speed up the process. More details on configuring this builder can be found [here](https://www.packer.io/docs/builders/vmware/vmx).
 
 
 ### vsphere-clone builder


### PR DESCRIPTION
What this PR does / why we need it: I struggled to understand the usage and value of `source_path` variable. After searching that online, I found a good reference in the official docs of the Packer tool. So, I updated the docs to put a reference of the page explaining in detail about the configuration of `vmware-vmx` option.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #NA

**Additional context**
Add any other context for the reviewers