### PR TITLE
Increase Restart timeout for Windows

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -91,6 +91,7 @@
       "user": "Administrator"
     },
     {
+      "restart_timeout": "10m",
       "type": "windows-restart"
     },
     {

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -114,6 +114,7 @@
       "user": "packer"
     },
     {
+      "restart_timeout": "10m",
       "type": "windows-restart"
     },
     {


### PR DESCRIPTION
What this PR does / why we need it:

#659 is seeing builds timeout for Windows (https://github.com/kubernetes-sigs/image-builder/pull/659#issuecomment-884357758)

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

I didn't update the restart timeout for OVA as there was custom logic.  @perithompson do you think we should increase it there too?

/sig windows
