### PR TITLE
Update nightly CAPG jobs to the latest k8s releases and add 1.21/1.22 configs

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.18.18-00",
-  "kubernetes_rpm_version": "1.18.18-0",
-  "kubernetes_semver": "v1.18.18",
+  "kubernetes_deb_version": "1.18.20-00",
+  "kubernetes_rpm_version": "1.18.20-0",
+  "kubernetes_semver": "v1.18.20",
   "kubernetes_series": "v1.18",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.19.10-00",
-  "kubernetes_rpm_version": "1.19.10-0",
-  "kubernetes_semver": "v1.19.10",
+  "kubernetes_deb_version": "1.19.13-00",
+  "kubernetes_rpm_version": "1.19.13-0",
+  "kubernetes_semver": "v1.19.13",
   "kubernetes_series": "v1.19",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.20.6-00",
-  "kubernetes_rpm_version": "1.20.6-0",
-  "kubernetes_semver": "v1.20.6",
+  "kubernetes_deb_version": "1.20.9-00",
+  "kubernetes_rpm_version": "1.20.9-0",
+  "kubernetes_semver": "v1.20.9",
   "kubernetes_series": "v1.20",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-21.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-21.json
@@ -1,0 +1,8 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.21.3-00",
+  "kubernetes_rpm_version": "1.21.3-0",
+  "kubernetes_semver": "v1.21.3",
+  "kubernetes_series": "v1.21",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
+}

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-22.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-22.json
@@ -1,0 +1,8 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.22.0-00",
+  "kubernetes_rpm_version": "1.22.0-0",
+  "kubernetes_semver": "v1.22.0",
+  "kubernetes_series": "v1.22",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
+}

--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -52,6 +52,10 @@ su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/c
 # using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
 su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-20.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
 
+# build image for 1.21
+# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-21.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+
 echo "Displaying the generated image information"
 filter="name~cluster-api-ubuntu-*"
 gcloud compute images list --project "$GCP_PROJECT" \

--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -56,6 +56,10 @@ su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/c
 # using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
 su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-21.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
 
+# build image for 1.22
+# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-22.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+
 echo "Displaying the generated image information"
 filter="name~cluster-api-ubuntu-*"
 gcloud compute images list --project "$GCP_PROJECT" \


### PR DESCRIPTION
What this PR does / why we need it:
 - Update nightly CAPG jobs to the latest k8s releases and add 1.21 and 1.22 configs

/assign @dims @codenrhoden 

**Additional context**
