### PR TITLE
Lower concurrency for windows goss

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -112,7 +112,7 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": false,
       "vars_env": {
-        "GOSS_MAX_CONCURRENT": "5",
+        "GOSS_MAX_CONCURRENT": "1",
         "GOSS_USE_ALPHA": "1"
       },
       "vars_file": "{{user `goss_vars_file`}}",

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -135,7 +135,7 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": false,
       "vars_env": {
-        "GOSS_MAX_CONCURRENT": "5",
+        "GOSS_MAX_CONCURRENT": "1",
         "GOSS_USE_ALPHA": "1"
       },
       "vars_file": "{{user `goss_vars_file`}}",

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -196,7 +196,7 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": false,
       "vars_env": {
-        "GOSS_MAX_CONCURRENT": "5",
+        "GOSS_MAX_CONCURRENT": "1",
         "GOSS_USE_ALPHA": "1"
       },
       "vars_file": "{{user `goss_vars_file`}}",


### PR DESCRIPTION
What this PR does / why we need it:

Windows has some timeout issues for windows when running in parallel. This lowers the concurrency.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes  flakes:

https://github.com/kubernetes-sigs/image-builder/pull/659#issuecomment-886876869
https://github.com/kubernetes-sigs/image-builder/pull/652#issuecomment-886781733

**Additional context**
Add any other context for the reviewers

/sig windows

/cc @CecileRobertMichon @perithompson @codenrhoden 