### PR TITLE
capi: avoid specifying containerd version for Flatcar

### DIFF
--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -6,12 +6,20 @@ export VAGRANT_VAGRANTFILE=${VAGRANT_VAGRANTFILE:-/tmp/Vagrantfile.builder-flatc
 export VAGRANT_SSH_PRIVATE_KEY=${VAGRANT_SSH_PRIVATE_KEY:-/tmp/vagrant-insecure-key}
 export VAGRANT_SSH_PUBLIC_KEY=${VAGRANT_SSH_PUBLIC_KEY:-/tmp/vagrant-insecure-key.pub}
 
+CONTAINERD_TMPDIR="$(mktemp -d)"
+CONTAINERD_CHECKSUM_FILE="${CONTAINERD_TMPDIR}/containerd-sha256sum"
+PACKER_VAR_FILES_CONTAINERD="${CONTAINERD_TMPDIR}/containerd.json"
+
 usage() {
     echo "Usage: $0 [<channel>] [<version>]"
     echo "          <channel> is one of: edge alpha beta stable (defaults to"
     echo "                      stable)"
     echo "          <version> release version to use (defaults to the latest"
     echo "                      release available for <channel>)"
+    echo ""
+    echo "To specify Flatcar-specific containerd version and/or its sha256:"
+    echo ""
+    echo "  FLATCAR_CONTAINERD_VERSION=1.5.4 FLATCAR_CONTAINERD_SHA256=abcd... ./hack/image-build-flatcar.sh"
 }
 # --
 
@@ -90,6 +98,25 @@ run_vagrant() {
     echo "before using vagrant commands."
 }
 
+function create_containerd_config() {
+    [ -z "${FLATCAR_CONTAINERD_VERSION}" ] && return
+
+    if [ -z "${FLATCAR_CONTAINERD_SHA256}" ]; then
+        curl -Ls -o ${CONTAINERD_CHECKSUM_FILE} \
+            "https://github.com/containerd/containerd/releases/download/v${FLATCAR_CONTAINERD_VERSION}/cri-containerd-cni-${FLATCAR_CONTAINERD_VERSION}-linux-amd64.tar.gz.sha256sum"
+        FLATCAR_CONTAINERD_SHA256="$(cat ${CONTAINERD_CHECKSUM_FILE} | cut -f1 -d \  )"
+    fi
+
+    echo "{\"containerd_sha256\": \"${FLATCAR_CONTAINERD_SHA256}\", \"containerd_version\": \"${FLATCAR_CONTAINERD_VERSION}\"}" \
+        > ${PACKER_VAR_FILES_CONTAINERD}
+}
+
+function cleanup_containerd_config() {
+    rm -rf ${CONTAINERD_TMPDIR}
+}
+
+trap cleanup_containerd_config INT KILL EXIT
+
 CAPI_PROVIDER=${CAPI_PROVIDER:-qemu}
 
 channel="$1"
@@ -125,18 +152,27 @@ export FLATCAR_CHANNEL FLATCAR_VERSION
 
 rm -rf ./output/flatcar-"${channel}-${release}"-kube-*
 
+create_containerd_config
+
+if [ -f "${PACKER_VAR_FILES_CONTAINERD}" ]; then
+    FLATCAR_MAKE_OPTS+="PACKER_VAR_FILES=${PACKER_VAR_FILES_CONTAINERD} "
+fi
+
 if [[ ${CAPI_PROVIDER} = "qemu" ]]; then
+    FLATCAR_MAKE_OPTS+="FLATCAR_CHANNEL=$channel FLATCAR_VERSION=$release "
+    FLATCAR_MAKE_OPTS+="SSH_PRIVATE_KEY_FILE=${VAGRANT_SSH_PRIVATE_KEY} "
+    FLATCAR_MAKE_OPTS+="SSH_PUBLIC_KEY_FILE=${VAGRANT_SSH_PUBLIC_KEY} "
+
     fetch_vagrant_ssh_keys
-    make FLATCAR_CHANNEL="$channel" FLATCAR_VERSION="$release" \
-        SSH_PRIVATE_KEY_FILE="${VAGRANT_SSH_PRIVATE_KEY}" \
-        SSH_PUBLIC_KEY_FILE="${VAGRANT_SSH_PUBLIC_KEY}" \
-        build-${CAPI_PROVIDER}-flatcar
+    make ${FLATCAR_MAKE_OPTS} build-qemu-flatcar
     run_vagrant
 elif [[ ${CAPI_PROVIDER} = "aws" ]] || [[ ${CAPI_PROVIDER} = "ami" ]]; then
-    make build-ami-flatcar
+    make ${FLATCAR_MAKE_OPTS} build-ami-flatcar
 else
     echo "Unknown CAPI_PROVIDER=${CAPI_PROVIDER}. exit."
     exit 1
 fi
+
+exit 0
 
 # vim:set sts=4 sw=4 et:

--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -4,8 +4,6 @@
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}",
   "containerd_cri_socket": "/run/docker/libcontainerd/docker-containerd.sock",
-  "containerd_sha256": "96641849cb78a0a119223a427dfdc1ade88412ef791a14193212c8c8e29d447b",
-  "containerd_version": "1.4.4",
   "crictl_source_type": "http",
   "goss_entry_file": "goss/goss-flatcar.yaml",
   "kubernetes_cni_source_type": "http",

--- a/images/capi/packer/qemu/qemu-flatcar.json
+++ b/images/capi/packer/qemu/qemu-flatcar.json
@@ -5,8 +5,6 @@
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",
   "containerd_cri_socket": "/run/docker/libcontainerd/docker-containerd.sock",
-  "containerd_sha256": "96641849cb78a0a119223a427dfdc1ade88412ef791a14193212c8c8e29d447b",
-  "containerd_version": "1.4.4",
   "crictl_source_type": "http",
   "distro_name": "flatcar",
   "guest_os_type": "linux-64",

--- a/images/capi/packer/raw/raw-flatcar.json
+++ b/images/capi/packer/raw/raw-flatcar.json
@@ -5,8 +5,6 @@
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",
   "containerd_cri_socket": "/run/docker/libcontainerd/docker-containerd.sock",
-  "containerd_sha256": "2697a342e3477c211ab48313e259fd7e32ad1f5ded19320e6a559f50a82bff3d",
-  "containerd_version": "1.4.3",
   "crictl_source_type": "http",
   "distro_name": "flatcar",
   "guest_os_type": "linux-64",


### PR DESCRIPTION
Containerd version in Flatcar could be different from the default containerd version for other distros.
However, it is difficult to update the version in the code every time when Flatcar stable gets released.
Instead, delete the Flatcar-specific version, and take a different approach, specifying a user-defined containerd json config.

Now that Flatcar-specific versions and sha256 variables are gone, in `hack/image-build-flatcar.sh`, we need to provide containerd.json that includes Flatcar-specific version to the make command.

Users are also allowed to pass their own Flatcar version and sha256. e.g.

```
FLATCAR_CONTAINERD_VERSION=1.5.4 hack/image-build-flatcar.sh
```
