### PR TITLE
Update kubeadm API version to v1beta2

### DIFF
--- a/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
+++ b/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
@@ -1,9 +1,9 @@
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 imageRepository: {{ kubernetes_container_registry }}
 kubernetesVersion: {{ kubernetes_semver }}
 ---
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
   criSocket: {{ containerd_cri_socket }}

--- a/images/capi/cloudinit/user-data
+++ b/images/capi/cloudinit/user-data
@@ -218,7 +218,7 @@ write_files:
       apiServer:
         extraArgs:
           cloud-provider: external
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       certificatesDir: ""
       clusterName: sakc4
       controlPlaneEndpoint: ""
@@ -238,7 +238,7 @@ write_files:
       scheduler: {}
       
       ---
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: InitConfiguration
       localAPIEndpoint:
         advertiseAddress: ""


### PR DESCRIPTION
What this PR does / why we need it: kubeadm v1beta1 is deprecated in v1.22.x

v1beta1 is supported starting with k8s v1.15. v1beta3 is supported starting v1.22.x. Updating the API version to v1beta2 for now so we can build images for all k8s versions currently in support (vv1.20, v1.21, v1.22).

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers