### PR TITLE
provide a way for users to bring their own containerd config

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -65,6 +65,7 @@ Several variables can be used to customize the image build.
 | `additional_registry_images` | Set this to `"true"` to load addtional container images using their registry url. `additional_registry_images_list` var should be set to a comma seperated string of registry urls of the container images. | `"false"` |
 | `additional_executables` | Set this to `"true"` to load addtional executables from a url. `additional_executables_list` var should be set to a comma seperated string of urls. `additional_executables_destination_path` should be set to the destination path of the executables. | `"false"` |
 | `ansible_user_vars` | A space delimited string that the user can pass to use in the ansible roles  | `""` |
+| `containerd_config_file` | Custom containerd config file a user can pass to override the default. Use `ansible_user_vars` to pass this var  | `""` |
 
 The variables found in `packer/config/*.json` or `packer/<provider>/*.json` should not need to be modified directly. For customization it is better to create a JSON file with your changes and provide it via the `PACKER_VAR_FILES` environment variable. Variables set in this file will override any previous values. Multiple files can be passed via `PACKER_VAR_FILES`, with the last file taking precedence over any others.
 

--- a/images/capi/ansible/roles/containerd/defaults/main.yml
+++ b/images/capi/ansible/roles/containerd/defaults/main.yml
@@ -17,3 +17,4 @@ containerd_flatcar_bins:
 - containerd
 - containerd-shim
 
+containerd_config_file: "etc/containerd/config.toml"

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -127,10 +127,10 @@
     path: /etc/containerd
     state: directory
 
-- name: Copy in containerd config overrides
+- name: Copy in containerd config file {{ containerd_config_file }}
   template:
     dest: /etc/containerd/config.toml
-    src: etc/containerd/config.toml
+    src: "{{ containerd_config_file }}"
     mode: 0644
 
 - name: Copy in crictl config

--- a/images/capi/ansible/windows/roles/runtimes/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/runtimes/defaults/main.yml
@@ -14,6 +14,7 @@
 ---
 pause_image: mcr.microsoft.com/oss/kubernetes/pause:1.4.0
 containerd_additional_settings: ""
+containerd_config_file: "config.toml"
 
 prepull: false
 prepull_images:

--- a/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
+++ b/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
@@ -49,10 +49,10 @@
     - '{{ programfiles.stdout | trim }}\containerd'
     scope: machine
 
-- name: Copy containerd config overrides
+- name: Copy containerd config file {{ containerd_config_file }}
   win_template:
     dest: '{{ programfiles.stdout | trim }}\containerd\config.toml'
-    src: config.toml
+    src: "{{ containerd_config_file }}"
   vars:
     allusersprofile: "{{ alluserprofile.stdout | trim }}"
     plugin_bin_dir: "{{ systemdrive.stdout | trim }}/opt/cni/bin"


### PR DESCRIPTION
What this PR does / why we need it:
A way for users to use their own containerd config file. 

`containerd_config_file` points to the default config file that's being used currently. Users can set the var to point it to their custom config to use. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers