### PR TITLE
Allow specifying kubernetes version

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -111,6 +111,7 @@ CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
 ARCH ?= amd64
 BASE_IMAGE ?= docker.io/library/ubuntu:focal
+KUBERNETES_VERSION ?= 1.22
 
 ## --------------------------------------
 ## Packer flags
@@ -173,7 +174,8 @@ COMMON_NODE_VAR_FILES :=	packer/config/kubernetes.json \
 					packer/config/ansible-args.json \
 					packer/config/goss-args.json \
 					packer/config/common.json \
-					packer/config/additional_components.json
+					packer/config/additional_components.json \
+					packer/config/kubernetes-versions/version-$(subst .,-,$(KUBERNETES_VERSION)).json
 
 COMMON_HAPROXY_VAR_FILES := packer/ova/packer-common.json \
 					packer/config/ansible-args.json \

--- a/images/capi/packer/config/kubernetes-versions/version-1-18.json
+++ b/images/capi/packer/config/kubernetes-versions/version-1-18.json
@@ -1,0 +1,6 @@
+{
+  "kubernetes_deb_version": "1.18.20-00",
+  "kubernetes_rpm_version": "1.18.20-0",
+  "kubernetes_semver": "v1.18.20",
+  "kubernetes_series": "v1.18"
+}

--- a/images/capi/packer/config/kubernetes-versions/version-1-19.json
+++ b/images/capi/packer/config/kubernetes-versions/version-1-19.json
@@ -1,0 +1,6 @@
+{
+  "kubernetes_deb_version": "1.19.13-00",
+  "kubernetes_rpm_version": "1.19.13-0",
+  "kubernetes_semver": "v1.19.13",
+  "kubernetes_series": "v1.19"
+}

--- a/images/capi/packer/config/kubernetes-versions/version-1-20.json
+++ b/images/capi/packer/config/kubernetes-versions/version-1-20.json
@@ -1,0 +1,6 @@
+{
+  "kubernetes_deb_version": "1.20.9-00",
+  "kubernetes_rpm_version": "1.20.9-0",
+  "kubernetes_semver": "v1.20.9",
+  "kubernetes_series": "v1.20"
+}

--- a/images/capi/packer/config/kubernetes-versions/version-1-21.json
+++ b/images/capi/packer/config/kubernetes-versions/version-1-21.json
@@ -1,0 +1,6 @@
+{
+  "kubernetes_deb_version": "1.21.3-00",
+  "kubernetes_rpm_version": "1.21.3-0",
+  "kubernetes_semver": "v1.21.3",
+  "kubernetes_series": "v1.21"
+}

--- a/images/capi/packer/config/kubernetes-versions/version-1-22.json
+++ b/images/capi/packer/config/kubernetes-versions/version-1-22.json
@@ -1,0 +1,6 @@
+{
+  "kubernetes_deb_version": "1.22.0-00",
+  "kubernetes_rpm_version": "1.22.0-0",
+  "kubernetes_semver": "v1.22.0",
+  "kubernetes_series": "v1.22"
+}


### PR DESCRIPTION
Bumps the default kubernetes version to current latest: 1.22
Another version can be specified with:

  make &lt;target&gt; KUBERNETES_VERSION=1.18

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers