### PR TITLE
Support building Azure SIG images using custom networks

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -55,6 +55,7 @@
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "name": "sig-{{user `build_name`}}",
       "os_type": "Windows",
+      "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
       "shared_image_gallery_destination": {
         "gallery_name": "{{user `shared_image_gallery_name`}}",
         "image_name": "{{user `image_name`}}-{{user `runtime`}}",
@@ -66,6 +67,9 @@
       },
       "subscription_id": "{{user `subscription_id`}}",
       "type": "azure-arm",
+      "virtual_network_name": "{{user `virtual_network_name`}}",
+      "virtual_network_resource_group_name": "{{user `virtual_network_resource_group_name`}}",
+      "virtual_network_subnet_name": "{{user `virtual_network_subnet_name`}}",
       "vm_size": "{{user `vm_size`}}",
       "winrm_insecure": true,
       "winrm_timeout": "10m",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -54,6 +54,7 @@
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "name": "sig-{{user `build_name`}}",
       "os_type": "Linux",
+      "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
       "shared_image_gallery_destination": {
         "gallery_name": "{{user `shared_image_gallery_name`}}",
         "image_name": "{{user `image_name`}}",
@@ -66,6 +67,9 @@
       "ssh_username": "packer",
       "subscription_id": "{{user `subscription_id`}}",
       "type": "azure-arm",
+      "virtual_network_name": "{{user `virtual_network_name`}}",
+      "virtual_network_resource_group_name": "{{user `virtual_network_resource_group_name`}}",
+      "virtual_network_subnet_name": "{{user `virtual_network_subnet_name`}}",
       "vm_size": "{{user `vm_size`}}"
     }
   ],


### PR DESCRIPTION
What this PR does / why we need it:
Extension of #681. 
I did not notice that there are separate Azure builders for VHD & SIG. My bad. 
This PR adds the same support for building SIG images. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers