### PR TITLE
Fix Azure sigs builds

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -240,7 +240,7 @@ AMI_BUILD_NAMES			   ?= ami-centos-7 ami-ubuntu-1804 ami-ubuntu-2004 ami-amazon-
 GCE_BUILD_NAMES			   ?= gce-ubuntu-1804 ## gce-ubuntu-2004
 AZURE_BUILD_VHD_NAMES	   ?= azure-vhd-ubuntu-1804 azure-vhd-ubuntu-2004 azure-vhd-centos-7 azure-vhd-windows-2019 azure-vhd-windows-2019-containerd
 AZURE_BUILD_SIG_NAMES	   ?= azure-sig-ubuntu-1804 azure-sig-ubuntu-2004 azure-sig-centos-7 azure-sig-windows-2019 azure-sig-windows-2019-containerd
-AZURE_BUILD_SIG_GEN2_NAMES ?= azure-sig-ubuntu-1804-gen2 azure-sig-ubuntu-2004-gen2 azure-sig-centos7-gen2
+AZURE_BUILD_SIG_GEN2_NAMES ?= azure-sig-ubuntu-1804-gen2 azure-sig-ubuntu-2004-gen2 azure-sig-centos-7-gen2
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 

--- a/images/capi/ansible/windows/example.vars.yml
+++ b/images/capi/ansible/windows/example.vars.yml
@@ -17,7 +17,7 @@ cloudbase_init_url: https://github.com/cloudbase/cloudbase-init/releases/downloa
 wins_url: https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
 nssm_url: https://azurek8scishared.blob.core.windows.net/nssm/nssm.exe
 
-runtime: docker_ee
+runtime: docker-ee
 docker_ee_version: "19.03.12"
 kubernetes_install_path: 'c:\k'
 windows_service_manager: 'nssm'

--- a/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
@@ -40,7 +40,7 @@
   vars:
     dependencies:
       containerd: containerd
-      docker_ee: docker
+      docker-ee: docker
       default: docker
     runtime_service: "{{ dependencies[runtime] | default(dependencies['docker']) }}"
 

--- a/images/capi/ansible/windows/roles/load_additional_components/tasks/registry.yml
+++ b/images/capi/ansible/windows/roles/load_additional_components/tasks/registry.yml
@@ -35,5 +35,5 @@
   delay: 3
   register: pull
   until: pull is not failed
-  when: runtime == "docker_ee"
+  when: runtime == "docker-ee"
   

--- a/images/capi/ansible/windows/roles/runtimes/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/runtimes/tasks/main.yml
@@ -16,4 +16,4 @@
   when: runtime == "containerd" 
 
 - import_tasks: docker_ee.yml
-  when: runtime == "docker_ee"
+  when: runtime == "docker-ee"

--- a/images/capi/hack/generate-goss-specs.py
+++ b/images/capi/hack/generate-goss-specs.py
@@ -133,7 +133,7 @@ def main():
     for provider, system in itertools.product(providers, oss):
         if system in builds[provider]:
             if system == 'windows':
-                runtimes = ["docker_ee","containerd"]
+                runtimes = ["docker-ee","containerd"]
                 os_versions = ["2019", "2004"]
             else: 
                 runtimes = ["containerd"]

--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -42,10 +42,10 @@ az sig image-definition create \
 az sig image-definition create \
    --resource-group ${RESOURCE_GROUP_NAME} \
    --gallery-name ${GALLERY_NAME} \
-   --gallery-image-definition capi-windows-2019-docker_ee \
+   --gallery-image-definition capi-windows-2019-docker-ee \
    --publisher capz \
    --offer capz-demo \
-   --sku win-2019-docker \
+   --sku win-2019-docker-ee \
    --os-type Windows
 az sig image-definition create \
    --resource-group ${RESOURCE_GROUP_NAME} \

--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -42,18 +42,18 @@ az sig image-definition create \
 az sig image-definition create \
    --resource-group ${RESOURCE_GROUP_NAME} \
    --gallery-name ${GALLERY_NAME} \
-   --gallery-image-definition capi-windows-2019 \
+   --gallery-image-definition capi-windows-2019-docker_ee \
    --publisher capz \
    --offer capz-demo \
-   --sku win-2019 \
+   --sku win-2019-docker \
    --os-type Windows
 az sig image-definition create \
    --resource-group ${RESOURCE_GROUP_NAME} \
    --gallery-name ${GALLERY_NAME} \
-   --gallery-image-definition capi-windows-2004 \
+   --gallery-image-definition capi-windows-2019-containerd \
    --publisher capz \
    --offer capz-demo \
-   --sku win-2004 \
+   --sku win-2019-containerd \
    --os-type Windows
 az sig image-definition create \
    --resource-group ${RESOURCE_GROUP_NAME} \

--- a/images/capi/packer/config/windows/common.json
+++ b/images/capi/packer/config/windows/common.json
@@ -7,7 +7,7 @@
   "no_proxy": "",
   "nssm_url": "https://azurek8scishared.blob.core.windows.net/nssm/nssm.exe",
   "prepull": "true",
-  "runtime": "docker_ee",
+  "runtime": "docker-ee",
   "windows_service_manager": "nssm",
   "windows_updates_categories": "",
   "windows_updates_kbs": "",

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -130,7 +130,7 @@ command:
     timeout: 30000
 {{end}}
 
-{{ if eq .Vars.runtime "docker_ee" }}
+{{ if eq .Vars.runtime "docker-ee" }}
   Correct Docker Version:
     exec: "docker.exe version"
     exit-status: 0

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -52,7 +52,7 @@ command:
     {{end}}
 {{end}}
 
-{{ if eq .Vars.runtime "docker_ee" }}
+{{ if eq .Vars.runtime "docker-ee" }}
 
   "Windows Service - docker":
     exec: powershell -command "(Get-Service docker | select *)"


### PR DESCRIPTION
What this PR does / why we need it:

#661 introduced containerd but the azure sigs `make build-azure-sigs` broke with:

```
==> Some builds didn't complete successfully and had errors:
--> sig-windows-2019-containerd: the Shared Gallery Image to which to publish the managed image version to does not exist in the resource group image-builder-e2e-lc3p6d
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes https://github.com/kubernetes-sigs/image-builder/pull/652#pullrequestreview-740713045

**Additional context**
Add any other context for the reviewers

/cc @CecileRobertMichon @whites11 @invidian 