### PR TITLE
block traffic to 168.63.129.16 port 80 for cve-2021-27075

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -29,3 +29,12 @@
     path: /etc/chrony/chrony.conf
     regexp: '^makestep'
     line: makestep 1.0 -1
+
+- name: Block traffic to 168.63.129.16 port 80 for cve-2021-27075
+  ansible.builtin.iptables:
+    chain: FORWARD
+    destination: 168.63.129.16
+    destination_port: 80
+    protocol: tcp
+    jump: DROP
+    comment: block traffic to 168.63.129.16 for cve-2021-27075


### PR DESCRIPTION
What this PR does / why we need it:

This PR explicitly ensures that TCP traffic bound for the reserved Azure IP 168.63.129.16 via TCP on port 80 is dropped to remediate https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-27075. 

Needs: #691 

/cc @CecileRobertMichon 