### PR TITLE
add Windows firewall rule to block 168.63.129.16:80 for cve-2021-27075

### DIFF
--- a/images/capi/ansible/windows/node_windows.yml
+++ b/images/capi/ansible/windows/node_windows.yml
@@ -70,6 +70,8 @@
         name: cloudbase-init
       when: install_cloudbase_init
     - include_role:
+        name: providers
+    - include_role:
         name: runtimes
     - include_role:
         name: kubernetes

--- a/images/capi/ansible/windows/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/azure.yml
@@ -1,0 +1,18 @@
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Block traffic to 168.63.129.16 port 80 for cve-2021-27075
+  win_shell: |
+    New-NetFirewallRule -DisplayName 'Block-Outbound-168.63.129.16-port-80-for-cve-2021-27075' -Direction Outbound -RemoteAddress '168.63.129.16' -RemotePort '80' -Protocol TCP -Action Block
+  become: yes
+  become_method: runas
+  become_user: SYSTEM

--- a/images/capi/ansible/windows/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/main.yml
@@ -1,0 +1,14 @@
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- include_tasks: azure.yml
+  when: packer_builder_type.startswith('azure')

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -138,4 +138,14 @@ command:
     - "{{.Vars.docker_ee_version}}"
     timeout: 30000
 {{end}}
+
+{{if eq .Vars.PROVIDER "azure"}}
+  Verify firewall rule to block 168.63.129.16:80 for cve-2021-27075:
+    exit-status: 0
+    exec: powershell -command "(Get-NetFirewallRule -ErrorAction Stop -DisplayName 'Block-Outbound-168.63.129.16-port-80-for-cve-2021-27075').Enabled"
+    stdout:
+    - True
+    stderr: []
+    timeout: 30000
+{{end}}
 {{end}} #end windows


### PR DESCRIPTION
What this PR does / why we need it:

This PR explicitly ensures that TCP traffic bound for the reserved Azure IP 168.63.129.16 via TCP on port 80 is dropped to remediate https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-27075 on Windows nodes.

**Additional context**
Related to: #690 