### PR TITLE
Create ssh program data if not exists on image

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -110,6 +110,10 @@
     data: '{{ systemdrive.stdout | trim }}\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
     type: string
 
+- name: Create SSH program data folder
+  win_shell: mkdir "$env:ProgramData\ssh"
+  ignore_errors: yes
+
 - name: Enable ssh login without a password
   win_shell: Add-Content -Path "$env:ProgramData\ssh\sshd_config" -Value "PasswordAuthentication no`nPubkeyAuthentication yes"
 


### PR DESCRIPTION
What this PR does / why we need it:
On the latest ISO image `ProgramData\ssh` folder does not exist and the build fails in the middle of execution, this PR creates the folder before changing the configuration

Fixes #693
