### PR TITLE
Checking if ssh directory exists before creating it

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -111,8 +111,7 @@
     type: string
 
 - name: Create SSH program data folder
-  win_shell: mkdir "$env:ProgramData\ssh"
-  ignore_errors: yes
+  win_shell: If (-Not (Test-Path -Path "$env:ProgramData\ssh")) { mkdir "$env:ProgramData\ssh" }
 
 - name: Enable ssh login without a password
   win_shell: Add-Content -Path "$env:ProgramData\ssh\sshd_config" -Value "PasswordAuthentication no`nPubkeyAuthentication yes"


### PR DESCRIPTION
What this PR does / why we need it:

If the .ssh directory already exists in the image, a warning is raised, checking the directory before creating

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers