### PR TITLE
Bump Ubuntu 18.04 ISO to currently available ISO

### DIFF
--- a/images/capi/packer/ova/ubuntu-1804.json
+++ b/images/capi/packer/ova/ubuntu-1804.json
@@ -9,9 +9,9 @@
   "distro_version": "18.04",
   "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
+  "iso_checksum": "f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.5-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.6-server-amd64.iso",
   "os_display_name": "Ubuntu 18.04",
   "shutdown_command": "shutdown -P now",
   "vsphere_guest_os_type": "ubuntu64Guest"

--- a/images/capi/packer/qemu/qemu-ubuntu-1804.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-1804.json
@@ -4,9 +4,9 @@
   "build_name": "ubuntu-1804",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
+  "iso_checksum": "f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.5-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.6-server-amd64.iso",
   "os_display_name": "Ubuntu 18.04",
   "shutdown_command": "shutdown -P now"
 }

--- a/images/capi/packer/raw/raw-ubuntu-1804.json
+++ b/images/capi/packer/raw/raw-ubuntu-1804.json
@@ -4,9 +4,9 @@
   "build_name": "ubuntu-1804",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
+  "iso_checksum": "f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.5-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.6-server-amd64.iso",
   "os_display_name": "Ubuntu 18.04",
   "shutdown_command": "shutdown -P now"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Current builds reference the `ubuntu-18.04.5-server-amd64.iso`, which is no longer available and has been replaced with `ubuntu-18.04-6-server-amd64.iso`

