### PR TITLE
Include the common var file for windows

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -185,6 +185,7 @@ COMMON_WINDOWS_VAR_FILES :=	packer/config/kubernetes.json \
 					packer/config/windows/containerd.json \
 					packer/config/windows/docker.json \
 					packer/config/windows/ansible-args-windows.json \
+					packer/config/common.json \
 					packer/config/windows/common.json \
 					packer/config/windows/cloudbase-init.json \
 					packer/config/goss-args.json \


### PR DESCRIPTION
What this PR does / why we need it:
The common.json packer file contains the definition for the pause image.  It wasn't properly wired up for Windows and is need for containerd configuration.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #703

**Additional context**
Add any other context for the reviewers

/sig windows
/assign @perithompson 