### PR TITLE
feat: set a default Containerd imports directory

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -101,6 +101,24 @@ Then, execute the build (using a Photon OVA as an example) with the following:
 PACKER_VAR_FILES=extra_vars.json make build-node-ova-local-photon-3
 ```
 
+##### Configuring Containerd at runtime
+
+Containerd default configuration has the following `imports` value:
+
+```
+imports = ["/etc/containerd/conf.d/*.toml"]
+```
+
+This allows you to place files at runtime in `/etc/containerd/conf.d/` that will then be merged with the rest of containerd configuration.
+
+For example to enable containerd metrics, create a file `/etc/containerd/conf.d/metrics.toml` with the following:
+
+```
+[metrics]
+  address = "0.0.0.0:1338"
+  grpc_histogram = false
+```
+
 ##### Disabling default repos and using an internal package mirror
 
 A common use-case within enterprise environments is to have a package repository available on an internal network to install from rather than reaching out to the internet. To support this, you can inject custom repository definitions into the image, and optionally disable the use of the default ones.

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -4,6 +4,10 @@
 # Config file is parsed as version 1 by default.
 version = 2
 
+{% if 'imports' not in containerd_additional_settings | b64decode %}
+imports = ["/etc/containerd/conf.d/*.toml"]
+{% endif %}
+
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pause_image }}"

--- a/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
+++ b/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
@@ -57,6 +57,9 @@
     allusersprofile: "{{ alluserprofile.stdout | trim }}"
     plugin_bin_dir: "{{ systemdrive.stdout | trim }}/opt/cni/bin"
     plugin_conf_dir: "{{ systemdrive.stdout | trim }}/etc/cni/net.d"
+    # programfiles is C:\Program Files, but should be C:\\Program Files
+    # otherwise task Register Containerd fails with "invalid escape sequence: \P"
+    containerd_conf_dir: '{{ programfiles.stdout | trim | regex_replace("\\", "\\\\") }}\\\\containerd'
 
 - name: Check if a Containerd service is installed
   win_service:

--- a/images/capi/ansible/windows/roles/runtimes/templates/config.toml
+++ b/images/capi/ansible/windows/roles/runtimes/templates/config.toml
@@ -16,6 +16,10 @@ root = "{{ allusersprofile }}\\root"
 state = "{{ allusersprofile }}\\state"
 version = 2
 
+{% if 'imports' not in containerd_additional_settings | b64decode %}
+imports = ["{{ containerd_conf_dir }}\\conf.d\\*.toml"]
+{% endif %}
+
 [grpc]
   address = "\\\\.\\pipe\\containerd-containerd"
   


### PR DESCRIPTION
What this PR does / why we need it:
Adds a well-defined location to include additional Containerd configuration using `imports`. Wrapped it in an `if` statement to not break existing users who may be already defining an `imports` in `containerd_additional_settings`.

Tested by building an AMI and verifying the new behavior:

1. The new `imports` is in the config.
```
sh-4.2$ cat config.toml 
## template: jinja

# Use config version 2 to enable new configuration fields.
# Config file is parsed as version 1 by default.
version = 2

imports = ["/etc/containerd/config.toml", "/etc/containerd/conf.d/*.toml"]

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    sandbox_image = "k8s.gcr.io/pause:3.6"
```

2. Before adding any config files notice the `[metrics].address` is empty:
```
sh-4.2$ containerd config dump
disabled_plugins = []
imports = ["/etc/containerd/config.toml"]
oom_score = 0
plugin_dir = ""
required_plugins = []
root = "/var/lib/containerd"
state = "/run/containerd"
version = 2

...

[metrics]
  address = ""
  grpc_histogram = false
```

3. Added a file in `conf.d`
```
sh-4.2$ cat conf.d/metrics.toml 
[metrics]
  address = "0.0.0.0:1338"
  grpc_histogram = false
```

4. New config with `address = "0.0.0.0:1338"`.
```
sh-4.2$ containerd config dump
disabled_plugins = []
imports = ["/etc/containerd/config.toml", "/etc/containerd/conf.d/metrics.toml"]
oom_score = 0
plugin_dir = ""
required_plugins = []
root = "/var/lib/containerd"
state = "/run/containerd"
version = 2

...

[metrics]
  address = "0.0.0.0:1338"
  grpc_histogram = false
```

5. And Containerd picking up the config changes
```
sh-4.2$ sudo systemctl restart containerd
sh-4.2$ sudo netstat -tulpn | grep LISTEN | grep 1338
tcp6       0      0 :::1338                 :::*                    LISTEN      11053/containerd    
sh-4.2$ 
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes https://github.com/kubernetes-sigs/image-builder/issues/709

**Additional context**
Add any other context for the reviewers