### PR TITLE
Add Windows approvers for docs and Win config

### DIFF
--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - image-builder-windows-maintainers

--- a/images/capi/packer/config/windows/OWNERS
+++ b/images/capi/packer/config/windows/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - image-builder-windows-maintainers


### PR DESCRIPTION
What this PR does / why we need it:
We previously listed Windows maintainers are approvers for the Windows ansible roles, but Windows-only PRs often get hung up on doc changes or changes to the Packer config. This PR adds the WIndows maintainers as approvers for more areas that are Windows-specific (and all of docs).

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
/assign @jsturtevant @CecileRobertMichon 