### PR TITLE
add test to validate iptable rule drop 168.63.129.16 on Azure

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/azure/iptables
+++ b/images/capi/ansible/roles/providers/files/etc/azure/iptables
@@ -1,0 +1,8 @@
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+-A FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -m comment --comment "block traffic to 168.63.129.16 for cve-2021-27075" -j DROP
+-A OUTPUT -d 168.63.129.16/32 -p tcp -m owner --uid-owner 0 -j ACCEPT
+-A OUTPUT -d 168.63.129.16/32 -p tcp -m conntrack --ctstate INVALID,NEW -j DROP
+COMMIT

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -30,11 +30,27 @@
     regexp: '^makestep'
     line: makestep 1.0 -1
 
+- name: Install iptables persistence
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+  vars:
+    packages:
+      - iptables-persistent
+  when: ansible_os_family == "Debian"
+
 - name: Block traffic to 168.63.129.16 port 80 for cve-2021-27075
-  ansible.builtin.iptables:
-    chain: FORWARD
-    destination: 168.63.129.16
-    destination_port: 80
-    protocol: tcp
-    jump: DROP
-    comment: block traffic to 168.63.129.16 for cve-2021-27075
+  copy:
+    src: files/etc/azure/iptables
+    dest: /etc/iptables/rules.v4
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_os_family == "Debian"
+
+- name: Load iptable rules from file
+  community.general.iptables_state:
+    state: restored
+    path: /etc/iptables/rules.v4
+  when: ansible_os_family == "Debian"

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -161,6 +161,9 @@ ubuntu:
         stdout: ["azure-cli"]
         stderr: []
         timeout: 0
+      iptables -C FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -m comment --comment "block traffic to 168.63.129.16 for cve-2021-27075" -j DROP:
+        exit-status: 0
+        timeout: 0
     package:
       <<: *chrony_deb
     service:


### PR DESCRIPTION
What this PR does / why we need it:
PR #690 didn't include a test to validate the iptable rule was set in Azure Linux machines. This PR adds a test to validate the iptable rule was created and matches expectation.

/cc @jsturtevant 