### PR TITLE
Allow subset of users to have access to Azure wireserver for Windows

### DIFF
--- a/images/capi/ansible/windows/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/azure.yml
@@ -10,9 +10,39 @@
 # limitations under the License.
 ---
 
+- name: Create Azure wireserver access group
+  ansible.windows.win_group:
+    name: WireServerAccess
+    description: Controls access to the Azure WireServer
+
+# AzureGuestAgent and Cloudbase-init need access to wireserver otherwise VM doesn't boot
+# So we give the users access via the firewall security filters
+# https://docs.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallsecurityfilter
+# 
+# Permissions set on the Firewall rule:
+#   S-1-1-0 is Everyone. We mark this as Allow (A) to ensure the Block is enforced for all users other than on the exception list.
+#   S-1-5-18 is LocalSystem used by AzureGuestAgent.  We mark this as Deny (D) to add to Block exception list. 
+#   We also add the newly created group WireServerAccess to the block exception list and add Cloudbase-init user later.
+#
+# View the details of the SDDL string used with ConvertFrom-SddlString and see well known sids: https://docs.microsoft.com/en-us/windows/win32/secauthz/well-known-sids
 - name: Block traffic to 168.63.129.16 port 80 for cve-2021-27075
   win_shell: |
-    New-NetFirewallRule -DisplayName 'Block-Outbound-168.63.129.16-port-80-for-cve-2021-27075' -Direction Outbound -RemoteAddress '168.63.129.16' -RemotePort '80' -Protocol TCP -Action Block
+    $wsg = Get-LocalGroup -n "WireServerAccess"
+    $r = New-NetFirewallRule -DisplayName 'Block-Outbound-168.63.129.16-port-80-for-cve-2021-27075' -Direction Outbound -RemoteAddress '168.63.129.16' -RemotePort '80' -Protocol TCP -Action Block
+    $r | Get-NetFirewallSecurityFilter | Set-NetFirewallSecurityFilter -LocalUser "O:LSD:(D;;CC;;;S-1-5-18)(D;;CC;;;$($wsg.SID.Value))(A;;CC;;;S-1-1-0)"
   become: yes
   become_method: runas
   become_user: SYSTEM
+
+- name: Add users to WireServerAccessGroup
+  ansible.windows.win_group_membership:
+    name: WireServerAccess
+    members:
+      - cloudbase-init
+
+- name: Add additional users
+  ansible.windows.win_group_membership:
+    name: WireServerAccess
+    members: "{{ users }}"
+  vars:
+    users: "{{ wire_server_users.split(',') if (wire_server_users is defined) and (wire_server_users|length > 0) else [] }}"

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -112,6 +112,8 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
+        "{{user `azure_extra_vars`}}",
+        "--extra-vars",
         "{{user `ansible_extra_vars`}}",
         "--extra-vars",
         "{{user `ansible_user_vars`}}"
@@ -171,6 +173,7 @@
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
     "ansible_user_vars": "",
+    "azure_extra_vars": "wire_server_users={{user `wire_server_users`}}",
     "azure_location": null,
     "build_name": null,
     "build_timestamp": "{{timestamp}}",
@@ -201,6 +204,7 @@
     "vm_size": "",
     "windows_service_manager": null,
     "windows_updates_kbs": null,
-    "wins_url": "https://github.com/rancher/wins/releases/download/v{{user `wins_version`}}/wins.exe"
+    "wins_url": "https://github.com/rancher/wins/releases/download/v{{user `wins_version`}}/wins.exe",
+    "wire_server_users": ""
   }
 }


### PR DESCRIPTION
What this PR does / why we need it:

#694 resulted in Azure VM's not coming online when provisioned.  This is due to the GuestAgent and cloudbase-init needing access to the wireserver.  

This configured the block rule to apply to everyone but LocalSystem and users in the local Administrator group which includes GuestAgent and cloudbase-init.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

This does mean that if you have an application installed on the VM that is not in the administrator group then you will not be able to access the wireserver. 

`ContainerAdministrator` is considered a part of the Administrator group and therefore containers running as `ContainerAdministrator` would be given access to the wireserver.  We have two options:
- use cni specific acl (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1672/commits/dc241572c96d13f2ea2e51b35494a8a0aaf8e543#diff-d0c3cd272af154ea5bc8ae6f19ef250f1ea9c2f6d78d92d7fdc3b3d61ad68f2a)
- create a group and add cloudbase-init too it to remove `containeradministrator`'s access 

**update**: went with option two, adding a group.  The blocks access to the wireserver for `conatineradministrator` and allows for adding permissions for other users/apps.