### PR TITLE
kernel values to support --protect-kernel-defaults

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -51,6 +51,9 @@
     - { param: net.ipv6.conf.all.forwarding, val: 1 }
     - { param: net.ipv6.conf.all.disable_ipv6, val: 0 }
     - { param: net.ipv4.tcp_congestion_control, val: bbr }
+    - { param: vm.overcommit_memory, val: 1 }
+    - { param: kernel.panic, val: 10 }
+    - { param: kernel.panic_on_oops, val: 1 }
 
 - name: Disable swap memory
   shell: |

--- a/images/capi/packer/goss/goss-kernel-params.yaml
+++ b/images/capi/packer/goss/goss-kernel-params.yaml
@@ -10,6 +10,12 @@ kernel-param:
     value: "1"
   net.bridge.bridge-nf-call-ip6tables:
     value: "1"
+  vm.overcommit_memory:
+    value: "1"
+  kernel.panic:
+    value: "10"
+  kernel.panic_on_oops:
+    value: "1"
 {{range $name, $vers := index .Vars .Vars.OS "common-kernel-param"}}
   {{ $name }}:
   {{range $key, $val := $vers}}


### PR DESCRIPTION
What this PR does / why we need it:
Kernel setting to support `--protect-kernel-defaults=true` 

Which issue(s) this PR fixes: 
Fixes k/k issue [#66241](https://github.com/kubernetes/kubernetes/issues/66241)

**Additional context**
`--protect-kernel-defaults` setting is required by both CIS and STIG kubernetes benchmarks
- CIS  rule 4.2.6
- STIG rule V-242434