### PR TITLE
Update Flatcar-related URLs

### DIFF
--- a/images/capi/README-flatcar.md
+++ b/images/capi/README-flatcar.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This is a Cluster API image builder for [Flatcar Container Linux](https://kinvolk.io/flatcar-container-linux).
+This is a Cluster API image builder for [Flatcar Container Linux](https://www.flatcar-linux.org/).
 
 On the Packer side it includes `packer/qemu/flatcar.json` and `packer/qemu/packer.json`.
 In `packer/config/` it also includes some other JSON files with configuration for
@@ -47,7 +47,7 @@ Start a new build with
 
 Flatcar Container Linux maintains four distinct
 channels: `alpha`, `beta`, `stable`, and `edge`. For details please refer to
-the [releases page](https://kinvolk.io/flatcar-container-linux/releases/).
+the [releases page](https://www.flatcar-linux.org/releases/).
 
 The build script will default to the latest release of the `stable` channel.
 

--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -19,7 +19,7 @@ check_for_release() {
     channel="$1"
     release="$2"
     curl -L -s \
-         "https://kinvolk.io/flatcar-container-linux/releases-json/releases-$channel.json" \
+         "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
         | jq -r 'to_entries[] | "\(.key)"' \
         | grep -q "$release"
 }

--- a/images/capi/hack/image-grok-latest-flatcar-version.sh
+++ b/images/capi/hack/image-grok-latest-flatcar-version.sh
@@ -5,7 +5,7 @@
 channel="$1"
 
 curl -L -s \
-     "https://kinvolk.io/flatcar-container-linux/releases-json/releases-$channel.json" \
+     "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
     | jq -r 'to_entries[] | "\(.key)"' \
     | grep -v "current" \
     | sort --version-sort \


### PR DESCRIPTION
What this PR does / why we need it:

We have some Flatcar-related URLs which point to older Flatcar servers which may not always be up to date, for example when querying for release metadata. This fixes the URLs to point to the current, authoritative servers.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
None