### PR TITLE
Downgrade cloud-init. Workaround for #712

### DIFF
--- a/images/capi/ansible/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/roles/providers/defaults/main.yml
@@ -1,0 +1,15 @@
+# Copyright 2021 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+cloud_init_deb_download_url: "https://launchpad.net/ubuntu/+source/cloud-init/21.1-19-gbad84ad4-0ubuntu1~20.04.2/+build/21434629/+files/cloud-init_21.1-19-gbad84ad4-0ubuntu1~20.04.2_all.deb"

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -25,6 +25,21 @@
     - cloud-initramfs-dyn-netconf
   when: ansible_os_family == "Debian"
 
+- name: Download cloud-init_21.1-19 from launchpad
+  get_url:
+    url: "{{ cloud_init_deb_download_url }}"
+    dest: /tmp
+  register: cloud_init_deb_file
+  when: ansible_os_family == "Debian" and ansible_distribution_version == "20.04"
+
+- name: Install cloud-init v21.1-19 deb
+  command: "dpkg -i {{ cloud_init_deb_file.dest }}"
+  when: ansible_os_family == "Debian" and ansible_distribution_version == "20.04"
+
+- name: Downgrade to cloud-init 21.2-4.ph3
+  command: "tdnf downgrade cloud-init=21.2-4.ph3 -y"
+  when: ansible_os_family == "VMware Photon OS"
+
 - name: Install cloud-init packages
   yum:
     name: "{{ packages }}"


### PR DESCRIPTION
What this PR does / why we need it:
Fixes #722 

- Download 21.1-19 from launchpad and install it. 
- Downgrade to 21.2-4.ph3 on photon-3
- Latest available version on RHEL-7 is 19.4-7. [Link](https://access.redhat.com/downloads/content/cloud-init/19.4-7.el7_9.5/x86_64/fd431d51/package). So, no changes on RHEL-7

Of course, revert these changes once the fix has made it to the update channel. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @codenrhoden @randomvariable 