### PR TITLE
fixed kickstart file for centos-7 and rhel-7 and added centos-7 to ci…

### DIFF
--- a/images/capi/packer/ova/linux/centos/http/7/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/7/ks.cfg
@@ -53,7 +53,6 @@ part / --grow --asprimary --fstype=ext4 --label=slash
 openssh-server
 sed
 sudo
-open-vm-tools
 
 # Remove unnecessary firmware
 -*-firmware
@@ -78,6 +77,9 @@ update-ca-trust force-enable
 # or else Ansible will fail
 echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
 chmod 440 /etc/sudoers.d/builder
+
+# Install open-vm-tools
+yum install -y open-vm-tools
 
 # Remove the package cache
 yum -y clean all

--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -21,7 +21,7 @@ set -o pipefail # any non-zero exit code in a piped command causes the pipeline 
 CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
-TARGETS=("ubuntu-1804" "ubuntu-2004")
+TARGETS=("ubuntu-1804" "ubuntu-2004" "centos-7")
 
 on_exit() {
   for target in ${TARGETS[@]};


### PR DESCRIPTION
…-ova.sh script

What this PR does / why we need it:
This PR will fix the installation of open-vm-tools for centos and RHEL.
open-vm-tools package is in "Update" Repo and with the default --ignoremissing we don't see any error like "open-vm-tools package not found"

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Without open-vm-tools installed, if you try to build centos/rhel OVA the process will remain stuck in "Waiting for IP address"