### PR TITLE
Add networkd-dispatcher script to access NTP servers provided by DHCP

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -57,11 +57,13 @@ common_photon_rpms:
 - audit
 - conntrack-tools
 - chrony
+- dbus-python3
 - distrib-compat
 - ebtables
 - jq
 - net-tools
 - openssl-c_rehash
+- python3-pygobject
 - python-netifaces
 - python3-pip
 - python-requests

--- a/images/capi/ansible/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/roles/providers/defaults/main.yml
@@ -13,3 +13,4 @@
 # limitations under the License.
 ---
 cloud_init_deb_download_url: "https://launchpad.net/ubuntu/+source/cloud-init/21.1-19-gbad84ad4-0ubuntu1~20.04.2/+build/21434629/+files/cloud-init_21.1-19-gbad84ad4-0ubuntu1~20.04.2_all.deb"
+networkd_dispatcher_download_url: "https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.bz2"

--- a/images/capi/ansible/roles/providers/files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2
+++ b/images/capi/ansible/roles/providers/files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This is a networkd-dispatcher script for chronyd to handle its NTP
+# sources. It sets the NTP sources online or offline when a network
+# interface is configured or removed. On DHCP change, chrony will
+# update its NTP sources passed from DHCP options.
+
+export LC_ALL=C
+
+DHCP_SERVER_FILE={{ server_dir }}/chrony.servers.$IFACE
+
+clear_servers_from_dhcp() {
+    if [ -f "$DHCP_SERVER_FILE" ]; then
+        rm -f "$DHCP_SERVER_FILE"
+        {{ chrony_helper_dir }}/chrony-helper update-daemon || :
+    fi
+}
+
+if [ "$STATE" = "no-carrier" ]; then
+    clear_servers_from_dhcp
+    # The onoffline command tells chronyd to switch all sources to
+    # the online (routable) or offline (off) status according to the current network configuration.
+    chronyc onoffline > /dev/null 2>&1
+fi
+
+exit 0

--- a/images/capi/ansible/roles/providers/files/etc/networkd-dispatcher/off.d/20-chrony.j2
+++ b/images/capi/ansible/roles/providers/files/etc/networkd-dispatcher/off.d/20-chrony.j2
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This is a networkd-dispatcher script for chronyd to handle its NTP
+# sources. It sets the NTP sources online or offline when a network
+# interface is configured or removed. On DHCP change, chrony will
+# update its NTP sources passed from DHCP options.
+
+export LC_ALL=C
+
+DHCP_SERVER_FILE={{ server_dir }}/chrony.servers.$IFACE
+
+clear_servers_from_dhcp() {
+    if [ -f "$DHCP_SERVER_FILE" ]; then
+        rm -f "$DHCP_SERVER_FILE"
+        {{ chrony_helper_dir }}/chrony-helper update-daemon || :
+    fi
+}
+
+if [ "$STATE" = "off" ]; then
+    clear_servers_from_dhcp
+    # The onoffline command tells chronyd to switch all sources to
+    # the online (routable) or offline (off) status according to the current network configuration.
+    chronyc onoffline > /dev/null 2>&1
+fi
+
+exit 0

--- a/images/capi/ansible/roles/providers/files/etc/networkd-dispatcher/routable.d/20-chrony.j2
+++ b/images/capi/ansible/roles/providers/files/etc/networkd-dispatcher/routable.d/20-chrony.j2
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This is a networkd-dispatcher script for chronyd to handle its NTP
+# sources. It sets the NTP sources online or offline when a network
+# interface is configured or removed. On DHCP change, chrony will
+# update its NTP sources passed from DHCP options.
+
+export LC_ALL=C
+
+DHCP_SERVER_FILE={{ server_dir }}/chrony.servers.$IFACE
+
+add_servers_from_dhcp() {
+    if [ -f "$DHCP_SERVER_FILE" ]; then
+        rm -f "$DHCP_SERVER_FILE"
+    fi
+    echo "$json" | jq -r 'select(.NTP !=null) .NTP[]' >> $DHCP_SERVER_FILE
+    {{ chrony_helper_dir }}/chrony-helper update-daemon || :
+}
+
+if [ "$STATE" = "routable" ]; then
+    add_servers_from_dhcp
+    # The onoffline command tells chronyd to switch all sources to
+    # the online (routable) or offline (off) status according to the current network configuration.
+    chronyc onoffline > /dev/null 2>&1
+fi
+
+exit 0

--- a/images/capi/ansible/roles/providers/files/usr/libexec/chrony-helper
+++ b/images/capi/ansible/roles/providers/files/usr/libexec/chrony-helper
@@ -1,0 +1,251 @@
+#!/bin/bash
+# This script configures running chronyd to use NTP servers obtained from
+# DHCP and _ntp._udp DNS SRV records. Files with servers from DHCP are managed
+# externally (e.g. by a dhclient script). Files with servers from DNS SRV
+# records are updated here using the dig utility. The script can also list
+# and set static sources in the chronyd configuration file.
+
+chronyc=/usr/bin/chronyc
+chrony_conf=/etc/chrony.conf
+chrony_service=chronyd.service
+helper_dir=/var/run/chrony-helper
+added_servers_file=$helper_dir/added_servers
+
+network_sysconfig_file=/etc/sysconfig/network
+dhclient_servers_files=/var/lib/dhclient/chrony.servers.*
+dnssrv_servers_files=$helper_dir/dnssrv@*
+dnssrv_timer_prefix=chrony-dnssrv@
+
+chrony_command() {
+    $chronyc -a -n -m "$1"
+}
+
+is_running() {
+    chrony_command "tracking" &> /dev/null
+}
+
+is_update_needed() {
+    for file in $dhclient_servers_files $dnssrv_servers_files \
+            $added_servers_file; do
+        [ -e "$file" ] && return 0
+    done
+    return 1
+}
+
+update_daemon() {
+    local all_servers_with_args all_servers added_servers
+
+    if ! is_running; then
+        rm -f $added_servers_file
+        return 0
+    fi
+
+    all_servers_with_args=$(
+        cat $dhclient_servers_files $dnssrv_servers_files 2> /dev/null)
+
+    all_servers=$(
+        echo "$all_servers_with_args" |
+            while read server serverargs; do
+                echo "$server"
+            done | sort -u)
+    added_servers=$( (
+        cat $added_servers_file 2> /dev/null
+        echo "$all_servers_with_args" |
+            while read server serverargs; do
+                [ -z "$server" ] && continue
+                chrony_command "add server $server $serverargs" &> /dev/null &&
+                    echo "$server"
+            done) | sort -u)
+
+    comm -23 <(echo -n "$added_servers") <(echo -n "$all_servers") |
+        while read server; do
+            chrony_command "delete $server" &> /dev/null
+        done
+
+    added_servers=$(comm -12 <(echo -n "$added_servers") <(echo -n "$all_servers"))
+
+    [ -n "$added_servers" ] && echo "$added_servers" > $added_servers_file ||
+        rm -f $added_servers_file
+}
+
+get_dnssrv_servers() {
+    local name=$1
+
+    if ! command -v dig &> /dev/null; then
+        echo "Missing dig (DNS lookup utility)" >&2
+        return 1
+    fi
+
+    (
+        . $network_sysconfig_file &> /dev/null
+
+        output=$(dig "$name" srv +short +ndots=2 +search 2> /dev/null)
+        [ $? -ne 0 ] && return 0
+
+        echo "$output" | while read prio weight port target; do
+            server=${target%.}
+            [ -z "$server" ] && continue
+            echo "$server port $port ${NTPSERVERARGS:-iburst}"
+        done
+    )
+}
+
+check_dnssrv_name() {
+    local name=$1
+
+    if [ -z "$name" ]; then
+        echo "No DNS SRV name specified" >&2
+        return 1
+    fi
+
+    if [ "${name:0:9}" != _ntp._udp ]; then
+        echo "DNS SRV name $name doesn't start with _ntp._udp" >&2
+        return 1
+    fi
+}
+
+update_dnssrv_servers() {
+    local name=$1
+    local srv_file=$helper_dir/dnssrv@$name servers
+
+    check_dnssrv_name "$name" || return 1
+
+    servers=$(get_dnssrv_servers "$name")
+    [ -n "$servers" ] && echo "$servers" > "$srv_file" || rm -f "$srv_file"
+}
+
+set_dnssrv_timer() {
+    local state=$1 name=$2
+    local srv_file=$helper_dir/dnssrv@$name servers
+    local timer=$dnssrv_timer_prefix$(systemd-escape "$name").timer
+
+    check_dnssrv_name "$name" || return 1
+
+    if [ "$state" = enable ]; then
+        systemctl enable "$timer"
+        systemctl start "$timer"
+    elif [ "$state" = disable ]; then
+        systemctl stop "$timer"
+        systemctl disable "$timer"
+        rm -f "$srv_file"
+    fi
+}
+
+list_dnssrv_timers() {
+    systemctl --all --full -t timer list-units | grep "^$dnssrv_timer_prefix" | \
+            sed "s|^$dnssrv_timer_prefix\(.*\)\.timer.*|\1|" |
+        while read -r name; do
+            systemd-escape --unescape "$name"
+        done
+}
+
+prepare_helper_dir() {
+    mkdir -p $helper_dir
+    exec 100> $helper_dir/lock
+    if ! flock -w 20 100; then
+        echo "Failed to lock $helper_dir" >&2
+        return 1
+    fi
+}
+
+is_source_line() {
+    local pattern="^[ \t]*(server|pool|peer|refclock)[ \t]+[^ \t]+"
+    [[ "$1" =~ $pattern ]]
+}
+
+list_static_sources() {
+    while read line; do
+        is_source_line "$line" && echo "$line" || :
+    done < $chrony_conf
+}
+
+set_static_sources() {
+    local new_config tmp_conf
+
+    new_config=$(
+        sources=$(
+            while read line; do
+                is_source_line "$line" && echo "$line"
+            done)
+
+        while read line; do
+            if ! is_source_line "$line"; then
+                echo "$line"
+                continue
+            fi
+
+            tmp_sources=$(
+                local removed=0
+
+                echo "$sources" | while read line2; do
+                    [ "$removed" -ne 0 -o "$line" != "$line2" ] && \
+                        echo "$line2" || removed=1
+                done)
+
+            [ "$sources" == "$tmp_sources" ] && continue
+            sources=$tmp_sources
+            echo "$line"
+        done < $chrony_conf
+
+        echo "$sources"
+    )
+
+    tmp_conf=${chrony_conf}.tmp
+
+    cp -a $chrony_conf $tmp_conf &&
+        echo "$new_config" > $tmp_conf &&
+        mv $tmp_conf $chrony_conf || return 1
+
+    systemctl try-restart $chrony_service
+}
+
+print_help() {
+    echo "Usage: $0 COMMAND"
+    echo
+    echo "Commands:"
+    echo "	update-daemon"
+    echo "	update-dnssrv-servers NAME"
+    echo "	enable-dnssrv NAME"
+    echo "	disable-dnssrv NAME"
+    echo "	list-dnssrv"
+    echo "	list-static-sources"
+    echo "	set-static-sources < sources.list"
+    echo "	is-running"
+    echo "	command CHRONYC-COMMAND"
+}
+
+case "$1" in
+    update-daemon|add-dhclient-servers|remove-dhclient-servers)
+        is_update_needed || exit 0
+        prepare_helper_dir && update_daemon
+        ;;
+    update-dnssrv-servers)
+        prepare_helper_dir && update_dnssrv_servers "$2" && update_daemon
+        ;;
+    enable-dnssrv)
+        set_dnssrv_timer enable "$2"
+        ;;
+    disable-dnssrv)
+        set_dnssrv_timer disable "$2" && prepare_helper_dir && update_daemon
+        ;;
+    list-dnssrv)
+        list_dnssrv_timers
+        ;;
+    list-static-sources)
+        list_static_sources
+        ;;
+    set-static-sources)
+        set_static_sources
+        ;;
+    is-running)
+        is_running
+        ;;
+    command|forced-command)
+        chrony_command "$2"
+        ;;
+    *)
+        print_help
+        exit 2
+esac
+
+exit $?

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -33,6 +33,16 @@
   when: packer_builder_type is search('qemu') and 
     build_target is search('raw')
 
+- include_tasks: vmware-photon.yml
+  when: (packer_builder_type is search('vmware') or
+    packer_builder_type is search('vsphere')) and
+    ansible_os_family == "VMware Photon OS"
+
+- include_tasks: vmware-ubuntu.yml
+  when: (packer_builder_type is search('vmware') or
+    packer_builder_type is search('vsphere')) and
+    ansible_distribution == "Ubuntu"
+
 # Create a boot order configuration
 # b/w containerd and cloud final, cloud config services
 

--- a/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
@@ -1,0 +1,70 @@
+# Copyright 2021 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install networkd-dispatcher service (Download from source)
+  unarchive:
+    src: "{{ networkd_dispatcher_download_url }}"
+    dest: /tmp
+    remote_src: yes
+
+- name: Create needed directories
+  file:
+    path: "{{ item.dir }}"
+    state: directory
+  loop:
+    - { dir: /etc/conf.d }
+    - { dir: /etc/networkd-dispatcher/carrier.d }
+    - { dir: /etc/networkd-dispatcher/configured.d }
+    - { dir: /etc/networkd-dispatcher/configuring.d }
+    - { dir: /etc/networkd-dispatcher/degraded.d }
+    - { dir: /etc/networkd-dispatcher/dormant.d }
+    - { dir: /etc/networkd-dispatcher/no-carrier.d }
+    - { dir: /etc/networkd-dispatcher/off.d }
+    - { dir: /etc/networkd-dispatcher/routable.d }
+
+- name: Install networkd-dispatcher service (Move files)
+  command: mv "{{ item.src }}" "{{ item.dest }}"
+  loop:
+    - { src: /tmp/networkd-dispatcher-2.1/networkd-dispatcher, dest: /usr/bin }
+    - { src: /tmp/networkd-dispatcher-2.1/networkd-dispatcher.service, dest: /etc/systemd/system }
+    - { src: /tmp/networkd-dispatcher-2.1/networkd-dispatcher.conf, dest: /etc/conf.d }
+
+- name: Install networkd-dispatcher service (Run networkd-dispatcher)
+  systemd:
+    name: networkd-dispatcher
+    state: started
+    enabled: yes
+
+- name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: a+x
+  vars:
+    server_dir: "/var/lib/dhclient"
+    chrony_helper_dir: "/usr/libexec"
+  loop:
+    - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
+
+- name: Copy chrony-helper script
+  copy:
+    src: files/usr/libexec/chrony-helper
+    dest: /usr/libexec/chrony-helper
+    owner: root
+    group: root
+    mode: a+x

--- a/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
@@ -1,0 +1,27 @@
+# Copyright 2021 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: a+x
+  vars:
+    server_dir: "/var/lib/dhcp"
+    chrony_helper_dir: "/usr/lib/chrony"
+  loop:
+    - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -148,6 +148,10 @@ photon:
     <<: *common_photon_rpms
     audit:
   ova:
+    service:
+      networkd-dispatcher:
+        enabled: true
+        running: true
     package:
       open-vm-tools:
       cloud-init:
@@ -246,6 +250,10 @@ ubuntu:
         stderr: []
         timeout: 0
   ova:
+    service:
+      networkd-dispatcher:
+        enabled: true
+        running: true
     package:
       linux-cloud-tools-virtual:
       linux-tools-virtual:


### PR DESCRIPTION
Chrony is unable to get time source from DHCP provided NTP servers.
To fix this, we use [networkd-dispatcher](https://gitlab.com/craftyguy/networkd-dispatcher) to add a new dispatcher script that parses DHCP provided NTP servers from the networkctl status output and add them to chrony.

This fix is for Ubuntu-2004 and Photon-3 images. `networkd-dispatcher` is already packaged for Ubuntu-2004 but needs to be installed from source for Photon.
 
Fixes #676