### PR TITLE
Update capg nightly config

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-18.json
@@ -1,8 +1,0 @@
-{
-  "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.18.20-00",
-  "kubernetes_rpm_version": "1.18.20-0",
-  "kubernetes_semver": "v1.18.20",
-  "kubernetes_series": "v1.18",
-  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
-}

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-19.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.19.13-00",
-  "kubernetes_rpm_version": "1.19.13-0",
-  "kubernetes_semver": "v1.19.13",
+  "kubernetes_deb_version": "1.19.16-00",
+  "kubernetes_rpm_version": "1.19.16-0",
+  "kubernetes_semver": "v1.19.16",
   "kubernetes_series": "v1.19",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-20.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.20.9-00",
-  "kubernetes_rpm_version": "1.20.9-0",
-  "kubernetes_semver": "v1.20.9",
+  "kubernetes_deb_version": "1.20.12-00",
+  "kubernetes_rpm_version": "1.20.12-0",
+  "kubernetes_semver": "v1.20.12",
   "kubernetes_series": "v1.20",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-21.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-21.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.21.3-00",
-  "kubernetes_rpm_version": "1.21.3-0",
-  "kubernetes_semver": "v1.21.3",
+  "kubernetes_deb_version": "1.21.6-00",
+  "kubernetes_rpm_version": "1.21.6-0",
+  "kubernetes_semver": "v1.21.6",
   "kubernetes_series": "v1.21",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-22.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-22.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.22.0-00",
-  "kubernetes_rpm_version": "1.22.0-0",
-  "kubernetes_semver": "v1.22.0",
+  "kubernetes_deb_version": "1.22.3-00",
+  "kubernetes_rpm_version": "1.22.3-0",
+  "kubernetes_semver": "v1.22.3",
   "kubernetes_series": "v1.22",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -40,10 +40,6 @@ groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
 chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
 # use the packer user to run the build
 
-# build image for 1.18
-# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-18.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
-
 # build image for 1.19
 # using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
 su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-19.json PACKER_FLAGS=-force make deps-gce build-gce-all'"


### PR DESCRIPTION
What this PR does / why we need it:
- stop build images for 1.18 release
- update the nightly images to the latest k8s releases available

next time we update those we also remove the 1.19 release since it is eol.

after this get merged we can update the ci jobs in capg project

/assign @dims @codenrhoden 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers