### PR TITLE
remove python2-pip from photon GOSS pkg test

### DIFF
--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -152,7 +152,6 @@ photon:
       open-vm-tools:
       cloud-init:
       cloud-utils:
-      python2-pip:
       python3-netifaces:
 rockylinux:
   common-package: *common_rpms


### PR DESCRIPTION
What this PR does / why we need it:
A recent change to GOSS package test structure caused python2-pip to be
an expected package on Photon. Photon does not install/use python2-pip,
so this test is failing. This patch removes the test for that package.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
I noticed GOSS tests for Photon were failing over the weekend. This PR fixes the problem that introduced last week. @kkeshavamurthy this is a good example of something sneaking in since Photon is in the list of OVA CI targets. I know we can't really fix that yet, just something to be aware of.

/assign @kkeshavamurthy 