### PR TITLE
Install apparmor-parser on photon-3

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -55,6 +55,7 @@ common_debs:
 
 common_photon_rpms:
 - audit
+- apparmor-parser
 - conntrack-tools
 - chrony
 - dbus-python3

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -48,6 +48,7 @@ chrony_deb: &chrony_deb
 
 common_photon_rpms: &common_photon_rpms
   audit:
+  apparmor-parser:
   conntrack-tools:
   chrony:
   distrib-compat:


### PR DESCRIPTION
What this PR does / why we need it:
To fix this [issue](https://github.com/rancher/k3os/issues/702), `apparmor-parser` needs to be installed on photon-3. 
This issue is not seen on Ubuntu as `apparmor` pkg is preinstalled. 

The checks for this should be fixed in k8s 1.22+ and the rpm can be removed in the future

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @codenrhoden 