### PR TITLE
set defaults for the ansible variables

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -84,13 +84,13 @@ common_virt_debs:
 common_virt_photon_rpms:
 - open-vm-tools
 
-common_raw_rpms:
+common_raw_rpms: []
 
 common_raw_debs:
 - linux-cloud-tools-generic
 - linux-tools-generic
 
-common_raw_photon_rpms:
+common_raw_photon_rpms: []
 
 #photon does not have backward compatibility for legacy distro behavior for sysctl.conf by default
 #as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -99,3 +99,4 @@ sysctl_conf_file: "{{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family == 'VM
 pause_image: "k8s.gcr.io/pause:3.6"
 containerd_additional_settings: null
 leak_local_mdns_to_dns: false
+build_target: "virt"

--- a/images/capi/ansible/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/roles/providers/defaults/main.yml
@@ -14,3 +14,5 @@
 ---
 cloud_init_deb_download_url: "https://launchpad.net/ubuntu/+source/cloud-init/21.1-19-gbad84ad4-0ubuntu1~20.04.2/+build/21434629/+files/cloud-init_21.1-19-gbad84ad4-0ubuntu1~20.04.2_all.deb"
 networkd_dispatcher_download_url: "https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.bz2"
+packer_builder_type: ""
+build_target: ""

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -17,6 +17,7 @@ extra_debs: ""
 pinned_debs: []
 
 redhat_epel_rpm: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
+epel_rpm_gpg_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7"
 rpms: ""
 extra_rpms: ""
 

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -146,7 +146,7 @@
     path: "{{ item.path }}"
   loop:
   - { path: /root/.ssh/authorized_keys }
-  - { path: "/home/{{ ansible_env.SUDO_USER }}/.ssh/authorized_keys" }
+  - { path: "/home/{{ ansible_env.SUDO_USER | default(ansible_user_id) }}/.ssh/authorized_keys" }
   when: ansible_os_family != "Flatcar"
 
 - name: Remove SSH authorized users for Flatcar
@@ -185,7 +185,7 @@
     path: "{{ item.path }}"
   loop:
   - { path: /root/.bash_history }
-  - { path: "/home/{{ ansible_env.SUDO_USER }}/.bash_history" }
+  - { path: "/home/{{ ansible_env.SUDO_USER | default(ansible_user_id) }}/.bash_history" }
 
 - name: Rotate journalctl to archive logs
   shell:

--- a/images/capi/ansible/windows/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/providers/defaults/main.yml
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-cloud_init_deb_download_url: "https://launchpad.net/ubuntu/+source/cloud-init/21.1-19-gbad84ad4-0ubuntu1~20.04.2/+build/21434629/+files/cloud-init_21.1-19-gbad84ad4-0ubuntu1~20.04.2_all.deb"
-networkd_dispatcher_download_url: "https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.bz2"
 packer_builder_type: ""
-build_target: "virt"


### PR DESCRIPTION
What this PR does / why we need it:

Set defaults for the variable used in the ansible roles, this will help the user to use the ansible independently without the packer tool.

- Made `common_raw_rpms` and `common_raw_photon_rpms` as array instead of a string variable
- defined `packer_builder_type` and `build_target`
- defined `epel_rpm_gpg_key` which was missing
- `ansible_env.SUDO_USER` fails if user logins as root(this shell environment variable does not exist if logged as root), hence adding a default block to use `ansible_user_id` to avoid failure

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers