### PR TITLE
Switch base image from focal to latest

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=docker.io/library/ubuntu:focal
+ARG BASE_IMAGE=docker.io/library/ubuntu:latest
 FROM $BASE_IMAGE
 
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates python3-pip curl wget git rsync vim unzip build-essential \


### PR DESCRIPTION
What this PR does / why we need it:
- Current base image has many vulnerabilities that are fixed in newer release of ubuntu.
- Bumping this to latest will allow applying fixes to these vulnerabilities

**Additional context**
Slack thread: https://kubernetes.slack.com/archives/C01E0Q35A8J/p1636653385019700

/cc @CecileRobertMichon 

/sig security cluster-lifecycle