### PR TITLE
Move VMware tools installation to specialize phase of Windows install

### DIFF
--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -67,7 +67,6 @@
         "./packer/ova/windows/disable-network-discovery.cmd",
         "./packer/ova/windows/disable-winrm.ps1",
         "./packer/ova/windows/enable-winrm.ps1",
-        "./packer/ova/windows/install-vm-tools.cmd",
         "./packer/ova/windows/sysprep.ps1"
       ],
       "folder": "{{user `folder`}}",

--- a/images/capi/packer/ova/windows/install-vm-tools.cmd
+++ b/images/capi/packer/ova/windows/install-vm-tools.cmd
@@ -1,2 +1,0 @@
-@rem Silent mode, basic UI, no reboot
-e:\setup64 /s /v "/qb REBOOT=R ADDLOCAL=ALL"

--- a/images/capi/packer/ova/windows/windows-2004/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2004/autounattend.xml
@@ -115,6 +115,17 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>    
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -195,19 +206,14 @@ Installation Notes:
                     <Description>Disable password expiration for Administrator user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Description>Install VMware Tools</Description>
-                    <CommandLine>cmd.exe /c a:\install-vm-tools.cmd</CommandLine>
-                    <Order>6</Order>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c %SystemDrive%\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\enable-winrm.ps1</CommandLine>
                     <Description>Enable WinRM</Description>
-                    <Order>7</Order>
+                    <Order>6</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\disable-network-discovery.cmd</CommandLine>
                     <Description>Disable Network Discovery</Description>
-                    <Order>8</Order>
+                    <Order>7</Order>
                 </SynchronousCommand>
             </FirstLogonCommands>
             <AutoLogon>

--- a/images/capi/packer/ova/windows/windows-2019/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019/autounattend.xml
@@ -113,6 +113,17 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -200,19 +211,14 @@ Installation Notes:
                     <Description>Disable password expiration for Administrator user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:\install-vm-tools.cmd</CommandLine>
-                    <Order>10</Order>
-                    <Description>Install VMware Tools</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c %SystemDrive%\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\enable-winrm.ps1</CommandLine>
                     <Description>Enable WinRM</Description>
-                    <Order>11</Order>
+                    <Order>10</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\disable-network-discovery.cmd</CommandLine>
                     <Description>Disable Network Discovery</Description>
-                    <Order>12</Order>
+                    <Order>11</Order>
                 </SynchronousCommand>
             </FirstLogonCommands>
             <OOBE>

--- a/images/capi/packer/ova/windows/windows-2022/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022/autounattend.xml
@@ -114,6 +114,17 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -201,19 +212,14 @@ Installation Notes:
                     <Description>Disable password expiration for Administrator user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>cmd.exe /c a:\install-vm-tools.cmd</CommandLine>
-                    <Order>10</Order>
-                    <Description>Install VMware Tools</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c %SystemDrive%\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\enable-winrm.ps1</CommandLine>
                     <Description>Enable WinRM</Description>
-                    <Order>11</Order>
+                    <Order>10</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c a:\disable-network-discovery.cmd</CommandLine>
                     <Description>Disable Network Discovery</Description>
-                    <Order>12</Order>
+                    <Order>11</Order>
                 </SynchronousCommand>
             </FirstLogonCommands>
             <OOBE>


### PR DESCRIPTION
Signed-off-by: Stuart Preston <spreston@vmware.com>

What this PR does / why we need it:

This PR moves the VMware guest tools into the Specialize configuration pass, meaning they will be installed prior to any first run scripts in the OOBE pass. The guest tools have a higher chance of deployment success when in its own phase and with a reboot immediately afterwards. #741 

This change also solves a previous issue being tracked where the TimeZone was required to be set to match the ESXi host otherwise the guest tools would not install correctly. #587 

Finally the PR removes the requirement to ship extra files on the boot floppy.

Fixes: #741 
Fixes: #587