### PR TITLE
fix al2 rpm list

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -24,6 +24,12 @@ common_rpms:
 - sysstat
 - yum-utils
 
+# Used for AmazonLinux-2 distributions
+al2_rpms:
+- ebtables
+- python-netifaces
+- python-requests
+
 # Used for RedHat based distributions ==  7 (ex. RHEL-7, CentOS-7 etc.)
 rh7_rpms:
 - ebtables

--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -15,5 +15,12 @@
 dependencies:
   - role: setup
     vars:
+      rpms: "{{ common_rpms + al2_rpms }}"
+      debs: "{{ common_debs }}"
+    when: ansible_distribution == "Amazon"
+
+  - role: setup
+    vars:
       rpms: "{{ ( common_photon_rpms + lookup('vars', 'common_' + build_target + '_photon_rpms') ) if ansible_os_family == 'VMware Photon OS' else ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
+    when: ansible_distribution != "Amazon"

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -13,6 +13,11 @@ common_rpms: &common_rpms
   sysstat:
   yum-utils:
 
+al2_rpms: &al2_rpms
+  ebtables:
+  python-netifaces:
+  python-requests:
+
 rh7_rpms: &rh7_rpms
   ebtables:
   python-netifaces:
@@ -104,7 +109,7 @@ amazon linux:
     package:
       awscli:
       amazon-ssm-agent:
-      <<: *rh7_rpms
+      <<: *al2_rpms
 centos:
   common-package: *common_rpms
   amazon:


### PR DESCRIPTION
What this PR does / why we need it:
When `common_rpms` list was modified to support rockylinux, I forgot to account for al2 image building. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #
Fixes #743 
**Additional context**
Add any other context for the reviewers