### PR TITLE
images: use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,8 +3,8 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  # 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud@sha256:0ef22100e63c0f7cdf4758d4732008c99d51ec149baca736f8cf94d7cf9b7a1b'
+  # 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af@sha256:0ef22100e63c0f7cdf4758d4732008c99d51ec149baca736f8cf94d7cf9b7a1b'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523