### PR TITLE
Include additional rpms in AL2 images

### DIFF
--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -15,7 +15,7 @@
 dependencies:
   - role: setup
     vars:
-      rpms: "{{ common_rpms + al2_rpms }}"
+      rpms: "{{ common_rpms + al2_rpms + lookup('vars', 'common_' + build_target + '_rpms') }}"
       debs: "{{ common_debs }}"
     when: ansible_distribution == "Amazon"
 


### PR DESCRIPTION
Small fix on top of #744 to include additional rpms (`open-vm-tools`) to AL2 images. 

/cc @kkeshavamurthy 