### PR TITLE
images: fix invalid k8s-staging-test-infra/gcb-docker-gcloud tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
 steps:
   # 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af'
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af@sha256:0ef22100e63c0f7cdf4758d4732008c99d51ec149baca736f8cf94d7cf9b7a1b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:67925b5897028eaab9a481c4ee9df00ab58d02e24103dfd1fe34cff81d9d0fb9'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes-sigs/image-builder/pull/745

I copy-pasted the wrong tag :sweat_smile:  Sorry about the churn