### PR TITLE
Azure: archive storage accounts used for reference images

### DIFF
--- a/images/capi/packer/azure/scripts/delete-unused-storage.sh
+++ b/images/capi/packer/azure/scripts/delete-unused-storage.sh
@@ -29,6 +29,7 @@ PUBLISHER=${PUBLISHER:-cncf-upstream}
 OFFERS=${OFFERS:-capi capi-windows}
 PREFIX=${PREFIX:-capi}
 LONG_PREFIX=${LONG_PREFIX:-${PREFIX}[0-9]{10\}}
+ARCHIVE_STORAGE_ACCOUNT=${ARCHIVE_STORAGE_ACCOUNT:-${PREFIX}archive}
 
 which pub &> /dev/null || (echo "Please install pub from https://github.com/devigned/pub/releases" && exit 1)
 
@@ -37,7 +38,8 @@ URLS=""
 for name in ${OFFERS}; do
   echo "Getting URLs for ${name}..."
   offer=$(pub offers show -p "$PUBLISHER" -o "$name")
-  urls=$(echo "${offer}" | jq '.definition["plans"][]."microsoft-azure-corevm.vmImagesPublicAzure"[]?.osVhdUrl')
+  # Capture "label" as well as "osVhdUrl" so we can archive storage accounts with something readable.
+  urls=$(echo "${offer}" | jq -r '.definition["plans"][]."microsoft-azure-corevm.vmImagesPublicAzure"[] | [.label, .osVhdUrl] | @csv')
   if [[ -z $URLS ]]; then
     URLS=${urls}
   else
@@ -46,7 +48,12 @@ for name in ${OFFERS}; do
 done
 NOW=$(date +%s)
 
+# ensure the existence of the archive storage account
+echo "Creating storage account ${ARCHIVE_STORAGE_ACCOUNT}..."
+az storage account create -g "${RESOURCE_GROUP}" -n "${ARCHIVE_STORAGE_ACCOUNT}" --sku Standard_LRS 
+
 IFS=$'\n'
+archived=0
 deleted=0
 # For each storage account in the subscription,
 for account in $(az storage account list -g "${RESOURCE_GROUP}" -o tsv --query "[?starts_with(name, '${PREFIX}')].[name,creationTime]"); do
@@ -55,15 +62,57 @@ for account in $(az storage account list -g "${RESOURCE_GROUP}" -o tsv --query "
   age=$(( (NOW - created) / 86400 ))
   # if it's older than a month
   if [[ $age -gt 30 ]]; then
-    # and it has the right naming pattern but isn't referenced in the offer osVhdUrls
-    if [[ ${storage_account} =~ ^${LONG_PREFIX} ]] && [[ ! ${URLS} =~ ${storage_account} ]]; then
+    # and it has the right naming pattern
+    if [[ ${storage_account} =~ ^${LONG_PREFIX} ]]; then
+      # but isn't referenced in the offer osVhdUrls
+      if [[ ! ${URLS} =~ ${storage_account} ]]; then
         # delete it.
         echo "Deleting unreferenced storage account ${storage_account} that is ${age} days old"
         # NOTE: Remove the "echo" to enable deletion of storage accounts.
-        echo az storage account delete -g "${RESOURCE_GROUP}" -n "${storage_account}" # -y
+        echo az storage account delete -g "${RESOURCE_GROUP}" -n "${storage_account}" -y
         deleted=$((deleted+1))
+      else
+        # archive it.
+        for URL in ${URLS}; do
+          IFS=$',' read -r label url <<< "${URL}"
+          # container names are somewhat strict, so transform the label into a valid container name
+          # See https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/storage-container-naming-rules-include.md
+          dest_label=${label//[ .]/-}
+          dest_label=${dest_label//[^a-zA-Z0-9-]/}
+          dest_label=$(echo "${dest_label}" | tr '[:upper:]' '[:lower:]')
+          if [[ ${url} =~ ${storage_account} ]]; then
+            echo "Archiving storage account ${storage_account} (${label}) that is ${age} days old"
+            # create a destination container
+            az storage container create --only-show-errors \
+              --name ${dest_label} --account-name "${ARCHIVE_STORAGE_ACCOUNT}"
+            # for each source container
+            for container in $(az storage container list --only-show-errors --account-name ${storage_account} --query "[].name" -o tsv); do
+              # copy it to the destination container
+              # NOTE: Remove "--dryrun" to enable blob copying.
+              az storage blob copy start-batch --dryrun \
+                --account-name capiarchive \
+                --destination-container ${dest_label} \
+                --destination-path ${container} \
+                --source-container ${container} \
+                --source-account-name ${storage_account} \
+                --pattern '*capi-*'
+              # TODO: poll new container until it is complete
+              sleep 10
+              az storage blob list --only-show-errors \
+                --container-name ${dest_label} \
+                --account-name capiarchive \
+                --prefix ${container} \
+                -o tsv
+            done
+            # NOTE: Remove the "echo" to enable deletion of storage accounts.
+            echo az storage account delete -g "${RESOURCE_GROUP}" -n "${storage_account}" -y
+            archived=$((archived+1))
+          fi
+        done
+      fi
     fi
   fi
 done
 
 echo "Deleted ${deleted} storage accounts."
+echo "Archived ${archived} storage accounts."


### PR DESCRIPTION
What this PR does / why we need it:

Azure has a limit on the number of storage accounts in use in a region, and we have sometimes hit that limit while building reference images for CAPZ. This PR enhances our periodic cleanup script to archive "keeper" build artifacts into a single archive storage account. This will keep us from hitting the limit as we continue to add reference images for new Kubernetes versions.

Which issue(s) this PR fixes):

N/A

**Additional context**

I've run this by hand several times without the final step of deleting the old SA. I think it's sane, but I'm not clear on how to poll that a batch `start-copy` operation has actually completed. In practice, it seems to complete very quickly (a couple seconds).

Also I need to verify that moving the location of the SA assets will in no way affect the existing Partner Center offer.

cc: @devigned @CecileRobertMichon 