### PR TITLE
support specifying remote_folder for packer provisioner

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -185,6 +185,7 @@
         "sudo bash -c \"/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent -force -deprovision+user && sync\""
       ],
       "inline_shebang": "/bin/bash -x",
+      "remote_folder": "{{user `provisioner_remote_folder`}}",
       "type": "shell"
     }
   ],
@@ -234,6 +235,7 @@
     "plan_image_publisher": "",
     "plan_image_sku": "",
     "private_virtual_network_with_public_ip": "",
+    "provisioner_remote_folder": "/tmp",
     "subscription_id": null,
     "virtual_network_name": "",
     "virtual_network_resource_group_name": "",


### PR DESCRIPTION
What this PR does / why we need it:
Azure `packer.json` has a shell provisioner block after the ansible roles are run. This shell provisioner runs the scripts from `/tmp` by default on the build VM. Sometimes permissions to `/tmp` can restricted after customizing the node image. This change adds a way to run the scripts from a different folder. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers