### PR TITLE
Expand windows dynamic port range

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -130,6 +130,9 @@
     data: 1
     type: dword
 
+- name: Expand dynamic port range to 33000-65535 to avoid port exhaustion
+  win_shell: netsh int ipv4 set dynamicportrange tcp 33000 32536
+
 - name: Add required Windows Features
   win_feature:
     name:

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -128,6 +128,13 @@ command:
     stdout:
     - True
     timeout: 30000
+  Windows Port Range is Expanded:
+    exit-status: 0
+    exec: netsh int ipv4 show dynamicportrange tcp
+    stdout:
+    - "Start Port      : 33000"
+    - "Number of Ports : 32536"
+    timeout: 30000
 {{end}}
 
 {{ if eq .Vars.runtime "docker-ee" }}


### PR DESCRIPTION
What this PR does / why we need it:

There are a two cases that dynamic ports can be consumed:

- pod to service traffic (pod to clusterip)
- pod to external/public ips (pod to google.com)

Even with DSR enabled (recommended)  you can still run into port exhaustion.  This expands the range to minimize the occurrence but does not overlap with nodeport range.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @perithompson 
/sig windows