### PR TITLE
Add support for OCI Images

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [DigitalOcean](./capi/providers/digitalocean.md)
   - [GCP](./capi/providers/gcp.md)
   - [OpenStack](./capi/providers/openstack.md)
+  - [OCI](./capi/providers/oci.md)
   - [raw](./capi/providers/raw.md)
   - [vSphere](./capi/providers/vsphere.md)
   - [Windows](./capi/windows/windows.md)

--- a/docs/book/src/capi/providers/oci.md
+++ b/docs/book/src/capi/providers/oci.md
@@ -1,0 +1,63 @@
+# Building Images for Oracle Cloud Infrastructure (OCI)
+
+## Prerequisites
+
+- An OCI account
+- [The OCI plugin for Packer supports three options for authentication](https://www.packer.io/docs/builders/oracle/oci#authentication)
+  . You may use any of these options when building the Cluster API images.
+
+## Building Images
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building OCI images are managed by running:
+
+```bash
+make deps-oci
+```
+
+From the `images/capi` directory, run `make build-do-<OS>` where `<OS>` is
+the desired operating system. The available choices are listed via `make help`.
+
+### Configuration
+
+In addition to the configuration found in `images/capi/packer/config`, the `oci`
+directory includes several JSON files that define the default configuration for
+the different operating systems.
+
+| File | Description |
+|------|-------------|
+| `oracle-linux-8.json` | The settings for the Oracle Linux 8 image |
+| `ubuntu-1804.json` | The settings for the Ubuntu 18.04 image |
+| `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
+
+#### Common options
+
+This table lists several common options that a user must set via
+`PACKER_VAR_FILES` to customize their build behavior.  This is not an exhaustive
+list, and greater explanation can be found in the
+[Packer documentation for the OCI builder](https://www.packer.io/docs/builders/oracle/oci#required-configuration-parameters).
+
+| Variable | Description | Default | Mandatory |
+|----------|-------------|---------|---------|
+| `compartment_ocid` | The OCID of the compartment that the instance will run in. |  | Yes |
+| `subnet_ocid` |  The name of the subnet within which a new instance is launched and provisioned. |  | Yes |
+| `availability_domain` | The name of the Availability Domain within which a new instance is launched and provisioned. The names of the Availability Domains have a prefix that is specific to your tenancy. |  | Yes |
+| `shape` | An OCI region. Overrides value provided by the OCI config file if present. This cannot be used along with the use_instance_principals key. | `VM.Standard.E4.Flex` | No |
+
+#### Steps to create Packer VAR file
+
+Create a file with the following contents and name it as `oci.json`
+
+```json
+{
+  "compartment_ocid": "Fill compartment OCID here",
+  "subnet_ocid": "Fill Subnet OCID here",
+  "availability_domain": "Fill Availbility Domain here"
+}
+```
+
+#### Example make command with Packer VAR file
+
+```bash
+PACKER_VAR_FILES=oci.json make build-oci-oracle-linux-8
+```

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -48,7 +48,7 @@ version: ## Display version of image-builder
 
 .PHONY: deps
 deps: ## Installs/checks all dependencies
-deps: deps-ami deps-azure deps-do deps-gce deps-ova deps-qemu deps-raw
+deps: deps-ami deps-azure deps-do deps-gce deps-ova deps-qemu deps-raw deps-oci
 
 .PHONY: deps-ami
 deps-ami: ## Installs/checks dependencies for AMI builds
@@ -103,6 +103,12 @@ deps-raw:
 	hack/ensure-ansible.sh
 	hack/ensure-packer.sh
 	hack/ensure-goss.sh
+
+.PHONY: deps-oci
+deps-oci: ## Installs/checks dependencies for OCI builds
+deps-oci:
+	hack/ensure-ansible.sh
+	hack/ensure-packer.sh
 
 ## --------------------------------------
 ## Container variables
@@ -250,6 +256,7 @@ GCE_BUILD_NAMES			   ?= gce-ubuntu-1804 ## gce-ubuntu-2004
 AZURE_BUILD_VHD_NAMES	   ?= azure-vhd-ubuntu-1804 azure-vhd-ubuntu-2004 azure-vhd-centos-7 azure-vhd-windows-2019 azure-vhd-windows-2019-containerd azure-vhd-windows-2022-containerd
 AZURE_BUILD_SIG_NAMES	   ?= azure-sig-ubuntu-1804 azure-sig-ubuntu-2004 azure-sig-centos-7 azure-sig-windows-2019 azure-sig-windows-2019-containerd azure-sig-flatcar azure-sig-windows-2022-containerd
 AZURE_BUILD_SIG_GEN2_NAMES ?= azure-sig-ubuntu-1804-gen2 azure-sig-ubuntu-2004-gen2 azure-sig-centos-7-gen2
+OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-oracle-linux-8
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
@@ -291,6 +298,8 @@ QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 QEMU_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_BUILD_NAMES))
 RAW_BUILD_TARGETS      := $(addprefix build-,$(RAW_BUILD_NAMES))
 RAW_VALIDATE_TARGETS   := $(addprefix validate-,$(RAW_BUILD_NAMES))
+OCI_BUILD_TARGETS	:= $(addprefix build-,$(OCI_BUILD_NAMES))
+OCI_VALIDATE_TARGETS	:= $(addprefix validate-,$(OCI_BUILD_NAMES))
 
 .PHONY: $(NODE_OVA_LOCAL_BUILD_TARGETS)
 $(NODE_OVA_LOCAL_BUILD_TARGETS): deps-ova
@@ -418,6 +427,14 @@ $(RAW_BUILD_TARGETS): deps-raw
 .PHONY: $(RAW_VALIDATE_TARGETS)
 $(RAW_VALIDATE_TARGETS): deps-raw
 	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/raw/packer.json
+
+.PHONY: $(OCI_BUILD_TARGETS)
+$(OCI_BUILD_TARGETS): deps-oci
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst build-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
+
+.PHONY: $(OCI_VALIDATE_TARGETS)
+$(OCI_VALIDATE_TARGETS): deps-oci
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst validate-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
 
 
 ## --------------------------------------
@@ -566,6 +583,11 @@ build-raw-ubuntu-2004: ## Builds Ubuntu 20.04 RAW image
 build-raw-ubuntu-2004-efi: ## Builds Ubuntu 20.04 RAW image that EFI boots
 build-raw-all: $(RAW_BUILD_TARGETS) ## Builds all RAW images
 
+build-oci-ubuntu-1804: ## Builds the OCI ubuntu-1804 image
+build-oci-ubuntu-2004: ## Builds the OCI ubuntu-2004 image
+build-oci-oracle-linux-8: ## Builds the OCI Oracle Linux 8.x image
+build-oci-all: $(OCI_BUILD_TARGETS) ## Builds all OCI image
+
 ## --------------------------------------
 ## Document dynamic validate targets
 ## --------------------------------------
@@ -597,14 +619,14 @@ validate-azure-sig-ubuntu-1804-gen2: ## Validates Ubuntu 18.04 Azure managed ima
 validate-azure-sig-ubuntu-2004-gen2: ## Validates Ubuntu 20.04 Azure managed image in Shared Image Gallery Packer config
 validate-azure-all: $(AZURE_VALIDATE_SIG_TARGETS) $(AZURE_VALIDATE_VHD_TARGETS) ## Validates all VHD images Azure Packer config
 
-validate-do-ubuntu-1804: ## Valdiates Ubuntu 18.04 DigitalOcean Snapshot Packer config
-validate-do-ubuntu-2004: ## Valdiates Ubuntu 20.04 DigitalOcean Snapshot Packer config
-validate-do-centos-7: ## Valdiates Centos 7 DigitalOcean Snapshot Packer config
-validate-do-all: $(DO_VALIDATE_TARGETS) ## Valdiates all DigitalOcean Snapshot Packer config
+validate-do-ubuntu-1804: ## Validates Ubuntu 18.04 DigitalOcean Snapshot Packer config
+validate-do-ubuntu-2004: ## Validates Ubuntu 20.04 DigitalOcean Snapshot Packer config
+validate-do-centos-7: ## Validates Centos 7 DigitalOcean Snapshot Packer config
+validate-do-all: $(DO_VALIDATE_TARGETS) ## Validates all DigitalOcean Snapshot Packer config
 
-validate-gce-ubuntu-1804: ## Valdiates Ubuntu 18.04 GCE Snapshot Packer config
-validate-gce-ubuntu-2004: ## Valdiates Ubuntu 20.04 GCE Snapshot Packer config
-validate-gce-all: $(GCE_VALIDATE_TARGETS) ## Valdiates all GCE Snapshot Packer config
+validate-gce-ubuntu-1804: ## Validates Ubuntu 18.04 GCE Snapshot Packer config
+validate-gce-ubuntu-2004: ## Validates Ubuntu 20.04 GCE Snapshot Packer config
+validate-gce-all: $(GCE_VALIDATE_TARGETS) ## Validates all GCE Snapshot Packer config
 
 validate-node-ova-local-centos-7: ## Validates CentOS 7 Node OVA Packer config w local hypervisor
 validate-node-ova-local-photon-3: ## Validates Photon 3 Node OVA Packer config w local hypervisor
@@ -646,6 +668,11 @@ validate-raw-ubuntu-2004: ## Validates Ubuntu 20.04 RAW image packer config
 validate-raw-ubuntu-2004-efi: ## Validates Ubuntu 20.04 RAW EFI image packer config
 validate-raw-all: $(RAW_VALIDATE_TARGETS) ## Validates all RAW Packer config
 
+validate-oci-ubuntu-1804: ## Validates the OCI ubuntu-1804 image packer config
+validate-oci-ubuntu-2004: ## Validates the OCI ubuntu-2004 image packer config
+validate-oci-oracle-linux-8: ## Validates the OCI Oracle Linux 8.x image packer config
+validate-oci-all: $(OCI_VALIDATE_TARGETS) ## Validates all OCI image packer config
+
 validate-all: validate-ami-all \
 	validate-azure-all \
 	validate-do-all \
@@ -654,7 +681,8 @@ validate-all: validate-ami-all \
 	validate-haproxy-ova-local-photon-3 \
 	validate-qemu-flatcar \
 	validate-qemu-all \
-	validate-raw-all
+	validate-raw-all \
+	validate-oci-all
 validate-all: ## Validates the Packer config for all build targets
 
 ## --------------------------------------

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -25,6 +25,9 @@
 - include_tasks: googlecompute.yml
   when: packer_builder_type.startswith('googlecompute')
 
+- include_tasks: oci.yml
+  when: packer_builder_type.startswith('oracle-oci')
+
 - include_tasks: qemu.yml
   when: packer_builder_type is search('qemu') and
     build_target is not search('raw')

--- a/images/capi/ansible/roles/providers/tasks/oci.yml
+++ b/images/capi/ansible/roles/providers/tasks/oci.yml
@@ -1,0 +1,34 @@
+# Copyright 2021 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Remove the default input reject all iptable rule
+  lineinfile:
+    path: /etc/iptables/rules.v4
+    state: absent
+    regexp: "-A INPUT -j REJECT --reject-with icmp-host-prohibited"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Remove the default input reject all iptable rule
+  lineinfile:
+    path: /etc/iptables/rules.v4
+    state: absent
+    regexp: "-A FORWARD -j REJECT --reject-with icmp-host-prohibited"
+  when: ansible_distribution == "Ubuntu"
+
+- name: Disable firewalld service
+  systemd:
+    name: firewalld
+    state: stopped
+    enabled: false
+  when: ansible_distribution == "OracleLinux"

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -19,6 +19,7 @@
 
 - import_tasks: rpm_repos.yml
 
+# Oracle Linux does not have temp-disk-swapfile service
 - name: Disable swap service and ensure it is masked
   systemd:
     name: temp-disk-swapfile
@@ -31,7 +32,7 @@
     name: swap.target
     enabled: no
     masked: yes
-  when: ansible_memory_mb.swap.total != 0 and ansible_distribution_major_version|int == 8 
+  when: ansible_memory_mb.swap.total != 0 and ansible_distribution_major_version|int == 8
 
 - name: Remove RHEL subscription
   block:

--- a/images/capi/packer/oci/oracle-linux-8.json
+++ b/images/capi/packer/oci/oracle-linux-8.json
@@ -1,0 +1,7 @@
+{
+  "build_name": "oracle-linux-8",
+  "operating_system": "Oracle Linux",
+  "operating_system_version": "8",
+  "redhat_epel_rpm": "oracle-epel-release-el8",
+  "ssh_username": "opc"
+}

--- a/images/capi/packer/oci/packer.json
+++ b/images/capi/packer/oci/packer.json
@@ -1,0 +1,97 @@
+{
+  "builders": [
+    {
+      "availability_domain": "{{user `availability_domain`}}",
+      "base_image_filter": {
+        "operating_system": "{{user `operating_system`}}",
+        "operating_system_version": "{{user `operating_system_version`}}"
+      },
+      "compartment_ocid": "{{user `compartment_ocid`}}",
+      "fingerprint": "{{user `fingerprint`}}",
+      "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
+      "key_file": "{{user `key_file`}}",
+      "shape": "{{user `shape`}}",
+      "shape_config": {
+        "ocpus": "{{user `ocpus`}}"
+      },
+      "ssh_username": "{{user `ssh_username`}}",
+      "subnet_ocid": "{{user `subnet_ocid`}}",
+      "tenancy_ocid": "{{user `tenancy_ocid`}}",
+      "type": "oracle-oci",
+      "user_ocid": "{{user `user_ocid`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "inline": [
+        "if [ $BUILD_NAME != \"ubuntu-1804\" ] || [ $BUILD_NAME != \"ubuntu-2004\" ]; then exit 0; fi",
+        "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
+        "sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install python python-pip"
+      ],
+      "type": "shell"
+    },
+    {
+      "ansible_env_vars": [
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
+      ],
+      "extra_arguments": [
+        "--extra-vars",
+        "{{user `ansible_common_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
+      ],
+      "playbook_file": "./ansible/node.yml",
+      "type": "ansible"
+    }
+  ],
+  "variables": {
+    "ansible_common_vars": "",
+    "ansible_extra_vars": "",
+    "ansible_user_vars": "",
+    "availability_domain": "{{env `OCI_AVAILABILITY_DOMAIN`}}",
+    "build_timestamp": "{{timestamp}}",
+    "compartment_ocid": "",
+    "containerd_sha256": null,
+    "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
+    "containerd_version": null,
+    "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
+    "crictl_version": null,
+    "disable_default_service_account": "",
+    "encrypted": "false",
+    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "fingerprint": "{{env `OCI_USER_FINGERPRINT`}}",
+    "key_file": "{{env `OCI_USER_KEY_FILE`}}",
+    "kubernetes_cni_deb_version": null,
+    "kubernetes_cni_http_source": null,
+    "kubernetes_cni_rpm_version": null,
+    "kubernetes_cni_semver": null,
+    "kubernetes_cni_source_type": null,
+    "kubernetes_container_registry": null,
+    "kubernetes_deb_gpg_key": null,
+    "kubernetes_deb_repo": null,
+    "kubernetes_deb_version": null,
+    "kubernetes_http_source": null,
+    "kubernetes_load_additional_imgs": null,
+    "kubernetes_rpm_gpg_check": null,
+    "kubernetes_rpm_gpg_key": null,
+    "kubernetes_rpm_repo": null,
+    "kubernetes_rpm_version": null,
+    "kubernetes_semver": null,
+    "kubernetes_series": null,
+    "kubernetes_source_type": null,
+    "ocpus": "1",
+    "operating_system": null,
+    "operating_system_version": null,
+    "region": "us-ashburn-1",
+    "shape": "VM.Standard.E4.Flex",
+    "ssh_username": null,
+    "subnet_ocid": "{{env `OCI_SUBNET_OCID`}}",
+    "tenancy_ocid": "{{env `OCI_TENANCY_OCID`}}",
+    "user_ocid": "{{env `OCI_USER_OCID`}}"
+  }
+}

--- a/images/capi/packer/oci/ubuntu-1804.json
+++ b/images/capi/packer/oci/ubuntu-1804.json
@@ -1,0 +1,6 @@
+{
+  "build_name": "ubuntu-1804",
+  "operating_system": "Canonical Ubuntu",
+  "operating_system_version": "18.04",
+  "ssh_username": "ubuntu"
+}

--- a/images/capi/packer/oci/ubuntu-2004.json
+++ b/images/capi/packer/oci/ubuntu-2004.json
@@ -1,0 +1,6 @@
+{
+  "build_name": "ubuntu-2004",
+  "operating_system": "Canonical Ubuntu",
+  "operating_system_version": "20.04",
+  "ssh_username": "ubuntu"
+}

--- a/images/capi/scripts/ci-packer-validate.sh
+++ b/images/capi/scripts/ci-packer-validate.sh
@@ -28,6 +28,11 @@ cd "${CAPI_ROOT}" || exit 1
 export PATH=${PWD}/.local/bin:$PATH
 export PATH=${PYTHON_BIN_DIR:-"${HOME}/.local/bin"}:$PATH
 
+# OCI packer builder requires a valid private key file, hence creating a temporary one
+openssl genrsa -out /tmp/oci_api_key.pem 2048
+
 AZURE_LOCATION=fake RESOURCE_GROUP_NAME=fake STORAGE_ACCOUNT_NAME=fake \
   DIGITALOCEAN_ACCESS_TOKEN=fake GCP_PROJECT_ID=fake \
+  OCI_AVAILABILITY_DOMAIN=fake OCI_SUBNET_OCID=fake OCI_USER_FINGERPRINT=fake \
+  OCI_TENANCY_OCID=fake OCI_USER_OCID=fake OCI_USER_KEY_FILE=/tmp/oci_api_key.pem \
   make validate-all


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds support for Oracle Cloud Infrastructure(OCI) support in image-builder project. We are starting off with support to Ubuntu 18.04/20.04 and Oracle Linux 8 image.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Uses OCI packer support similar to other providers.