### PR TITLE
Disable apparmor service on photon-3

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -58,3 +58,10 @@
     path: /etc/systemd/scripts/ip6save
     regexp: 'INPUT DROP'
     replace: 'INPUT ACCEPT'
+
+- name: Disable Apparmor service
+  systemd:
+    name: apparmor
+    daemon_reload: yes
+    enabled: false
+    state: stopped

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -147,6 +147,10 @@ flatcar:
   amazon:
     command:
 photon:
+  common-service:
+    apparmor:
+      enabled: false
+      running: false
   common-kernel-param:
     net.ipv4.tcp_limit_output_bytes:
       value: "524288"


### PR DESCRIPTION
What this PR does / why we need it:
#735 installs apparmor but it does not need to be running since all the features are not fully supported on photon-3. 
This PR keeps the apparmor rpm installed (required) but will stay `disabled`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers
/assign @codenrhoden 