### PR TITLE
photon: disable apparmor in kernel

### DIFF
--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -20,6 +20,7 @@
     option: Domains
     value: "~local"
   when: leak_local_mdns_to_dns
+
 - name: Leak mDNS to DNS (dhcp) (enable .local domain lookups)
   ini_file:
     path: /etc/systemd/network/99-dhcp-en.network
@@ -27,6 +28,7 @@
     option: Domains
     value: "~local"
   when: leak_local_mdns_to_dns
+
 - name: Double TCP small queue limit to be the same as Ubuntu
   sysctl:
     name: net.ipv4.tcp_limit_output_bytes
@@ -35,3 +37,17 @@
     sysctl_set: yes
     reload: yes
     sysctl_file: "{{ sysctl_conf_file }}"
+
+- name: Disable Apparmor service
+  systemd:
+    name: apparmor
+    daemon_reload: yes
+    enabled: false
+    state: stopped
+
+- name: Disable Apparmor in kernel
+  lineinfile:
+    path: /boot/photon.cfg
+    backrefs: yes
+    regexp: "^(?!.*apparmor=0)(photon_cmdline.*)"
+    line: '\1 apparmor=0'

--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -58,10 +58,3 @@
     path: /etc/systemd/scripts/ip6save
     regexp: 'INPUT DROP'
     replace: 'INPUT ACCEPT'
-
-- name: Disable Apparmor service
-  systemd:
-    name: apparmor
-    daemon_reload: yes
-    enabled: false
-    state: stopped


### PR DESCRIPTION
**What this PR does / why we need it:**
Previous attempts to disable AppArmor on Photon were not sufficient. So
long as AppArmor is enabled in the kernel, kubelet and containerD are
loading an apparmor profile that gets enforced and does not work on
Photon at this time.

This patch appends `apparmor=0` to the kernel boot command line to
disable.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
I made sure the regex was idempotent. A negative lookahead assertion is used to only match if the change isn't already present.

/assign @kkeshavamurthy 

I also moved the previous block of code disabling the service from the `setup` role to the `node` role, as `setup` is more of a generic library for installing and bootstrapping, and the changes here are specific to K8s, so I think it is better place in the `node` role.