### PR TITLE
photon: Add GOSS test for apparmor disabled

### DIFF
--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -158,6 +158,12 @@ photon:
     <<: *common_photon_rpms
     audit:
   ova:
+    command:
+      grep apparmor=0 /boot/photon.cfg:
+        exit-status: 0
+        stdout: ["apparmor=0"]
+        stderr: []
+        timeout: 0
     service:
       networkd-dispatcher:
         enabled: true


### PR DESCRIPTION
What this PR does / why we need it:

Needed to add GOSS test to make sure photon kernel is configured to disable apparmor

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**

/assign @kkeshavamurthy 

photon-3 isn't in the OVA CI script yet (but will be soon!), so here is sample output for this:

```sh
    vmware-iso:         {
    vmware-iso:             "duration": 6439,
    vmware-iso:             "err": null,
    vmware-iso:             "expected": [
    vmware-iso:                 "apparmor=0"
    vmware-iso:             ],
    vmware-iso:             "found": [
    vmware-iso:                 "apparmor=0"
    vmware-iso:             ],
    vmware-iso:             "human": "",
    vmware-iso:             "meta": null,
    vmware-iso:             "property": "stdout",
    vmware-iso:             "resource-id": "grep apparmor=0 /boot/photon.cfg",
    vmware-iso:             "resource-type": "Command",
    vmware-iso:             "result": 0,
    vmware-iso:             "successful": true,
    vmware-iso:             "summary-line": "Command: grep apparmor=0 /boot/photon.cfg: stdout: matches expectation: [apparmor=0]",
    vmware-iso:             "test-type": 2,
    vmware-iso:             "title": ""
    vmware-iso:         },
```