### PR TITLE
Use dword to turn off auto updates on Windows

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -29,12 +29,14 @@
     path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
     state: present
 
+# https://docs.microsoft.com/en-us/windows/deployment/update/waas-wu-settings#configuring-automatic-updates-by-editing-the-registry
 - name: Disable Windows automatic updates in registry
   win_regedit:
     path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU
     state: present
     name: NoAutoUpdate
     data: 1
+    type: dword
 
 - name: Set Windows automatic updates to notify only in registry
   win_regedit:
@@ -42,6 +44,7 @@
     state: present
     name: AUOptions
     data: 2
+    type: dword
 
 # Hyper-V messes with networking components on startup after the feature is enabled
 # causing issues with communication over winrm and setting winrm to delayed start

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -68,6 +68,30 @@ command:
 {{end}} #End linux only 
 
 {{ if eq .Vars.OS "windows" }} # Windows
+  automatic updates set to notify:
+    exit-status: 0
+    exec: powershell -command "(Get-ItemPropertyValue 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -name AUOptions) -eq '2'"
+    stdout:
+    - "True"
+    timeout: 30000
+  automatic updates set to notify with correct type:
+    exit-status: 0
+    exec: powershell -command "(Get-ItemPropertyValue 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -name AUOptions).GetType().Name -eq 'Int32'"
+    stdout:
+    - "True"
+    timeout: 30000
+  automatic updates are disabled:
+    exit-status: 0
+    exec: powershell -command "(Get-ItemPropertyValue 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -name NoAutoUpdate) -eq '1'"
+    stdout:
+    - "True"
+    timeout: 30000
+  automatic updates are disabled with correct type:
+    exit-status: 0
+    exec: powershell -command "(Get-ItemPropertyValue 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU' -name NoAutoUpdate).GetType().Name -eq 'Int32'"
+    stdout:
+    - "True"
+    timeout: 30000
   kubectl version --client:
     exit-status: 0
     stdout:


### PR DESCRIPTION
What this PR does / why we need it:
We had logic to disable automatic updates in Windows but the registry key was the wrong value type because the default in ansible is `string`.  This fixes to use `dword` and adds goss tests to verify.


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

We saw failures on long running jobs due to reboots: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1881#issuecomment-990394749

This maybe why we see other failures during building particularly around https://github.com/kubernetes-sigs/image-builder/issues/549

/sig windows 
/assign @perithompson @marosset 