### PR TITLE
Fix failure observed during adding additional registry images

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -50,6 +50,19 @@
     src: etc/kubernetes-version
     mode: 0644
 
+- name: Symlink cri-tools
+  file:
+    src:   "/usr/local/bin/{{ item }}"
+    dest:  "/usr/bin/{{ item }}"
+    mode: 0777
+    state: link
+    force: yes
+  loop:
+  - ctr
+  - crictl
+  - critest
+  when: ansible_os_family != "Flatcar"
+
 # TODO: This section will be deprecated once https://github.com/containerd/cri/issues/1131 is fixed. It is used to support ECR with containerd.
 - name: Check if Kubernetes container registry is using Amazon ECR
   set_fact:

--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Symlink cri-tools
-  file:
-    src:   "/usr/local/bin/{{ item }}"
-    dest:  "/usr/bin/{{ item }}"
-    mode: 0777
-    state: link
-    force: yes
-  loop:
-  - ctr
-  - crictl
-  - critest
-  when: ansible_os_family != "Flatcar"
-
 - name: Create CNI directory
   file:
     state: directory


### PR DESCRIPTION
What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #760 

**Additional context**
Moves the task of creating symlink for `/usr/local//bin/ctr` so as to make it available when images are to be pulled in registry.yml

Post this modification, the image build successfully completes, snippet of the log pertaining to pulling of the specified image from the registry:
```
...
qemu:  ___________________________________________________________
    qemu: / TASK [load_additional_components : Pull additional images \
    qemu: \ from registry]                                            /
    qemu:  -----------------------------------------------------------
    qemu:         \   ^__^
    qemu:          \  (oo)\_______
    qemu:             (__)\       )\/\
    qemu:                 ||----w |
    qemu:                 ||     ||
    qemu:
    qemu: changed: [default] => (item=docker.io/calico/cni:v3.20.1)
...
```