### PR TITLE
Use nssm for kubelet log rotation on Windows

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
@@ -36,7 +36,7 @@
   win_service:
     name: kubelet
     dependencies: [ "{{ runtime_service }}" ]
-    start_mode: manual
+    start_mode: auto
   vars:
     dependencies:
       containerd: containerd

--- a/images/capi/ansible/windows/roles/kubernetes/tasks/nssm.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/nssm.yml
@@ -29,6 +29,11 @@
 - name: Install kubelet via nssm
   win_nssm:
     name: kubelet
-    start_mode: manual
+    start_mode: auto
+    state: present
     application: '%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe'
     arguments: '-ExecutionPolicy Bypass -NoProfile {{ kubernetes_install_path }}\StartKubelet.ps1'
+    app_rotate_bytes: 10485760
+    stderr_file: '{{ systemdrive.stdout | trim }}\var\log\kubelet\kubelet.err.log'
+    stdout_file: '{{ systemdrive.stdout | trim }}\var\log\kubelet\kubelet.log'
+    app_rotate_online: 1

--- a/images/capi/ansible/windows/roles/kubernetes/templates/StartKubelet.ps1
+++ b/images/capi/ansible/windows/roles/kubernetes/templates/StartKubelet.ps1
@@ -33,8 +33,6 @@ $args = "--cert-dir=$env:SYSTEMDRIVE/var/lib/kubelet/pki",
         "--enforce-node-allocatable=`"`"",
         "--network-plugin=cni",
         "--resolv-conf=`"`"",
-        "--log-dir=$env:SYSTEMDRIVE/var/log/kubelet",
-        "--logtostderr=false",
        	"--image-pull-progress-deadline=20m"
 
 $kubeletCommandLine = "{{ kubernetes_install_path }}\kubelet.exe " + ($args -join " ") + " $kubeAdmArgs"

--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -129,6 +129,12 @@
       "version": "{{user `goss_version`}}"
     },
     {
+      "inline": [
+        "rm -Force -Recurse C:\\var\\log\\kubelet\\*"
+      ],
+      "type": "powershell"
+    },
+    {
       "elevated_password": "{{.WinRMPassword}}",
       "elevated_user": "Administrator",
       "script": "packer/ami/scripts/sysprep_prerequisites.ps1",

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -162,6 +162,12 @@
       "version": "{{user `goss_version`}}"
     },
     {
+      "inline": [
+        "rm -Force -Recurse C:\\var\\log\\kubelet\\*"
+      ],
+      "type": "powershell"
+    },
+    {
       "elevated_password": "{{.WinRMPassword}}",
       "elevated_user": "packer",
       "script": "packer/azure/scripts/sysprep.ps1",

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -320,8 +320,7 @@ windows:
       - Stopped
     kubelet:
       expected: 
-      - Manual 
-      - Stopped
+      - Automatic 
       - "/RequiredServices.+:.+(containerd|docker)/"
     sshd:
       expected:

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -231,6 +231,12 @@
         "runtime": "{{user `runtime`}}"
       },
       "version": "{{user `goss_version`}}"
+    },
+    {
+      "inline": [
+        "rm -Force -Recurse C:\\var\\log\\kubelet\\*"
+      ],
+      "type": "powershell"
     }
   ],
   "variables": {


### PR DESCRIPTION
What this PR does / why we need it:

When installing kubelet via nssm we still used kubelets built in logging.  The built in logger logs duplicated data two three different files streams which isn't useful since it duplicates data and the error/warning files don't have enough context in them.  

Since we already use nssm we can use the built in log redirection and logging will be much simpler to reason about and contain less information.  The log files will still be in the same location.

This also turns on kubelet to Automatic so it will boot automatically on restart (#554)

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #554 

**Additional context**
Add any other context for the reviewers