### PR TITLE
fix ova-ci script to use vCenter IP directly

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -42,7 +42,7 @@ cleanup_build_vm() {
   chmod +x govc
   mv govc /usr/local/bin/govc
 
-  export GOVC_URL="${VSPHERE_SERVER}"
+  export GOVC_URL="10.2.224.4"
   export GOVC_USERNAME="${VSPHERE_USERNAME}"
   export GOVC_PASSWORD="${VSPHERE_PASSWORD}"
   export GOVC_DATACENTER="SDDC-Datacenter"
@@ -69,7 +69,8 @@ fi
 
 cat << EOF > packer/ova/vsphere.json
 {
-    "vcenter_server":"${VSPHERE_SERVER}",
+    "vcenter_server":"10.2.224.4",
+    "insecure_connection": "true",
     "username":"${VSPHERE_USERNAME}",
     "password":"${VSPHERE_PASSWORD}",
     "datastore":"WorkloadDatastore",


### PR DESCRIPTION
What this PR does / why we need it:
Due to a CVE, VMC locked down certain access to vCenter on AWS. 
Adding the IP of the vCenter should force the connection to go thru the VPN and unblock the CI. 
In the long run, we should update the prow secrets. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @codenrhoden 