### PR TITLE
Fix the location of the containerd state/root folders for Windows

### DIFF
--- a/images/capi/ansible/windows/roles/runtimes/templates/config.toml
+++ b/images/capi/ansible/windows/roles/runtimes/templates/config.toml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-root = "{{ allusersprofile }}\\root"
-state = "{{ allusersprofile }}\\state"
+root = "{{ allusersprofile }}\\containerd\\root"
+state = "{{ allusersprofile }}\\containerd\\state"
 version = 2
 
 {% if 'imports' not in containerd_additional_settings | b64decode %}

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -108,13 +108,15 @@ command:
     stdout:
     - "{{.Vars.containerd_version}}"
     timeout: 30000
-  Correct Containerd cni config:
+  Correct Containerd config:
     exec: "\"/Program Files/containerd/containerd.exe\" config dump"
     exit-status: 0
     stdout:
     - "sandbox_image = \"{{.Vars.pause_image}}\""
     - "conf_dir = \"C:/etc/cni/net.d\""
     - "bin_dir = \"C:/opt/cni/bin\""
+    - "root = \"C:\\\\ProgramData\\\\containerd\\\\root\""
+    - "state = \"C:\\\\ProgramData\\\\containerd\\\\state\""
     timeout: 30000
   Check Windows Defender Exclusions are in place:
     exit-status: 0


### PR DESCRIPTION
What this PR does / why we need it:

The intent was to have the data folders (`state` and `root` be in `c:\programdata\containerd\`: 

https://github.com/kubernetes-sigs/image-builder/blob/196c549b8f31f890f7839cdd5681c1facd78dad2/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml#L31-L33

but the didn't land there due to wrong config:

https://github.com/kubernetes-sigs/image-builder/blob/196c549b8f31f890f7839cdd5681c1facd78dad2/images/capi/ansible/windows/roles/runtimes/templates/config.toml#L15-L16

This puts them in the correct location. This should be a non breaking change as it is not user facing but will be less confusing for an admin looking for these folders (right now there are in `c:\programdata\root` but there are folders in `c:\programdata\containerd\`


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/sig windows
/assign @perithompson 