### PR TITLE
ensure goss installation for the qemu and raw targets

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -95,12 +95,14 @@ deps-qemu: ## Installs/checks dependencies for QEMU builds
 deps-qemu:
 	hack/ensure-ansible.sh
 	hack/ensure-packer.sh
+	hack/ensure-goss.sh
 
 .PHONY: deps-raw
 deps-raw: ## Installs/checks dependencies for RAW builds
 deps-raw:
 	hack/ensure-ansible.sh
 	hack/ensure-packer.sh
+	hack/ensure-goss.sh
 
 ## --------------------------------------
 ## Container variables


### PR DESCRIPTION
What this PR does / why we need it:

qemu target throws following error, hence need goss as prereq

```shell
root@mkumatag-image-test:~/image-builder/images/capi# make build-qemu-centos-7
hack/ensure-ansible.sh
hack/ensure-packer.sh
packer build -var-file="/root/image-builder/images/capi/packer/config/kubernetes.json"  -var-file="/root/image-builder/images/capi/packer/config/cni.json"  -var-file="/root/image-builder/images/capi/packer/config/containerd.json"  -var-file="/root/image-builder/images/capi/packer/config/ansible-args.json"  -var-file="/root/image-builder/images/capi/packer/config/goss-args.json"  -var-file="/root/image-builder/images/capi/packer/config/common.json"  -var-file="/root/image-builder/images/capi/packer/config/additional_components.json"  -color=true -var-file="/root/image-builder/images/capi/packer/qemu/qemu-centos-7.json"  -except=flatcar packer/qemu/packer.json
Error: Failed to initialize build "qemu"

error initializing provisioner 'goss': Unknown provisioner goss



==> Wait completed after 3 microseconds

==> Builds finished but no artifacts were created.
make: *** [Makefile:406: build-qemu-centos-7] Error 1
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers