### PR TITLE
Link to Windows docs in TOC

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [OpenStack](./capi/providers/openstack.md)
   - [raw](./capi/providers/raw.md)
   - [vSphere](./capi/providers/vsphere.md)
+  - [Windows](./capi/windows/windows.md)
   - [Testing the Images](./capi/goss/goss.md)
   - [Using Container Images](./capi/container-image.md)
 - [Glossary](./glossary.md)

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -39,7 +39,7 @@ The `images/capi/packer/config` directory includes several JSON files that defin
 | `packer/config/containerd.json` | The version of containerd to install and customizations specific to the containerd runtime |
 | `packer/config/kubernetes.json` | The version of Kubernetes to install. The default version is kept at n-2. See [Customization](#customization) section below for overriding this value |
 
-Due to OS differences, Windows images has additional configuration in the `packer/config/windows` folder.  See [Windows documentation](windows/windows.md) for more details.
+Due to OS differences, Windows images has additional configuration in the `packer/config/windows` folder.  See [Windows documentation](./windows/windows.md) for more details.
 
 ### Customization
 


### PR DESCRIPTION
**What this PR does / why we need it:**
mdBook doesn't generate/compile a doc page unless it is referenced from
SUMMARY.md. Even though the windows page was linked to in capi.md, that
wasn't enough to bring it in. By adding it to the Table of Contents, it
shows up in the left-side nav, and the link from capi.md works now too.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
n/a

/assign @jsturtevant 