### PR TITLE
Bump mdBook to v0.4.14

### DIFF
--- a/docs/book/build.sh
+++ b/docs/book/build.sh
@@ -24,7 +24,7 @@ cd "${KUBE_ROOT}" || exit 1
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
-MDBOOK_VERSION="0.4.6"
+MDBOOK_VERSION="0.4.14"
 
 # translate arch to rust's conventions (if we can)
 if [[ ${arch} == "amd64" ]]; then


### PR DESCRIPTION
What this PR does / why we need it:
The previous release we were using, v0.4.6, is 11 months old. Worthwhile
to use a newer version.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
n/a

/assign @jsturtevant @kkeshavamurthy 