### PR TITLE
Refresh OWNERs files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,9 @@ approvers:
 reviewers:
   - image-builder-maintainers
   - image-builder-reviewers
+
+emeritus_approvers:
+  - akutz
+  - figo
+  - luxas
+  - timothysc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,15 +2,11 @@
 
 aliases:
   image-builder-maintainers:
-    - akutz
     - CecileRobertMichon
     - codenrhoden
     - detiber
-    - figo
     - justinsb
-    - luxas
     - moshloop
-    - timothysc
   image-builder-reviewers:
     - EleanorRigby
     - randomvariable

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,23 +28,23 @@ aliases:
     - jsturtevant
     - perithompson
   cluster-api-maintainers:
-    - justinsb
-    - detiber
-    - vincepri
     - CecileRobertMichon
-  cluster-api-aws-maintainers:
-    - detiber
-    - randomvariable
-    - richardcase
-    - rudoi
+    - enxebre
+    - fabriziopandini
     - vincepri
+  cluster-api-aws-maintainers:
+    - richardcase
+    - sedefsavas
   cluster-api-azure-maintainers:
+    - alexeldeib
     - CecileRobertMichon
     - devigned
     - nader-ziada
+    - shysank
   cluster-api-gcp-maintainers:
     - cpanato
     - detiber
+    - dims
     - gab-satchi
     - justinsb
     - krousey
@@ -56,18 +56,18 @@ aliases:
     - prksu
     - timoreimann
   cluster-api-openstack-maintainers:
-    - chaosaffe
-    - chrigl
-    - dims
-    - gyliu513
+    - chrischdi
+    - hidekazuna
     - jichenjc
-    - Lion-Wei
-    - m1093782566
-    - sbueringer
+    - mdbooth
+    - seanschneeweiss
+    - tobiasgiese
   cluster-api-vsphere-maintainers:
     - frapposelli
-    - yastij
+    - gab-satchi
     - randomvariable
+    - srm09
+    - yastij
   kops-maintainers:
     - hakman
     - justinsb

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,9 @@ aliases:
     - CecileRobertMichon
     - codenrhoden
     - detiber
+    - jsturtevant
     - justinsb
+    - kkeshavamurthy
     - moshloop
   image-builder-reviewers:
     - EleanorRigby


### PR DESCRIPTION
What this PR does / why we need it:

1. makes sure various project owner aliases are up to date with their source project OWNERs ✅ 
2. moves inactive image-builder approvers and reviewers to emeritus (@akutz @figo @luxas @timothysc - thanks for all your contributions to the project ❤️ )
3. proposes that we add @jsturtevant and @kkeshavamurthy to image-builder-maintainers 🎉 

/hold 

lazy consensus date: Tuesday 1/18

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

- Inactive approvers were identified based on folks they'd like to be removed in [slack](https://kubernetes.slack.com/archives/C01E0Q35A8J/p1641578987008200), or 0 issues/PRs in 2021 returned by search (https://github.com/kubernetes-sigs/image-builder/issues?q=created%3A%3E2021-01-01++username+)
- Contributions from @jsturtevant: https://github.com/kubernetes-sigs/image-builder/pulls?q=jsturtevant+
- Contributions from @kkeshavamurthy: https://github.com/kubernetes-sigs/image-builder/issues?q=kkeshavamurthy+
