### PR TITLE
Fix target argument in Makefile substitution command

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -438,7 +438,7 @@ QEMU_CLEAN_TARGETS := $(subst build-,clean-,$(QEMU_BUILD_TARGETS))
 $(QEMU_CLEAN_TARGETS):
 	rm -fr output/$(subst clean-qemu-,,$@)-kube*
 
-RAW_CLEAN_TARGETS := $(subst build-,clean-,$(RAW_CLEAN_TARGETS))
+RAW_CLEAN_TARGETS := $(subst build-,clean-,$(RAW_BUILD_TARGETS))
 .PHONY: $(RAW_CLEAN_TARGETS)
 $(RAW_CLEAN_TARGETS):
 	rm -fr output/$(subst clean-raw-,,$@)-kube*


### PR DESCRIPTION
This PR fixes the Make substitution command to derive the value of `RAW_CLEAN_TARGETS` from `RAW_BUILD_TARGETS` instead of self-referencing itself.