### PR TITLE
[ansible][windows] Add `ExtendVolumesPlugin` cloubase-init plugin

### DIFF
--- a/images/capi/ansible/windows/roles/cloudbase-init/templates/cloudbase-init.conf
+++ b/images/capi/ansible/windows/roles/cloudbase-init/templates/cloudbase-init.conf
@@ -33,5 +33,6 @@ netbios_host_name_compatibility={{ netbios_host_name_compatibility }}
 metadata_services={{ cloudbase_metadata_services }}
 plugins=cloudbaseinit.plugins.windows.createuser.CreateUserPlugin, 
         cloudbaseinit.plugins.common.setuserpassword.SetUserPasswordPlugin, 
+        cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin,
         cloudbaseinit.plugins.common.userdata.UserDataPlugin,
         {{ cloudbase_plugins }}


### PR DESCRIPTION
### What this PR does / why we need it:

The official capi Windows marketplace image from the `cncf-upstream:capi`
are generated without this plugin, and the images have a 30GB system
root partition disk. Using a flavor with a bigger OS disk will not extend the
root system partition, unless manually extended.

The [ExtendVolumesPlugin](https://cloudbase-init.readthedocs.io/en/latest/plugins.html#cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin) plugin is required to extend the root system
partition to the maximum size, by the cloudbase-init.