### PR TITLE
Only provide dockershim flags with docker below 1.24

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/tasks/sc.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/sc.yml
@@ -15,8 +15,13 @@
 # Install kubelet as a windows service
 # Requires --windows-service flag: https://github.com/kubernetes/kubernetes/blob/7f23a743e8c23ac6489340bbb34fa6f1d392db9d/cmd/kubelet/app/options/osflags_windows.go#L26
 # Does not support kubeadm KUBELET_KUBEADM_ARGS which is used by Cluster API to pass extra user args
+- name: Set dockershim args
+  set_fact:
+    additional_kubelet_args: "--image-pull-progress-deadline=20m --network-plugin=cni"
+  when: runtime == "docker-ee" and kubernetes_semver is version('v1.24.0', '<')
+
 - name: Install kubelet as service
   win_service:
     name: kubelet
     start_mode: manual
-    path: '{{ kubernetes_install_path }}\kubelet.exe --windows-service --cert-dir={{ systemdrive.stdout | trim }}/var/lib/kubelet/pki --config={{ systemdrive.stdout | trim }}/var/lib/kubelet/config.yaml --bootstrap-kubeconfig={{ systemdrive.stdout | trim }}/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig={{ systemdrive.stdout | trim }}/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"{{ pause_image }}`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir={{ systemdrive.stdout | trim }}/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m'
+    path: '{{ kubernetes_install_path }}\kubelet.exe --windows-service --cert-dir={{ systemdrive.stdout | trim }}/var/lib/kubelet/pki --config={{ systemdrive.stdout | trim }}/var/lib/kubelet/config.yaml --bootstrap-kubeconfig={{ systemdrive.stdout | trim }}/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig={{ systemdrive.stdout | trim }}/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"{{ pause_image }}`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --resolv-conf=`"`" --log-dir={{ systemdrive.stdout | trim }}/var/log/kubelet --logtostderr=false {{ additional_kubelet_args if additional_kubelet_args is defined }}'

--- a/images/capi/ansible/windows/roles/kubernetes/templates/StartKubelet.ps1
+++ b/images/capi/ansible/windows/roles/kubernetes/templates/StartKubelet.ps1
@@ -15,12 +15,6 @@
 # From https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
 $FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
 $kubeAdmArgs = $FileContent.TrimStart('KUBELET_KUBEADM_ARGS=').Trim('"')
-{% raw %}
-$netId = docker network ls -f name=host --format "{{ .ID }}"
-{% endraw %}
-if ($netId.Length -lt 1) {
-    docker network create -d nat host
-}
 
 $args = "--cert-dir=$env:SYSTEMDRIVE/var/lib/kubelet/pki",
         "--config=$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml",
@@ -31,10 +25,19 @@ $args = "--cert-dir=$env:SYSTEMDRIVE/var/lib/kubelet/pki",
         "--enable-debugging-handlers",
         "--cgroups-per-qos=false",
         "--enforce-node-allocatable=`"`"",
-        "--network-plugin=cni",
-        "--resolv-conf=`"`"",
-       	"--image-pull-progress-deadline=20m"
+        "--resolv-conf=`"`""
+
+{% if runtime == "docker-ee" and kubernetes_semver is version('v1.24.0', '<') %}
+{% raw %}
+$netId = docker network ls -f name=host --format "{{ .ID }}"
+{% endraw %}
+if ($netId.Length -lt 1) {
+    docker network create -d nat host
+}
+
+$args += "--image-pull-progress-deadline=20m",
+        "--network-plugin=cni"
+{% endif %}
 
 $kubeletCommandLine = "{{ kubernetes_install_path }}\kubelet.exe " + ($args -join " ") + " $kubeAdmArgs"
-
 Invoke-Expression $kubeletCommandLine


### PR DESCRIPTION
What this PR does / why we need it:

The [removal of dockershim kubelet flags](https://github.com/kubernetes/kubernetes/pull/106907) is causing kubelet to fail to start in the 1.24.alpha e2e tests:

https://testgrid.k8s.io/sig-windows-master-release#capz-windows-containerd-master

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-master-containerd-windows/1484222566431199232

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/sig windows
/assign @perithompson 