### PR TITLE
Replacing \var\lib\kubelet path to \etc\kubernetes

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
@@ -18,12 +18,9 @@
     state: directory
   loop: 
     - '{{ systemdrive.stdout | trim }}\var\log\kubelet'
-    - '{{ systemdrive.stdout | trim }}\var\lib\kubelet\etc\kubernetes'
-    - '{{ systemdrive.stdout | trim }}\var\lib\kubelet\etc\kubernetes\manifests'
+    - '{{ systemdrive.stdout | trim }}\etc\kubernetes'
+    - '{{ systemdrive.stdout | trim }}\etc\kubernetes\manifests'
     - '{{ systemdrive.stdout | trim }}\etc\kubernetes\pki'
-
-- name: Symlink kubelet pki folder
-  win_shell: New-Item -path $env:SystemDrive\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value  $env:SystemDrive\etc\kubernetes\pki\ -Force
 
 - import_tasks: nssm.yml
   when: windows_service_manager == "nssm"

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -111,12 +111,6 @@ command:
     stdout:
     - {{.Vars.kubernetes_version}}
     timeout: 10000
-  Check Symbolic link to /etc/kubernetes/pki:
-    exit-status: 0
-    exec: powershell -command "(Get-item -path $env:SystemDrive\var\lib\kubelet\etc\kubernetes\pki| select LinkType,Target)"
-    stdout:
-    - SymbolicLink 
-    - C:\etc\kubernetes\pki\
 {{ if eq .Vars.distribution_version "2019" }}
   Windows build version is high enough:
     exit-status: 0

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -316,11 +316,11 @@ windows:
       exists: true
       filetype: directory
       contains:
-    c:/var/lib/kubelet/etc/kubernetes:
+    c:/etc/kubernetes:
       exists: true
       filetype: directory
       contains:
-    c:/var/lib/kubelet/etc/kubernetes/manifests:
+    c:/etc/kubernetes/manifests:
       exists: true
       filetype: directory
       contains:


### PR DESCRIPTION
What this PR does / why we need it:
- To avoid unnecessary symlinks renaming the var/lib path
- Moving directory to `/etc/kubernetes/manifests` for default kubelet path

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #https://github.com/kubernetes-sigs/image-builder/issues/780

**Additional context**
Add any other context for the reviewers