### PR TITLE
Use updated OVA CI credentials.

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -21,7 +21,7 @@ set -o pipefail # any non-zero exit code in a piped command causes the pipeline 
 CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
-TARGETS=("ubuntu-1804" "ubuntu-2004" "centos-7" "photon-3")
+TARGETS=("ubuntu-1804" "ubuntu-2004" "photon-3")
 
 on_exit() {
   for target in ${TARGETS[@]};

--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -42,12 +42,6 @@ cleanup_build_vm() {
   chmod +x govc
   mv govc /usr/local/bin/govc
 
-  export GOVC_URL="10.2.224.4"
-  export GOVC_USERNAME="${VSPHERE_USERNAME}"
-  export GOVC_PASSWORD="${VSPHERE_PASSWORD}"
-  export GOVC_DATACENTER="SDDC-Datacenter"
-  export GOVC_INSECURE=true
-
   for target in ${TARGETS[@]};
   do
     govc vm.destroy capv-ci-${target}-${TIMESTAMP}
@@ -61,20 +55,17 @@ export PATH=${PWD}/.local/bin:$PATH
 export PATH=${PYTHON_BIN_DIR:-"/root/.local/bin"}:$PATH
 export GC_KIND="false"
 export TIMESTAMP="$(date -u '+%Y%m%dT%H%M%S')"
-
-# Load VMC Creds
-if [ -f "${CONFIG_ENV-}" ]; then
-  set -o allexport && . "${CONFIG_ENV-}" && set +o allexport
-fi
+export GOVC_DATACENTER="SDDC-Datacenter"
+export GOVC_INSECURE=true
 
 cat << EOF > packer/ova/vsphere.json
 {
-    "vcenter_server":"10.2.224.4",
-    "insecure_connection": "true",
-    "username":"${VSPHERE_USERNAME}",
-    "password":"${VSPHERE_PASSWORD}",
+    "vcenter_server":"${GOVC_URL}",
+    "insecure_connection": "${GOVC_INSECURE}",
+    "username":"${GOVC_USERNAME}",
+    "password":"${GOVC_PASSWORD}",
     "datastore":"WorkloadDatastore",
-    "datacenter":"SDDC-Datacenter",
+    "datacenter":"${GOVC_DATACENTER}",
     "cluster": "Cluster-1",
     "network": "sddc-cgw-network-8",
     "folder": "Workloads/ci/imagebuilder"


### PR DESCRIPTION
What this PR does / why we need it:
Credentials for running OVA CI have been updated. This PR updates the OVA CI script to use them, and to no longer pull in credentials from an outdated source. Furthermore, remove the double definition of a couple of variables.

While testing this, it was found that CentOS-7 builds are consistently failing. This PR removes CentOS as a CI target so that OVA CI can be re-enabled reliably. A follow-on PR will be made to fix CentOS-7.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #775 

**Additional context**
