### PR TITLE
Update docs to use latest image-builder container v0.1.11

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -16,7 +16,7 @@ Run the docker build target of Makefile
 ## Using a Container Image
 The latest container image can be pulled from GCR as below -
 ```commandline
-docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd64:v0.1.9
+docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd64:v0.1.11
 ```
 
 ### Examples
@@ -25,7 +25,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
     - If the AWS-CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials.
 
     ```commandline
-    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-ami-ubuntu-2004
+    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.11 build-ami-ubuntu-2004
     ```
     - Another alternative is to use an `aws-creds.env` file to load the credentials and pass it during docker run.
 
@@ -36,7 +36,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
       ```
 
     ```commandline
-        docker run -it --rm --env-file aws-creds.env k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-ami-ubuntu-2004
+        docker run -it --rm --env-file aws-creds.env k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.11 build-ami-ubuntu-2004
     ```
 
 - AZURE
@@ -51,7 +51,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
       ```
 
     ```commandline
-    docker run -it --rm --env-file az-creds.env k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-azure-sig-ubuntu-2004
+    docker run -it --rm --env-file az-creds.env k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.11 build-azure-sig-ubuntu-2004
     ```
 
 - vSphere OVA
@@ -60,7 +60,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
 
     ```commandline
-    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.9 build-node-ova-vsphere-ubuntu-2004
+    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json k8s.gcr.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.11 build-node-ova-vsphere-ubuntu-2004
     ```
 
 In addition to this, further customizations can be done as discussed [here](./capi.md#customization).


### PR DESCRIPTION
[#0111](https://www.pivotaltracker.com/story/show/0111)

Update image-builder docs to refer to the latest container image with `v0.1.11` tag. 

/cc @codenrhoden 