### PR TITLE
Fix CentOS build for OVAs by upgrading pip

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -63,6 +63,14 @@
     dest: /tmp/cloud-init-vmware.sh
     mode: 0700
 
+# pip on CentOS needs to be upgraded, but since it's still
+# Python 2.7, need < 21.0
+- name: Upgrade pip
+  pip:
+    name: pip<21.0
+    state: forcereinstall
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
+
 - name: Execute cloud-init-vmware.sh
   shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh
   environment:

--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -21,7 +21,7 @@ set -o pipefail # any non-zero exit code in a piped command causes the pipeline 
 CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
-TARGETS=("ubuntu-1804" "ubuntu-2004" "photon-3")
+TARGETS=("ubuntu-1804" "ubuntu-2004" "photon-3" "centos-7")
 
 on_exit() {
   for target in ${TARGETS[@]};


### PR DESCRIPTION
What this PR does / why we need it:

    CentOS 7 is consistently failing when installing the VMW guestinfo
    datasource. An upgraded pip fixes it, but we need to make sure that pip
    stays < 21.0 because starting with 21.0 pip changed syntax to only be
    compatible with Python 3.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #794 

**Additional context**
This can likely be removed when we are able to use the newer cloud-init version that includes the VMW guestinfo datasource natively (and we remove the separate install task for it).