### PR TITLE
Add containerd source client header for CAPZ

### DIFF
--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -11,11 +11,15 @@ imports = ["/etc/containerd/conf.d/*.toml"]
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pause_image }}"
-  {% if kubernetes_semver is version('v1.21.0', '>=') %}
+{% if kubernetes_semver is version('v1.21.0', '>=') %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
     SystemdCgroup = true
-  {% endif %}
+{% endif %}
+{% if packer_builder_type.startswith('azure') %}
+  [plugins."io.containerd.grpc.v1.cri".registry.headers]
+    X-Meta-Source-Client = ["azure/capz"]
+{% endif %}
 
 {{containerd_additional_settings | b64decode}}

--- a/images/capi/ansible/windows/roles/runtimes/templates/config.toml
+++ b/images/capi/ansible/windows/roles/runtimes/templates/config.toml
@@ -29,5 +29,9 @@ imports = ["{{ containerd_conf_dir }}\\conf.d\\*.toml"]
     [plugins."io.containerd.grpc.v1.cri".cni]
       bin_dir = "{{ plugin_bin_dir }}"
       conf_dir = "{{ plugin_conf_dir }}"
+{% if packer_builder_type.startswith('azure') %}
+    [plugins."io.containerd.grpc.v1.cri".registry.headers]
+      X-Meta-Source-Client = ["azure/capz"]
+{% endif %}
 
 {{containerd_additional_settings | b64decode}}


### PR DESCRIPTION
What this PR does / why we need it: Provide telemetry so registries like ACR can understand how many requests are coming from CAPZ clusters. See https://github.com/Azure/acr/blob/main/docs/http-headers.md#azure-container-registry-http-headers for more details.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2079

**Additional context**
Add any other context for the reviewers