### PR TITLE
Fix hyperlink in Azure docs

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -1,6 +1,6 @@
 # Building Images for Azure
 
-These images are designed for use with [Cluster API Provider Azure]([Cluster API Provider Azure](https://capz.sigs.k8s.io/introduction.html#what-is-the-cluster-api-provider-azure)) (CAPZ). Learn more on using [custom images with CAPZ](https://capz.sigs.k8s.io/topics/custom-images.html).
+These images are designed for use with [Cluster API Provider Azure](https://capz.sigs.k8s.io/introduction.html#what-is-the-cluster-api-provider-azure) (CAPZ). Learn more on using [custom images with CAPZ](https://capz.sigs.k8s.io/topics/custom-images.html).
 
 ## Prerequisites for Azure
 


### PR DESCRIPTION
This PR fixes a malformed hyperlink in the Azure image-builder docs.