### PR TITLE
containerd: update to v1.6.1

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,7 +1,7 @@
 {
   "containerd_additional_settings": null,
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
-  "containerd_sha256": "f7187d0c6f38c33a4bf87b534b4434001fba6eba01ab7877059669da143f67f0",
-  "containerd_sha256_windows": "2ebf9bee333b568f10b774b4e474de37fe282b4291e16a11144254c358355392",
-  "containerd_version": "1.6.0"
+  "containerd_sha256": "e01da1ad4a41a71e0fef52b1f0ed08980b808f1d7c904c9956c24afb8236d6f0",
+  "containerd_sha256_windows": "eea650d7eca69d5e49926b3bcc3988c2c7b6649d98bb72bd3203252d513c021d",
+  "containerd_version": "1.6.1"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Updates containerd to 1.6.0.

Release Notes: https://github.com/containerd/containerd/releases/tag/v1.6.1

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 

**Additional context**
<sub>Sean Schneeweiss <sean.schneeweiss@mercedes-benz.com>, Daimler TSS GmbH, [Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md)</sub>