### PR TITLE
Install nfs-common package for Azure image

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -54,3 +54,14 @@
     state: restored
     path: /etc/iptables/rules.v4
   when: ansible_os_family == "Debian"
+
+- name: Install netbase and nfs-common
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+  vars:
+    packages:
+    - netbase
+    - nfs-common
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

What this PR does / why we need it:
Azure image installs netbase and nfs-common package.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

related: https://github.com/kubernetes/test-infra/issues/24957