### PR TITLE
Update VMware GuestInfo DS to v1.4.1

### DIFF
--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -8,7 +8,7 @@
   "disk_type_id": "0",
   "firmware": "bios",
   "format": "",
-  "guestinfo_datasource_ref": "v1.4.0",
+  "guestinfo_datasource_ref": "v1.4.1",
   "guestinfo_datasource_script": "{{user `guestinfo_datasource_slug`}}/{{user `guestinfo_datasource_ref`}}/install.sh",
   "guestinfo_datasource_slug": "https://raw.githubusercontent.com/vmware/cloud-init-vmware-guestinfo",
   "headless": "true",


### PR DESCRIPTION
What this PR does / why we need it:

While this DS has been archived, it did have a v1.4.1 release that removed the dependency on DeepMerge. This library no longer works on builds that use Python 2, such as RHEL 7, because the DeepMerge PyPi releases moved to Python3 packaging, and there is no longer a setup.py file after release 0.3.0 -- https://pypi.org/project/deepmerge.

This patch just increments the guest info DS to be v1.4.1 so it no longer attempts to install DeepMerge at all.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): NA

**Additional context**
NA