### PR TITLE
feat: allow overriding volume_type and throughput

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -20,7 +20,8 @@
           "delete_on_termination": true,
           "device_name": "{{ user `root_device_name` }}",
           "volume_size": "{{ user `volume_size` }}",
-          "volume_type": "gp2"
+          "volume_type": "{{ user `volume_type` }}",
+          "throughput": "{{ user `throughput` }}"
         }
       ],
       "name": "{{user `build_name`}}",
@@ -187,6 +188,8 @@
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "volume_size": "40",
+    "volume_type": "gp2",
+    "throughput": "",
     "vpc_id": "",
     "windows_service_manager": null,
     "windows_updates_kbs": null,

--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -13,15 +13,15 @@
       "disable_stop_instance": true,
       "encrypt_boot": "{{user `encrypted`}}",
       "iam_instance_profile": "{{user `iam_instance_profile`}}",
-      "instance_type": "t3.large",
+      "instance_type": "{{user `builder_instance_type`}}",
       "kms_key_id": "{{user `kms_key_id`}}",
       "launch_block_device_mappings": [
         {
           "delete_on_termination": true,
           "device_name": "{{ user `root_device_name` }}",
+          "throughput": "{{ user `throughput` }}",
           "volume_size": "{{ user `volume_size` }}",
-          "volume_type": "{{ user `volume_type` }}",
-          "throughput": "{{ user `throughput` }}"
+          "volume_type": "{{ user `volume_type` }}"
         }
       ],
       "name": "{{user `build_name`}}",
@@ -165,6 +165,7 @@
     "aws_secret_key": "",
     "build_name": null,
     "build_timestamp": "{{timestamp}}",
+    "builder_instance_type": "t3.large",
     "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/{{user `cloudbase_init_version`}}/CloudbaseInitSetup_{{user `cloudbase_init_version` | replace_all `.` `_` }}_x64.msi",
     "cloudbase_metadata_services": "cloudbaseinit.metadata.services.ec2service.EC2Service",
     "cloudbase_metadata_services_unattend": "cloudbaseinit.metadata.services.base.EmptyMetadataService",
@@ -187,9 +188,9 @@
     "snapshot_users": "",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
+    "throughput": "125",
     "volume_size": "40",
-    "volume_type": "gp2",
-    "throughput": "",
+    "volume_type": "gp3",
     "vpc_id": "",
     "windows_service_manager": null,
     "windows_updates_kbs": null,

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -19,7 +19,7 @@
           "iops": "{{ user `iops`}}",
           "throughput": "{{ user `throughput` }}",
           "volume_size": "{{ user `volume_size` }}",
-          "volume_type": "gp3"
+          "volume_type": "{{ user `volume_type` }}"
         }
       ],
       "name": "{{user `build_name`}}",
@@ -192,6 +192,7 @@
     "temporary_security_group_source_cidrs": "",
     "throughput": "125",
     "volume_size": "8",
+    "volume_type": "gp3",
     "vpc_id": ""
   }
 }


### PR DESCRIPTION
What this PR does / why we need it:
- Upgrades windows to gp3 volume type (default, can be configured) and accordingly specify the throughput. 
- Allows to specify builder_instance_type as variable
