### PR TITLE
Make Flatcar build process more generic

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/flatcar.yml
@@ -57,3 +57,8 @@
     owner: root
     group: root
     mode: "0755"
+
+- name: Enable systemd-timesyncd unit
+  systemd:
+    enabled: yes
+    name: systemd-timesyncd.service

--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -4,7 +4,6 @@
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}",
   "crictl_source_type": "http",
-  "goss_entry_file": "goss/goss-flatcar.yaml",
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
   "python_path": "/opt/bin/builder-env/site-packages",

--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -4,6 +4,7 @@
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}",
   "crictl_source_type": "http",
+  "distribution": "flatcar",
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
   "python_path": "/opt/bin/builder-env/site-packages",

--- a/images/capi/packer/azure/flatcar.json
+++ b/images/capi/packer/azure/flatcar.json
@@ -5,7 +5,6 @@
   "distribution": "flatcar",
   "distribution_release": "{{env `FLATCAR_CHANNEL`}}",
   "distribution_version": "{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
-  "goss_entry_file": "goss/goss-flatcar.yaml",
   "image_offer": "flatcar-container-linux-free",
   "image_publisher": "kinvolk",
   "image_sku": "{{env `FLATCAR_CHANNEL`}}",

--- a/images/capi/packer/goss/goss-flatcar.yaml
+++ b/images/capi/packer/goss/goss-flatcar.yaml
@@ -1,7 +1,0 @@
-service:
-  containerd:
-    enabled: true
-    running: true
-command:
-  crictl ps:
-    exit-status: 0

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -16,8 +16,11 @@ kubernetes_cni_version: &kubernetes_cni_version
           match-regexp: "^\\Q{{ .Vars.kubernetes_cni_rpm_version }}\\E$"
 
 package:
+# Flatcar uses Ignition instead of cloud-init
+{{if ne .Vars.OS "flatcar"}}
   cloud-init:
     installed: true
+{{end}}
   ntp:
     installed: false
 {{if eq .Vars.kubernetes_source_type "pkg"}}

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -12,12 +12,20 @@ service:
   conntrackd:
     enabled: false
     running: false
+  {{if ne .Vars.OS "flatcar"}}
+  # TODO: auditd was added to Flatcar in 
+  # https://github.com/flatcar-linux/coreos-overlay/commit/b3194ee538bf7ddb8f699d37a8be81ab106079c3
+  # but isn't available in the various channels yet.
+  # Remove the conditional when auditd is available in Flatcar stable (supposed to happen
+  # once the major release number of the stable channel is larger than 3140).
   auditd:
     enabled: true
     running: true
+  # Flatcar uses systemd-timesyncd instead of chronyd.
   chronyd:
     enabled: true
     running: true
+  {{end}}
 {{range $name, $vers := index .Vars .Vars.OS "common-service"}}
   {{ $name }}:
   {{range $key, $val := $vers}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -144,6 +144,13 @@ centos:
       cloud-utils-growpart:
       python2-pip:
 flatcar:
+  common-service:
+    containerd:
+      enabled: true
+      running: true
+    systemd-timesyncd:
+      enabled: true
+      running: true
   amazon:
     command:
 photon:

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -153,6 +153,8 @@ flatcar:
       running: true
   amazon:
     command:
+  azure:
+    command:
 photon:
   common-service:
     apparmor:


### PR DESCRIPTION
What this PR does / why we need it:

This PR modifies the Flatcar build process to make it as generic as possible and removes "special", Flatcar-specific cases. Following this change set Flatcar no longer uses its own set of GOSS validations but rather uses the same set as the other distros.

Summary of changes:

- Make GOSS validations execute for Flatcar.
- Ensure GOSS validations pass for Flatcar.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**

To test this PR I executed `PACKER_VAR_FILES=/tmp/packer-vars-aws.json FLATCAR_VERSION=3033.2.2 make build-ami-flatcar` with the following `packer-vars-aws.json` file:

```json
{
    "kubernetes_deb_version": "1.20.10-00",
    "kubernetes_rpm_version": "1.20.10-0",
    "kubernetes_semver": "v1.20.10",
    "kubernetes_series": null,
    "goss_inspect_mode": "false",
    "ami_regions": "eu-central-1",
    "aws_region": "eu-central-1"
}
```