### PR TITLE
Bump OVA template version used for Photon CI

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -96,7 +96,7 @@ cat << EOF > ci-${target}.json
 {
 "build_version": "capv-ci-${target}-${TIMESTAMP}",
 "linked_clone": "true",
-"template": "base-photon-3-20211209"
+"template": "base-photon-3-20220314"
 }
 EOF
     PACKER_VAR_FILES="ci-${target}.json" make build-node-ova-vsphere-clone-${target} > ${target}-${TIMESTAMP}.log 2>&1 &


### PR DESCRIPTION
What this PR does / why we need it:
The OVA CI build for photon-3 has been failing lately. This PR bumps the template that is used for doing those builds, and fixes the issue (for some reason, this particular error crops up when the base template gets old).

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
/assign @kkeshavamurthy 