### PR TITLE
Windows: remove admin user when creating custom user

### DIFF
--- a/images/capi/ansible/windows/roles/cloudbase-init/templates/cloudbase-init.conf
+++ b/images/capi/ansible/windows/roles/cloudbase-init/templates/cloudbase-init.conf
@@ -6,6 +6,7 @@ groups=Administrators
 inject_user_password=false
 user_password_length=123
 first_logon_behaviour=no
+rename_admin_user=true
 
 config_drive_raw_hhd=true
 config_drive_cdrom=true


### PR DESCRIPTION
What this PR does / why we need it:

We use cloudbase-init to create a user called `capi`.  This user is then used to ssh and do other work on the node.  This also makes sure that the default `administrator` account is moved to `capi`.  The administrator account was not usable unless the `capi` user assigned a password initializing the account which wasn't done.  The gets rid of that user entirely which is similiar behavoir as we see in Azure when we create a VM with a customer username. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

https://cloudbase-init.readthedocs.io/en/latest/plugins.html?highlight=rename_admin_user#creating-user-main

/sig windows
/assign @knabben 