### PR TITLE
flatcar Azure gen2 images

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -231,7 +231,7 @@ WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
 FLATCAR_CHANNEL ?= stable
 FLATCAR_VERSION ?= 2905.2.3
 ifeq ($(FLATCAR_VERSION),current)
-FLATCAR_VERSION := $(shell hack/image-grok-latest-flatcar-version.sh $(FLATCAR_CHANNEL))
+override FLATCAR_VERSION := $(shell hack/image-grok-latest-flatcar-version.sh $(FLATCAR_CHANNEL))
 endif
 
 export FLATCAR_CHANNEL FLATCAR_VERSION

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -469,6 +469,7 @@ build-azure-vhd-windows-2022-containerd: ## Builds for Windows Server 2022 with 
 build-azure-vhd-windows-2004: ## Builds for Windows Server 2004 SAC
 build-azure-sig-centos-7-gen2: ## Builds CentOS Gen2 managed image in Shared Image Gallery
 build-azure-sig-flatcar: ## Builds Flatcar Azure managed image in Shared Image Gallery
+build-azure-sig-flatcar-gen2: ## Builds Flatcar Azure Gen2 managed image in Shared Image Gallery
 build-azure-sig-ubuntu-1804-gen2: ## Builds Ubuntu 18.04 Gen2 managed image in Shared Image Gallery
 build-azure-sig-ubuntu-2004-gen2: ## Builds Ubuntu 20.04 Gen2 managed image in Shared Image Gallery
 build-azure-vhds: $(AZURE_BUILD_VHD_TARGETS) ## Builds all Azure VHDs

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -22,7 +22,7 @@ SHELL := /usr/bin/env bash
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
-export PATH := $(PATH):$(PWD)/.local/bin
+export PATH := $(PATH):$(CURDIR)/.local/bin
 
 export IB_VERSION ?= $(shell git describe --dirty)
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -229,7 +229,7 @@ WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
 
 # Set Flatcar Container Linux channel and version if not supplied
 FLATCAR_CHANNEL ?= stable
-FLATCAR_VERSION ?= 2905.2.3
+FLATCAR_VERSION ?= 3033.2.4
 ifeq ($(FLATCAR_VERSION),current)
 override FLATCAR_VERSION := $(shell hack/image-grok-latest-flatcar-version.sh $(FLATCAR_CHANNEL))
 endif

--- a/images/capi/azure_targets.sh
+++ b/images/capi/azure_targets.sh
@@ -1,3 +1,3 @@
 VHD_TARGETS="ubuntu-1804 ubuntu-2004 centos-7 windows-2019 windows-2019-containerd windows-2022-containerd"
 SIG_TARGETS="ubuntu-1804 ubuntu-2004 centos-7 windows-2019 windows-2019-containerd windows-2022-containerd flatcar"
-SIG_GEN2_TARGETS="ubuntu-1804 ubuntu-2004 centos-7"
+SIG_GEN2_TARGETS="ubuntu-1804 ubuntu-2004 centos-7 flatcar"

--- a/images/capi/packer/azure/flatcar-gen2.json
+++ b/images/capi/packer/azure/flatcar-gen2.json
@@ -1,0 +1,23 @@
+{
+  "ansible_extra_vars": "ansible_python_interpreter=/opt/pypy/bin/pypy",
+  "build_name": "flatcar-gen2",
+  "crictl_source_type": "http",
+  "distribution": "flatcar",
+  "distribution_release": "{{env `FLATCAR_CHANNEL`}}",
+  "distribution_version": "{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
+  "image_offer": "flatcar-container-linux-free",
+  "image_publisher": "kinvolk",
+  "image_sku": "{{env `FLATCAR_CHANNEL`}}-gen2",
+  "image_version": "{{env `FLATCAR_VERSION` }}",
+  "kubernetes_cni_source_type": "http",
+  "kubernetes_source_type": "http",
+  "plan_image_offer": "{{user `image_offer`}}",
+  "plan_image_publisher": "{{user `image_publisher`}}",
+  "plan_image_sku": "{{user `image_sku`}}",
+  "python_path": "/opt/pypy/site-packages",
+  "root_device_name": "/dev/sda",
+  "ssh_username": "core",
+  "systemd_prefix": "/etc/systemd",
+  "sysusr_prefix": "/opt",
+  "sysusrlocal_prefix": "/opt"
+}

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -182,7 +182,7 @@
         "BUILD_NAME={{user `build_name`}}"
       ],
       "inline": [
-        "if [ $BUILD_NAME != \"flatcar\" ]; then exit 0; fi",
+        "if [[ $BUILD_NAME != \"flatcar\"* ]]; then exit 0; fi",
         "sudo bash -c \"/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent -force -deprovision+user && sync\""
       ],
       "inline_shebang": "/bin/bash -x",

--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -62,6 +62,10 @@ case ${SIG_TARGET} in
   centos-7-gen2)
     create_image_definition "centos-7.7-gen2" "centos-7.7-gen2" "V2" "Linux"
   ;;
+  flatcar-gen2)
+    SKU="flatcar-${FLATCAR_CHANNEL}-${FLATCAR_VERSION}-gen2"
+    create_image_definition "${SKU}" "${SKU}" "V2" "Linux"
+  ;;
   *)
     >&2 echo "Unsupported SIG target: '${SIG_TARGET}'"
     exit 1


### PR DESCRIPTION
What this PR does / why we need it:
* add support for building Flatcar Azure Gen2 SIG images
* fix handling for FLATCAR_VERSION=current; previously specifying it as make argument had different behavior than passing it in the environment
* fix appending local packer directory to path

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers