### PR TITLE
doc: add OCI to CAPI provider list

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -18,6 +18,7 @@ If any needed binaries are not present, they can be installed to `images/capi/.b
 * [Azure](./providers/azure.md)
 * [DigitalOcean](./providers/digitalocean.md)
 * [GCP](./providers/gcp.md)
+* [OCI](./providers/oci.md)
 * [OpenStack](./providers/openstack.md)
 * [Raw](./providers/raw.md)
 * [VirtualBox](./providers/virtualbox.md)


### PR DESCRIPTION
What this PR does / why we need it:
The Oracle Cloud Infrastructure (OCI) CAPI provider documentation was added as part of https://github.com/kubernetes-sigs/image-builder/pull/754. I want to make sure the provider list was had a link to it.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): No currently open issue for this

**Additional context**
Add any other context for the reviewers