### PR TITLE
Make al-2 images immutable by disabling security updates on boot.

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -106,3 +106,4 @@ pause_image: "k8s.gcr.io/pause:3.6"
 containerd_additional_settings: null
 leak_local_mdns_to_dns: false
 build_target: "virt"
+cloud_cfg_file: "/etc/cloud/cloud.cfg"

--- a/images/capi/ansible/roles/node/tasks/amazonLinux2.yml
+++ b/images/capi/ansible/roles/node/tasks/amazonLinux2.yml
@@ -18,3 +18,11 @@
     name: sysstat
     state: started
     enabled: yes
+
+# images need to be immutable once built
+# https://aws.amazon.com/amazon-linux-ami/faqs/
+- name: Disable security updates on boot
+  lineinfile:
+    path: "{{ cloud_cfg_file }}"
+    regexp: "^repo_upgrade: security"
+    line: 'repo_upgrade: none'

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -57,6 +57,7 @@
       },
       "temporary_security_group_source_cidrs": "{{ user `temporary_security_group_source_cidrs` }}",
       "type": "amazon-ebs",
+      "user_data": "#cloud-config\nrepo_upgrade: none",
       "vpc_id": "{{ user `vpc_id` }}"
     }
   ],


### PR DESCRIPTION
1. al-2 images run security updates on first boot of the base ami. This task sometimes is slow and tasks [here](https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/ansible/roles/setup/tasks/redhat.yml#L29) fail to obtain the yum lock in 60s and the image build fails. Since we update all packages in ansible, disabling this on first boot thru `user_data` in `packer.json` should not affect anything. 

2. According to this [FAQ](https://aws.amazon.com/amazon-linux-ami/faqs/), al-2 images always pull security updates on every boot making the image different from build time. To make the images immutable, `repo_upgrade: none` is added to the cloud.cfg. 

Thanks @codenrhoden for the pointers. 

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers
/assign @codenrhoden 