### PR TITLE
Added  qemu image support for opensuse 15.3 Cloud image

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -247,6 +247,7 @@ RHEL_VERSIONS			:=	rhel-7
 ROCKYLINUX_VERSIONS     :=  rockylinux-8
 UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi
 WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
+OPENSUSE_VERSIONS               :=      opensuse-153
 
 # Set Flatcar Container Linux channel and version if not supplied
 FLATCAR_CHANNEL ?= stable
@@ -262,7 +263,8 @@ PLATFORMS_AND_VERSIONS	:=	$(CENTOS_VERSIONS) \
 							$(RHEL_VERSIONS) \
 							$(ROCKYLINUX_VERSIONS) \
 							$(UBUNTU_VERSIONS) \
-							$(WINDOWS_VERSIONS)
+							$(WINDOWS_VERSIONS) \
+							$(OPENSUSE_VERSIONS)
 
 NODE_OVA_LOCAL_BUILD_NAMES			:=	$(addprefix node-ova-local-,$(PLATFORMS_AND_VERSIONS))
 NODE_OVA_LOCAL_VMX_BUILD_NAMES		:=	$(addprefix node-ova-local-vmx-,$(PLATFORMS_AND_VERSIONS))
@@ -286,7 +288,7 @@ OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-oracle-linux-8
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar qemu-opensuse-153
 
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004 raw-ubuntu-2004-efi
 VBOX_BUILD_NAMES			?=      vbox-windows-2019
@@ -573,6 +575,7 @@ build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-ubuntu-2004-efi: ## Builds Ubuntu 20.04 QEMU image that EFI boots
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
+build-qemu-opensuse-153: ## Builds openSuse 15.3  QEMU image from base cloud image containing cloud-init
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
 build-qemu-all: $(QEMU_BUILD_TARGETS) ## Builds all Qemu images

--- a/images/capi/ansible/roles/firstboot/meta/main.yml
+++ b/images/capi/ansible/roles/firstboot/meta/main.yml
@@ -21,6 +21,6 @@ dependencies:
 
   - role: setup
     vars:
-      rpms: "{{ ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
+      rpms: "{{ ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + suse15_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'Suse' and ansible_distribution_major_version == '15') else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
     when: packer_builder_type is search('qemu')

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -21,6 +21,9 @@
 - import_tasks: photon.yml
   when: kubernetes_source_type == "pkg" and ansible_os_family == "VMware Photon OS"
 
+- import_tasks: suse.yml
+  when: kubernetes_source_type == "pkg" and ansible_os_family == "Suse"
+
 - name: Symlink cri-tools
   file:
     src:   "/usr/local/bin/{{ item }}"

--- a/images/capi/ansible/roles/kubernetes/tasks/suse.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/suse.yml
@@ -1,0 +1,37 @@
+# Copyright 2018 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Add  Kubernetes rpm repository
+  zypper_repository:
+    name: kubernetes
+    description: Kubernetes package repository
+    repo: "{{ kubernetes_rpm_repo }}"
+    disable_gpg_check:  "{{ kubernetes_rpm_gpg_check }}"
+    autorefresh: true
+  register: kubernetes_repo_installation_rpm
+  until: kubernetes_repo_installation_rpm is success
+  retries: 15
+  delay: 60
+
+- name: Download kubernetes rpms
+  shell: 'echo {{ item }} && zypper --pkg-cache-dir /tmp download  {{ item }}'
+  loop:
+     - "kubelet-{{ kubernetes_rpm_version }}"
+     - "kubeadm-{{ kubernetes_rpm_version }}" 
+     - "kubectl-{{ kubernetes_rpm_version }}"
+     - "kubernetes-cni-{{kubernetes_cni_rpm_version }}"
+
+- name: Install  kubernetes rpms
+  shell: 'rpm -ivh --nodeps /tmp/kubernetes/Packages/*.rpm'

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -42,6 +42,14 @@ rh8_rpms:
 - python3-netifaces
 - python3-requests
 
+suse15_rpms:
+- ebtables
+- python-netifaces
+- python-requests
+- iptables
+- apparmor-parser
+- ethtool
+
 common_debs:
 - auditd
 - apt-transport-https

--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -27,7 +27,7 @@ dependencies:
 
   - role: setup
     vars:
-      rpms: "{{ ( common_photon_rpms + lookup('vars', 'common_' + build_target + '_photon_rpms') ) if ansible_os_family == 'VMware Photon OS' else ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
+      rpms: "{{ ( common_photon_rpms + lookup('vars', 'common_' + build_target + '_photon_rpms') ) if ansible_os_family == 'VMware Photon OS' else ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + suse15_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'Suse' and ansible_distribution_major_version == '15')  else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
     when: ansible_distribution != "Amazon" and not (packer_builder_type == "oracle-oci" and ansible_architecture == "aarch64") and
       not packer_builder_type is search('qemu')

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -69,7 +69,7 @@
     name: conntrackd
     state: stopped
     enabled: false
-  when: ansible_os_family != "Debian" and ansible_os_family != "Flatcar"
+  when: ansible_os_family != "Debian" and ansible_os_family != "Flatcar" and ansible_os_family != "Suse"
 
 - name: Ensure auditd is running and comes on at reboot
   service:

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -18,6 +18,9 @@
 - import_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
+- import_tasks: suse.yml
+  when: ansible_os_family == "Suse"
+
 - name: Configure PTP
   lineinfile:
     path: /etc/chrony/chrony.conf

--- a/images/capi/ansible/roles/providers/tasks/suse.yml
+++ b/images/capi/ansible/roles/providers/tasks/suse.yml
@@ -1,0 +1,19 @@
+- name: Import a key from a url
+  rpm_key:
+    state: present
+    key: "https://packages.microsoft.com/keys/microsoft.asc"
+
+- name: Add  azure-cli rpm repository
+  zypper_repository:
+    name: azure-cli
+    description: azure-cli package repository
+    repo: "https://packages.microsoft.com/yumrepos/azure-cli"
+    autorefresh: true
+  register: azure_cli_installation_rpm
+  until: azure_cli_installation_rpm is success
+  retries: 15
+  delay: 60
+- name: install azure-cli
+  zypper:
+    name: azure-cli
+    state: present

--- a/images/capi/ansible/roles/setup/tasks/main.yml
+++ b/images/capi/ansible/roles/setup/tasks/main.yml
@@ -27,6 +27,9 @@
 - import_tasks: photon.yml
   when: ansible_os_family == "VMware Photon OS"
 
+- import_tasks: suse.yml
+  when: ansible_os_family == "Suse"
+
 # Copy in pip config file when defined
 - name: Install pip config file
   copy:

--- a/images/capi/ansible/roles/setup/tasks/suse.yml
+++ b/images/capi/ansible/roles/setup/tasks/suse.yml
@@ -1,0 +1,24 @@
+# Copyright 2018 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: install baseline dependencies
+  zypper:
+    name: "{{ rpms }}"
+    state: present
+
+- name: install extra rpms
+  zypper:
+    name: "{{ extra_rpms.split() }}"
+    state: present

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -24,6 +24,9 @@
 - import_tasks: photon.yml
   when: ansible_os_family == "VMware Photon OS"
 
+- import_tasks: suse.yml
+  when: ansible_os_family == "Suse"
+
 - name: Remove containerd http proxy conf file if needed
   file:
     path: /etc/systemd/system/containerd.service.d/http-proxy.conf

--- a/images/capi/ansible/roles/sysprep/tasks/suse.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/suse.yml
@@ -1,0 +1,22 @@
+---
+- name: Define file modes
+  set_fact:
+    last_log_mode: "0664"
+    machine_id_mode: "0444"
+
+
+- name: Disable swap service and ensure it is masked
+  systemd:
+    name: temp-disk-swapfile
+    enabled: false
+    masked: true
+  when:
+    - ansible_memory_mb.swap.total != 0
+    - "'temp-disk-swapfile' in ansible_facts.services"
+
+
+- name: Remove zypper package cache
+  command: zypper clean -a
+
+- name: Reset network interface IDs
+  shell: sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network/ifcfg-*

--- a/images/capi/packer/ova/linux/opensuse/http/README
+++ b/images/capi/packer/ova/linux/opensuse/http/README
@@ -1,0 +1,1 @@
+Empty directory to support packer builds of cloud based images for opensuse. http kickstart files can be added with iso support  here

--- a/images/capi/packer/qemu/cloud-init/user-data
+++ b/images/capi/packer/qemu/cloud-init/user-data
@@ -1,0 +1,11 @@
+#cloud-config
+users:
+  - name: builder
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL
+ssh_pwauth: true
+disable_root: false
+chpasswd:
+  list: |
+     builder:linux
+  expire: False

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -8,9 +8,12 @@
         "{{user `boot_command_suffix`}}"
       ],
       "boot_wait": "{{user `boot_wait`}}",
+      "cd_files": "{{user `cd_files`}}",
+      "cd_label": "{{user `cd_label`}}",
       "cpus": "{{user `cpus`}}",
       "disk_compression": "{{ user `disk_compression`}}",
       "disk_discard": "{{user `disk_discard`}}",
+      "disk_image": "{{user `disk_image`}}",
       "disk_interface": "virtio-scsi",
       "disk_size": "{{user `disk_size`}}",
       "firmware": "{{user `firmware`}}",

--- a/images/capi/packer/qemu/qemu-opensuse-153.json
+++ b/images/capi/packer/qemu/qemu-opensuse-153.json
@@ -1,0 +1,18 @@
+{
+  "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3 extra_arguments =vvvv",
+  "build_name": "opensuse-153",
+  "cd_files": "./packer/qemu/cloud-init/user-data,./packer/qemu/cloud-init/meta-data",
+  "cd_label": "cidata",
+  "disk_image": "true",
+  "distro_arch": "amd64",
+  "distro_name": "opensuse",
+  "distro_version": "153",
+  "guest_os_type": "opensuse153-64",
+  "iso_checksum": "2ee8e4aab3088079d9eb4eaaf28c3c7f326075707c024f0770d734e5eeabe955",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://downloadcontent.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2",
+  "os_display_name": "openSuSE 153 JeOS",
+  "ssh_username": "builder",
+  "ssh_password": "linux",
+  "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
What this PR does / why we need it:
Adds support for building CAPI qemu/qcow2 images based of openSuse 15.3 cloud init JeOS images - https://en.opensuse.org/Portal:JeOS . 



Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Base image is provisioned with a cloud init script to bootstrap the initial user for ansible to execute all the image building tasks.
The rpm repos providing kubelet,kubeadm etc work directly with zypper. however some of the dependencies specifically conntrack isnt recognized by zypper even after installing it from suse repos. For this reason the kubelet and other rpms are downloaded from the repos and installed manually. 