### PR TITLE
fix: windows goss wrong provider on AWS

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -120,7 +120,7 @@
       "vars_file": "{{user `goss_vars_file`}}",
       "vars_inline": {
         "OS": "{{user `distribution` | lower}}",
-        "PROVIDER": "ami",
+        "PROVIDER": "amazon",
         "containerd_version": "{{user `containerd_version`}}",
         "distribution_version": "{{user `distribution_version`}}",
         "docker_ee_version": "{{user `docker_ee_version`}}",


### PR DESCRIPTION
What this PR does / why we need it:
Goss for windows builds on AWS didn't work previous this change because the goss configuration expects `amazon`, not `ami`. 
