### PR TITLE
Switch kubernetes_container_registry to registry.k8s.io

### DIFF
--- a/images/capi/packer/config/kubernetes.json
+++ b/images/capi/packer/config/kubernetes.json
@@ -3,7 +3,7 @@
   "crictl_source_type": "pkg",
   "crictl_version": "1.23.0",
   "kubeadm_template": "etc/kubeadm.yml",
-  "kubernetes_container_registry": "k8s.gcr.io",
+  "kubernetes_container_registry": "registry.k8s.io",
   "kubernetes_deb_gpg_key": "https://packages.cloud.google.com/apt/doc/apt-key.gpg",
   "kubernetes_deb_repo": "\"https://apt.kubernetes.io/ kubernetes-xenial\"",
   "kubernetes_deb_version": "1.21.10-00",


### PR DESCRIPTION
Context: please see https://groups.google.com/g/kubernetes-sig-testing/c/U7b_im9vRrM/m/7qywJeUTBQAJ

I am hoping this is the right spot to be able to switch all CAP* CI jobs to use the new registry endpoint. Please do keep an eye on the CI jobs for any flakiness etc. We (Arnaud and i) will be monitoring the graphs for the oci-proxy as well. This is small and focused enough that we can flip it back if we run into problems.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers