### PR TITLE
Adding support for Kubevirt capi images

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -301,6 +301,7 @@ OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-oracle-linux-8
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar
 VBOX_BUILD_NAMES			?=      vbox-windows-2019
@@ -333,6 +334,8 @@ DO_BUILD_TARGETS 	:= $(addprefix build-,$(DO_BUILD_NAMES))
 DO_VALIDATE_TARGETS 	:= $(addprefix validate-,$(DO_BUILD_NAMES))
 QEMU_BUILD_TARGETS	:= $(addprefix build-,$(QEMU_BUILD_NAMES))
 QEMU_VALIDATE_TARGETS	:= $(addprefix validate-,$(QEMU_BUILD_NAMES))
+QEMU_KUBEVIRT_BUILD_TARGETS := $(addprefix build-,$(QEMU_KUBEVIRT_BUILD_NAMES))
+QEMU_KUBEVIRT_VALIDATE_TARGETS := $(addprefix validate-,$(QEMU_KUBEVIRT_BUILD_NAMES))
 RAW_BUILD_TARGETS      := $(addprefix build-,$(RAW_BUILD_NAMES))
 RAW_VALIDATE_TARGETS   := $(addprefix validate-,$(RAW_BUILD_NAMES))
 OCI_BUILD_TARGETS	:= $(addprefix build-,$(OCI_BUILD_NAMES))
@@ -433,6 +436,14 @@ $(QEMU_BUILD_TARGETS): deps-qemu
 .PHONY: $(QEMU_VALIDATE_TARGETS)
 $(QEMU_VALIDATE_TARGETS): deps-qemu
 	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+
+.PHONY: $(QEMU_KUBEVIRT_BUILD_TARGETS)
+$(QEMU_KUBEVIRT_BUILD_TARGETS): deps-qemu
+	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-kubevirt-,,$@).json)" --var 'kubevirt=true' $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+
+.PHONY: $(QEMU_KUBEVIRT_VALIDATE_TARGETS)
+$(QEMU_KUBEVIRT_VALIDATE_TARGETS): deps-qemu
+	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-kubevirt-,,$@).json)" --var 'kubevirt=true' $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
 
 .PHONY: $(RAW_BUILD_TARGETS)
 $(RAW_BUILD_TARGETS): deps-raw

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -217,3 +217,9 @@
     state: absent
     path: /usr/share/oem/config.ign
   when: ansible_os_family == "Flatcar"
+
+- name: start ssh
+  systemd:
+    name: ssh
+    enabled: yes
+  when: ansible_os_family == "Debian"

--- a/images/capi/kubevirt-Dockerfile
+++ b/images/capi/kubevirt-Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest AS builder                                                
+ADD --chown=107:107  /disk/image.qcow2                                            
+                                                                                                                
+FROM scratch                                                                                                    
+COPY --from=builder /disk/* /disk/

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -42,6 +42,22 @@
       ],
       "name": "custom-post-processor",
       "type": "shell-local"
+    },
+    {
+      "environment_vars": [
+        "OUTPUT_DIR={{user `output_directory`}}",
+        "ARTIFACT_NAME={{user `artificat_name`}}",
+        "KUBEVIRT={{user `kubevirt`}}"
+      ],
+      "inline": [
+        "if [ \"$KUBEVIRT\" != \"true\" ]; then",
+        "exit 0",
+        "else",
+        "bash ./packer/qemu/scripts/build_kubevirt_image.sh {{user `build_name`}}-container-disk",
+        "fi"
+      ],
+      "name": "kubevirt",
+      "type": "shell-local"
     }
   ],
   "provisioners": [
@@ -125,6 +141,7 @@
     "ansible_common_vars": "",
     "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
     "ansible_user_vars": "",
+    "artificat_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
     "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",

--- a/images/capi/packer/qemu/scripts/build_kubevirt_image.sh
+++ b/images/capi/packer/qemu/scripts/build_kubevirt_image.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "OUTPUT_DIR:$OUTPUT_DIR"
+echo "ARTIFACT_NAME:$ARTIFACT_NAME"
+echo "########"
+env
+cd $OUTPUT_DIR
+
+echo "FROM registry.access.redhat.com/ubi8/ubi:latest AS builder                                                
+ADD --chown=107:107 $ARTIFACT_NAME /disk/image.qcow2                                            
+                                                                                                                
+FROM scratch                                                                                                    
+COPY --from=builder /disk/* /disk/" > ./kubevirt-Dockerfile
+
+docker build -f ./kubevirt-Dockerfile . -t $1


### PR DESCRIPTION
What this PR does / why we need it:
Add support for kubevirt images(structured as qemu file in a container image) using the command "make build-kubevirt-qemu-ubuntu-2004" inside "images/capi".

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers