### PR TITLE
Disable Hyper-V KVP protocol daemon on GCE ubuntu images

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/googlecompute.yml
+++ b/images/capi/ansible/roles/providers/tasks/googlecompute.yml
@@ -38,3 +38,10 @@
     path: "/bin/{{ item.path | basename }}"
     state: link
   with_items: "{{ find.files }}"
+
+- name: Disable Hyper-V KVP protocol daemon on Ubuntu
+  systemd:
+    name: hv-kvp-daemon
+    state: stopped
+    enabled: false
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
What this PR does / why we need it:

GCE is not built on Hyper-V, so waiting for "Hyper-V KVP protocol daemon" (to fail) during boot needlessly introduces 1m30s of scale-up delay.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #848 

**Additional context**
Just to be safe I built both images (-1804 and -2004) with this change and tested spinning up clusters with them, which - as expected - worked fine and was a lot faster than before.