### PR TITLE
Fix tdnf install in firstboot role

### DIFF
--- a/images/capi/ansible/roles/firstboot/meta/main.yml
+++ b/images/capi/ansible/roles/firstboot/meta/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubernetes Authors.
+# Copyright 2022 The Kubernetes Authors.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# no-op task just to have something for the role to do. Right now
-# all the work happens in the setup role
-- meta: noop
+---
+dependencies:
+  - role: setup
+    vars:
+      rpms: ""
+      debs: ""
+    when: ansible_os_family == "VMware Photon OS"

--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -33,6 +33,7 @@
 
 - name: install baseline dependencies
   command: tdnf install {{ photon_rpms }} -y
+  when: photon_rpms != ""
 
 - name: install extra RPMs
   command: tdnf install {{ extra_rpms }} -y


### PR DESCRIPTION
What this PR does / why we need it:
The `tdnf` command in the `firstboot` role is happening before any custom
repos are put in place. This means that if you happen to define a
private or internal mirror to use instead of a public one, the `firstboot`
role ignores this and uses the public repo anyways.

The logic in the `setup` role (meant to be used as a dependency) already
accounts for this, and needs to be used instead.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
/assign @kkeshavamurthy 