### PR TITLE
Absolute in Windows kubelet don't work < 1.23

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/kubelet.yml
@@ -22,6 +22,12 @@
     - '{{ systemdrive.stdout | trim }}\etc\kubernetes\manifests'
     - '{{ systemdrive.stdout | trim }}\etc\kubernetes\pki'
 
+# this is required in 1.22 and below due to invalid absolute path handling
+# https://github.com/kubernetes-sigs/image-builder/issues/853
+- name: Symlink kubelet pki folder
+  win_shell: New-Item -path $env:SystemDrive\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value  $env:SystemDrive\etc\kubernetes\pki\ -Force
+  when: kubernetes_semver is version('v1.23.0', '<')
+
 - import_tasks: nssm.yml
   when: windows_service_manager == "nssm"
 


### PR DESCRIPTION
What this PR does / why we need it:

Absolute paths didn't work with kubelet CA paths prior to 1.23: https://github.com/kubernetes/kubernetes/pull/105992.  

To handle this we need to symlink the appropriate path if 1.22 or less after we re-aligned paths in https://github.com/kubernetes-sigs/image-builder/pull/785

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #853

**Additional context**
Add any other context for the reviewers

/sig windows
/assign @knabben 