### PR TITLE
Fix building Flatcar images for Flatcar stable releases after 3139.2.0

### DIFF
--- a/images/capi/ansible/python.yml
+++ b/images/capi/ansible/python.yml
@@ -13,6 +13,8 @@
 # limitations under the License.
 ---
 - hosts: all
+  # Gathering facts requires Python to be available, so it's a chicken and egg
+  # problem as this playbook installs Python.
   gather_facts: no
   become: yes
 

--- a/images/capi/ansible/roles/python/tasks/main.yml
+++ b/images/capi/ansible/roles/python/tasks/main.yml
@@ -17,5 +17,6 @@
   register: distrib_id
 
 - include_tasks: flatcar.yml
+  # We can't use ansible_os_family fact here for consistency, as facts gathering
+  # is disabled in the playbook which includes this role. See playbook for more details.
   when: distrib_id.stdout_lines[0] is search("Flatcar")
-

--- a/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
@@ -21,3 +21,14 @@
     ansible_python_interpreter: "{{ bin_dir }}/python"
   tags:
     - facts
+
+# Some tasks are not compatible with Flatcar, so to centralize and deduplicate the logic of checking
+# if we run on Flatcar, we define it here.
+#
+# This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
+- name: Override Flatcar's OS family
+  set_fact:
+    ansible_os_family: Flatcar
+  when: ansible_os_family == "Flatcar Container Linux by Kinvolk"
+  tags:
+    - facts

--- a/images/capi/ansible/roles/setup/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/flatcar.yml
@@ -12,16 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Fetch /etc/os-release
-  raw: cat /etc/os-release
-  register: os_release
-  changed_when: false
-  # This command should always run, even in check mode
-  check_mode: false
-  environment: {}
-
 - include_tasks: bootstrap-flatcar.yml
-  when: '"Flatcar" in os_release.stdout'
 
 - name: Create /opt/libexec overlay directories
   file:

--- a/images/capi/ansible/roles/setup/tasks/main.yml
+++ b/images/capi/ansible/roles/setup/tasks/main.yml
@@ -16,7 +16,10 @@
   when: ansible_os_family == "Debian"
 
 - import_tasks: flatcar.yml
-  when: ansible_os_family == "Flatcar"
+  # This task overrides ansible_os_family to "Flatcar" as a workaround for
+  # regression between Flatcar and Ansible, so rest of the code can use just
+  # "Flatcar" for comparison, which is the correct value.
+  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - import_tasks: redhat.yml
   when: ansible_os_family == "RedHat"

--- a/images/capi/packer/azure/flatcar.json
+++ b/images/capi/packer/azure/flatcar.json
@@ -8,6 +8,7 @@
   "image_offer": "flatcar-container-linux-free",
   "image_publisher": "kinvolk",
   "image_sku": "{{env `FLATCAR_CHANNEL`}}",
+  "image_version": "{{env `FLATCAR_VERSION` }}",
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
   "plan_image_offer": "{{user `image_offer`}}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -49,6 +49,7 @@
       "image_offer": "{{user `image_offer` }}",
       "image_publisher": "{{user `image_publisher` }}",
       "image_sku": "{{user `image_sku`}}",
+      "image_version": "{{user `image_version`}}",
       "location": "{{user `azure_location`}}",
       "managed_image_name": "{{user `image_name`}}-{{user `build_timestamp`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",


### PR DESCRIPTION
What this PR does / why we need it:

Fixes for building Flatcar Azure SIG images related to recent regression. See commit messages for more details.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Closes #862
Closes #861 