### PR TITLE
Set transparent huge pages to madvise

### DIFF
--- a/images/capi/ansible/roles/firstboot/tasks/photon.yml
+++ b/images/capi/ansible/roles/firstboot/tasks/photon.yml
@@ -14,4 +14,11 @@
 
 # no-op task just to have something for the role to do. Right now
 # all the work happens in the setup role
-- meta: noop
+# - meta: noop
+
+- name: Set transparent huge pages to madvise
+  lineinfile:
+    path: /boot/photon.cfg
+    backrefs: yes
+    regexp: "^(?!.*transparent_hugepage=madvise)(photon_cmdline.*)"
+    line: '\1 transparent_hugepage=madvise'

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -95,3 +95,11 @@
     sysctl_set: yes
     reload: yes
   when: ansible_distribution == "Ubuntu"
+
+- name: Set transparent huge pages to madvise
+  lineinfile:
+    path: /etc/default/grub
+    backrefs: yes
+    regexp: "^(?!.*transparent_hugepage=madvise)(GRUB_CMDLINE_LINUX=.*)(\"$)"
+    line: '\1 transparent_hugepage=madvise"'
+  when: ansible_os_family == "RedHat"

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -59,6 +59,13 @@ command:
     stderr: []
     timeout: 0
 {{end}}
+{{if eq .Vars.OS "photon"}}
+  cat /sys/kernel/mm/transparent_hugepage/enabled:
+    exit-status: 0
+    stdout: ["always [madvise] never"]
+    stderr: []
+    timeout: 0
+{{end}}
 {{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "command"}}
   {{ $name }}:
   {{range $key, $val := $vers}}


### PR DESCRIPTION
Photon defaults to always using transparent huge pages. This is fine for desktops but is risky for servers. Some applications can lose up to 30% performance. Setting it to `madvise` can help with this.

Ubuntu 20.04 has this set to `madvise` by default. This PR is to add and make it uniform across all -EL distros. 
A corresponding GOSS test ensures this setting is applied.

/cc @codenrhoden 