### PR TITLE
Add support for RHEL 8 OVA builds

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -222,7 +222,7 @@ PACKER_WINDOWS_NODE_FLAGS := $(foreach f,$(abspath $(COMMON_WINDOWS_VAR_FILES)),
 CENTOS_VERSIONS			:=	centos-7
 FLATCAR_VERSIONS		:=	flatcar
 PHOTON_VERSIONS			:=	photon-3
-RHEL_VERSIONS			:=	rhel-7
+RHEL_VERSIONS			:=	rhel-7 rhel-8
 ROCKYLINUX_VERSIONS     :=  rockylinux-8
 UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi
 WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
@@ -486,6 +486,7 @@ build-gce-all: $(GCE_BUILD_TARGETS) ## Builds all GCE image
 build-node-ova-local-centos-7: ## Builds CentOS 7 Node OVA w local hypervisor
 build-node-ova-local-photon-3: ## Builds Photon 3 Node OVA w local hypervisor
 build-node-ova-local-rhel-7: ## Builds RHEL 7 Node OVA w local hypervisor
+build-node-ova-local-rhel-8: ## Builds RHEL 8 Node OVA w local hypervisor
 build-node-ova-local-rockylinux-8: ## Builds RockyLinux 8 Node OVA w local hypervisor
 build-node-ova-local-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA w local hypervisor
 build-node-ova-local-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA w local hypervisor
@@ -496,6 +497,7 @@ build-node-ova-local-all: $(NODE_OVA_LOCAL_BUILD_TARGETS) ## Builds all Node OVA
 build-node-ova-vsphere-centos-7: ## Builds CentOS 7 Node OVA and template on vSphere
 build-node-ova-vsphere-photon-3: ## Builds Photon 3 Node OVA and template on vSphere
 build-node-ova-vsphere-rhel-7: ## Builds RHEL 7 Node OVA and template on vSphere
+build-node-ova-vsphere-rhel-8: ## Builds RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
@@ -508,6 +510,7 @@ build-node-ova-vsphere-all: $(NODE_OVA_VSPHERE_BUILD_TARGETS) ## Builds all Node
 build-node-ova-vsphere-clone-centos-7: ## Builds CentOS 7 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-photon-3: ## Builds Photon 3 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-rhel-7: ## Builds RHEL 7 Node OVA and template on vSphere
+build-node-ova-vsphere-clone-rhel-8: ## Builds RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
@@ -516,6 +519,7 @@ build-node-ova-vsphere-clone-all: $(NODE_OVA_VSPHERE_CLONE_BUILD_TARGETS) ## Bui
 build-node-ova-vsphere-base-centos-7: ## Builds base CentOS 7 Node OVA and template on vSphere
 build-node-ova-vsphere-base-photon-3: ## Builds base Photon 3 Node OVA and template on vSphere
 build-node-ova-vsphere-base-rhel-7: ## Builds base RHEL 7 Node OVA and template on vSphere
+build-node-ova-vsphere-base-rhel-8: ## Builds base RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-base-rockylinux-8: ## Builds base RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-1804: ## Builds base Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2004: ## Builds base Ubuntu 20.04 Node OVA and template on vSphere
@@ -524,6 +528,7 @@ build-node-ova-vsphere-base-all: $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS) ## Build
 build-node-ova-local-vmx-photon-3: ## Builds Photon 3 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-centos-7: ## Builds Centos 7 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-rhel-7: ## Builds RHEL 7 Node OVA from VMX file w local hypervisor
+build-node-ova-local-vmx-rhel-8: ## Builds RHEL 8 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-rockylinux-8: ## Builds RockyLinux 8 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA from VMX file w local hypervisor
@@ -531,6 +536,7 @@ build-node-ova-local-vmx-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA from VMX f
 build-node-ova-local-base-photon-3: ## Builds Photon 3 Base Node OVA w local hypervisor
 build-node-ova-local-base-centos-7: ## Builds Centos 7 Base Node OVA w local hypervisor
 build-node-ova-local-base-rhel-7: ## Builds RHEL 7 Base Node OVA w local hypervisor
+build-node-ova-local-base-rhel-8: ## Builds RHEL 8 Base Node OVA w local hypervisor
 build-node-ova-local-base-rockylinux-8: ## Builds RockyLinux 8 Base Node OVA w local hypervisor
 build-node-ova-local-base-ubuntu-1804: ## Builds Ubuntu 18.04 Base Node OVA w local hypervisor
 build-node-ova-local-base-ubuntu-2004: ## Builds Ubuntu 20.04 Base Node OVA w local hypervisor
@@ -602,6 +608,7 @@ validate-gce-all: $(GCE_VALIDATE_TARGETS) ## Validates all GCE Snapshot Packer c
 validate-node-ova-local-centos-7: ## Validates CentOS 7 Node OVA Packer config w local hypervisor
 validate-node-ova-local-photon-3: ## Validates Photon 3 Node OVA Packer config w local hypervisor
 validate-node-ova-local-rhel-7: ## Validates RHEL 7 Node OVA Packer config w local hypervisor
+validate-node-ova-local-rhel-8: ## Validates RHEL 8 Node OVA Packer config w local hypervisor
 validate-node-ova-local-rockylinux-8: ## Validates RockyLinux 8 Node OVA Packer config w local hypervisor
 validate-node-ova-local-ubuntu-1804: ## Validates Ubuntu 18.04 Node OVA Packer config w local hypervisor
 validate-node-ova-local-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA Packer config w local hypervisor
@@ -613,6 +620,7 @@ validate-node-ova-local-all: $(NODE_OVA_LOCAL_VALIDATE_TARGETS) ## Validates all
 validate-node-ova-local-vmx-photon-3: ## Validates Photon 3 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-centos-7: ## Validates Centos 7 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-rhel-7: ## Validates RHEL 7 Node OVA from VMX file w local hypervisor
+validate-node-ova-local-vmx-rhel-8: ## Validates RHEL 8 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-rockylinux-8: ## Validates RockyLinux 8 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-ubuntu-1804: ## Validates Ubuntu 18.04 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA from VMX file w local hypervisor
@@ -620,6 +628,7 @@ validate-node-ova-local-vmx-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA from
 validate-node-ova-local-base-photon-3: ## Validates Photon 3 Base Node OVA w local hypervisor
 validate-node-ova-local-base-centos-7: ## Validates Centos 7 Base Node OVA w local hypervisor
 validate-node-ova-local-base-rhel-7: ## Validates RHEL 7 Base Node OVA w local hypervisor
+validate-node-ova-local-base-rhel-8: ## Validates RHEL 8 Base Node OVA w local hypervisor
 validate-node-ova-local-base-rockylinux-8: ## Validates RockyLinux 8 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-1804: ## Validates Ubuntu 18.04 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-2004: ## Validates Ubuntu 20.04 Base Node OVA w local hypervisor

--- a/images/capi/hack/generate-goss-specs.py
+++ b/images/capi/hack/generate-goss-specs.py
@@ -30,7 +30,7 @@ builds = {'amazon': ['amazon linux', 'centos', 'flatcar', 'ubuntu', 'windows'],
 
 def generate_goss(provider, system, versions, runtime, dryrun=False, save=False):
     cmd = ['goss', '-g', 'packer/goss/goss.yaml', '--vars', 'packer/goss/goss-vars.yaml']
-    vars = {'OS': system, 'PROVIDER': provider,
+    vars = {'OS': system, 'OS_DISTRO_VERSION': versions["os"], 'PROVIDER': provider,
             'containerd_version': versions['containerd'],
             'docker_ee_version': versions['docker'],
             'distribution_version': versions['os'],

--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -111,6 +111,7 @@ def main():
                  "centos7-64": {"id": "107", "version": "7", "type": "centos7-64"},
                  "centos8-64": {"id": "107", "version": "8", "type": "centos8-64"},
                  "rhel7-64": {"id": "80", "version": "7", "type": "rhel7_64guest"},
+                 "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64guest"},
                  "ubuntu-64": {"id": "94", "version": "", "type": "ubuntu64Guest"},
                  "Windows2019Server-64": {"id": "112", "version": "", "type": "windows9srv-64"},
                  "Windows2004Server-64": {"id": "112", "version": "", "type": "windows9srv-64"}}

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -127,6 +127,7 @@
       "vars_inline": {
         "ARCH": "amd64",
         "OS": "{{user `distribution` | lower}}",
+        "OS_DISTRO_VERSION": "{{user `distro_version`}}",
         "PROVIDER": "amazon",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -164,6 +164,7 @@
       "vars_inline": {
         "ARCH": "amd64",
         "OS": "{{user `distribution` | lower}}",
+        "OS_DISTRO_VERSION": "{{user `distro_version`}}",
         "PROVIDER": "azure",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",

--- a/images/capi/packer/goss/README.md
+++ b/images/capi/packer/goss/README.md
@@ -1,0 +1,46 @@
+# Imagebuilder Goss validation
+
+The Imagebuilder project uses [Goss](https://github.com/aelsabbahy/goss) in the post-build stage
+to validate that the built images conform to the specified CAPI requirements in terms of installed packages,
+running services, files, etc.
+
+Refer to the [Goss documentation](https://image-builder.sigs.k8s.io/capi/goss/goss.html) in the Imagebuilder book for more information.
+
+## Testing package installation across versions of an OS distribution
+
+Verifying packages installation is a common usecase for Goss. Imagebuilder provides support for building multiple versions of the same OS, for example, RHEL 7 and RHEL 8 for the OVA provider. Often, the packages installed in one version will be different from those in the other. To add Goss validations for such cases, you can use the `versioned` field in `goss-vars.yaml` to separate the package listing for each supported distro versions, and Goss will pick the appropriate list of packages depending upon the provider, OS and version you are building.
+
+### Example
+
+Using the following configuration, RHEL 7 and RHEL 8 ova builds can validate a different set of package requirements, in
+addition to common packages that both are expected to have.
+
+```yaml
+# This defines a set of RPMs to test for RHEL 7 builds
+rh7_rpms: &rh7_rpms
+  ebtables:
+  python2-pip:
+  python-netifaces:
+  python-requests:
+
+# This defines a set of RPMs to test for RHEL 8 builds
+rh8_rpms: &rh8_rpms
+  nftables:
+  python3-pip:
+  python3-netifaces:
+  python3-requests:
+
+rhel:
+  ova:
+    package: # These are common packages that both versions of RHEL OVA must have installed
+      open-vm-tools:
+      yum-utils:
+      vim:
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms # This will be populated with the above RPMs for RHEL 7
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms # This will be populated with the above RPMs for RHEL 8
+```

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -56,6 +56,21 @@ package:
   {{end}}
 {{end}}
 
+# Looping over provider specific packages for an OS that differ by version
+# For example, between RHEL 7 and RHEL 8 
+{{$distro_version := .Vars.OS_DISTRO_VERSION}}
+{{range $component := index .Vars .Vars.OS .Vars.PROVIDER "versioned"}}
+{{if eq $distro_version (index $component "distro_version")}}
+  {{ range $name, $vers := index $component "package"}}
+  {{$name}}:
+    installed: true
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+  {{end}}
+{{end}}
+{{end}}
+
 {{end}}
 {{ if eq .Vars.OS "windows"}} # Windows
 # Workaround until windows features are added to goss

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -115,7 +115,10 @@ centos:
   amazon:
     package:
       amazon-ssm-agent:
-      <<: *rh7_rpms
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
     command:
       pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
         exit-status: 0
@@ -130,14 +133,20 @@ centos:
     package:
       python2-pip:
       open-vm-tools:
-      <<: *rh7_rpms
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
   qemu:
     package:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
       python2-pip:
-      <<: *rh7_rpms
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
   raw:
     package:
       cloud-init:
@@ -189,7 +198,10 @@ rockylinux:
   amazon:
     package:
       amazon-ssm-agent:
-      <<: *rh8_rpms
+    versioned:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
     command:
       pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
         exit-status: 0
@@ -204,40 +216,67 @@ rockylinux:
     package:
       open-vm-tools:
       python2-pip:
-      <<: *rh8_rpms
+    versioned:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
   qemu:
     package:
       open-vm-tools:
       cloud-init:
       cloud-utils:
       python3-netifaces:
-      <<: *rh8_rpms
+    versioned:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
   raw:
     package:
       cloud-init:
       cloud-utils:
       python3-netifaces:
-      <<: *rh8_rpms
+    versioned:
+      - distro_version: "8"
+        package:
+          <<: *rh8_rpms
 rhel:
   common-package: *common_rpms
   ova:
     package:
       python2-pip:
       open-vm-tools:
-      <<: *rh7_rpms
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
   qemu:
     package:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
       python2-pip:
-      <<: *rh7_rpms
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
   raw:
     package:
       cloud-init:
       cloud-utils-growpart:
       python2-pip:
-      <<: *rh7_rpms
+    versioned:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
 ubuntu:
   common-kernel-param:
     net.ipv4.conf.all.rp_filter:

--- a/images/capi/packer/ova/linux/centos/http/8/ks.cfg
+++ b/images/capi/packer/ova/linux/centos/http/8/ks.cfg
@@ -46,6 +46,7 @@ openssh-server
 sed
 sudo
 python3
+open-vm-tools
 
 # Exclude unnecessary firmwares
 -iwl*firmware

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -398,6 +398,7 @@
       "vars_inline": {
         "ARCH": "amd64",
         "OS": "{{user `distro_name` | lower}}",
+        "OS_DISTRO_VERSION": "{{user `distro_version`}}",
         "PROVIDER": "ova",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",

--- a/images/capi/packer/ova/rhel-8.json
+++ b/images/capi/packer/ova/rhel-8.json
@@ -1,0 +1,19 @@
+{
+  "boot_command_prefix": "<up><tab> text inst.ks=",
+  "boot_command_suffix": "/8/ks.cfg<enter><wait>",
+  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+  "build_name": "rhel-8",
+  "distro_arch": "amd64",
+  "distro_name": "rhel",
+  "distro_version": "8",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
+  "guest_os_type": "rhel8-64",
+  "http_directory": "./packer/ova/linux/{{user `distro_name`}}/http/",
+  "iso_checksum": "48f955712454c32718dcde858dea5aca574376a1d7a4b0ed6908ac0b85597811",
+  "iso_checksum_type": "sha256",
+  "iso_url": "file:///rhel-8.4-x86_64-dvd.iso",
+  "os_display_name": "RHEL 8",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+  "shutdown_command": "shutdown -P now",
+  "vsphere_guest_os_type": "rhel8_64Guest"
+}

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -124,6 +124,7 @@
       "vars_inline": {
         "ARCH": "amd64",
         "OS": "{{user `distro_name` | lower}}",
+        "OS_DISTRO_VERSION": "{{user `distro_version`}}",
         "PROVIDER": "raw",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds the necessary changes required to build RHEL 8 OVAs on vSphere. Tested on vSphere 6.7 with RHEL 8.4 DVD ISO.

* RHEL 8 removed floppy support so using Packer's local HTTP server to host kickstart files.
* Updated Goss validation to check for RHEL 8 rpms
* Added RHEL 8 to OS ID map

/cc @kkeshavamurthy @codenrhoden