### PR TITLE
feat: expose security group and ssh variables in capi packer ami

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -28,6 +28,7 @@
       "profile": "{{ user `aws_profile`}}",
       "region": "{{ user `aws_region` }}",
       "secret_key": "{{user `aws_secret_key`}}",
+      "security_group_ids": "{{user `aws_security_group_ids`}}",
       "skip_create_ami": "{{ user `skip_create_ami`}}",
       "skip_profile_validation": "{{user `skip_profile_validation`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
@@ -43,6 +44,8 @@
         "most_recent": true,
         "owners": "{{user `ami_filter_owners`}}"
       },
+      "ssh_keypair_name": "{{user `ssh_keypair_name`}}",
+      "ssh_private_key_file": "{{user `ssh_private_key_file`}}",
       "subnet_id": "{{ user `subnet_id` }}",
       "tags": {
         "build_date": "{{isotime}}",
@@ -164,6 +167,7 @@
     "aws_profile": "",
     "aws_region": "us-east-1",
     "aws_secret_key": "",
+    "aws_security_group_ids": "",
     "build_name": null,
     "build_timestamp": "{{timestamp}}",
     "builder_instance_type": "t3.large",
@@ -187,6 +191,8 @@
     "skip_profile_validation": "false",
     "snapshot_groups": "all",
     "snapshot_users": "",
+    "ssh_keypair_name": "",
+    "ssh_private_key_file": "",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "throughput": "125",

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -26,6 +26,7 @@
       "profile": "{{ user `aws_profile`}}",
       "region": "{{ user `aws_region` }}",
       "secret_key": "{{user `aws_secret_key`}}",
+      "security_group_ids": "{{user `aws_security_group_ids`}}",
       "skip_create_ami": "{{ user `skip_create_ami`}}",
       "skip_profile_validation": "{{user `skip_profile_validation`}}",
       "snapshot_groups": "{{user `snapshot_groups`}}",
@@ -41,6 +42,8 @@
         "most_recent": true,
         "owners": "{{user `ami_filter_owners`}}"
       },
+      "ssh_keypair_name": "{{user `ssh_keypair_name`}}",
+      "ssh_private_key_file": "{{user `ssh_private_key_file`}}",
       "ssh_username": "{{user `ssh_username`}}",
       "subnet_id": "{{ user `subnet_id` }}",
       "tags": {
@@ -153,6 +156,7 @@
     "aws_profile": "",
     "aws_region": "us-east-1",
     "aws_secret_key": "",
+    "aws_security_group_ids": "",
     "build_timestamp": "{{timestamp}}",
     "builder_instance_type": "t3.small",
     "containerd_sha256": null,
@@ -189,6 +193,8 @@
     "skip_profile_validation": "false",
     "snapshot_groups": "all",
     "snapshot_users": "",
+    "ssh_keypair_name": "",
+    "ssh_private_key_file": "",
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "throughput": "125",


### PR DESCRIPTION
What this PR does / why we need it:

- allow overriding security_group_ids
- allow overriding ssh_keypair_name
- allow overriding ssh_private_key_file

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

N/A

**Additional context**
We need to be able to provide these variables for our AWS environments so it would be great to have them available. 