### PR TITLE
ami: Use cloud-init only on supported distros

### DIFF
--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -12,5 +12,6 @@
   "ssh_username": "core",
   "systemd_prefix": "/etc/systemd",
   "sysusr_prefix": "/opt",
-  "sysusrlocal_prefix": "/opt"
+  "sysusrlocal_prefix": "/opt",
+  "user_data": ""
 }

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -57,7 +57,7 @@
       },
       "temporary_security_group_source_cidrs": "{{ user `temporary_security_group_source_cidrs` }}",
       "type": "amazon-ebs",
-      "user_data": "#cloud-config\nrepo_upgrade: none",
+      "user_data": "{{ user `user_data` }}",
       "vpc_id": "{{ user `vpc_id` }}"
     }
   ],
@@ -192,6 +192,7 @@
     "subnet_id": "",
     "temporary_security_group_source_cidrs": "",
     "throughput": "125",
+    "user_data": "#cloud-config\nrepo_upgrade: none",
     "volume_size": "8",
     "volume_type": "gp3",
     "vpc_id": ""


### PR DESCRIPTION
What this PR does / why we need it:

Not all Linux distros support cloud-init. Flatcar Container Linux, for example, uses Ignition as a bootstrap format.

In #837, a cloud-init user data script was added **for all distros**.

- Move user_data to a variable to allow per-distro overrides.
- Set the default to the existing cloud-init script.
- Override to an empty script for Flatcar.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
While we're at it, the cloud-init snippet added in #837 seems to be specific for Amazon Linux. Are there no side effects on other distros? IMO we may want to consider setting the `user_data` var to `""` for all distros except Amazon Linux.

cc @kkeshavamurthy