### PR TITLE
Use com2 serial port for logging on Azure

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -190,7 +190,7 @@
     "client_id": null,
     "client_secret": null,
     "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/{{user `cloudbase_init_version`}}/CloudbaseInitSetup_{{user `cloudbase_init_version` | replace_all `.` `_` }}_x64.msi",
-    "cloudbase_logging_serial_port": "COM1,115200,N,8",
+    "cloudbase_logging_serial_port": "COM2,115200,N,8",
     "cloudbase_metadata_services": "cloudbaseinit.metadata.services.azureservice.AzureService",
     "cloudbase_metadata_services_unattend": "cloudbaseinit.metadata.services.base.EmptyMetadataService",
     "cloudbase_plugins": "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin, cloudbaseinit.plugins.windows.azureguestagent.AzureGuestAgentPlugin, cloudbaseinit.plugins.common.mtu.MTUPlugin, cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin",

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -376,7 +376,7 @@ windows:
         exists: true
         filetype: file
         contains:
-        - "COM1,115200,N,8"
+        - "COM2,115200,N,8"
         - "metadata_services=cloudbaseinit.metadata.services.azureservice.AzureService"
         - "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin"
         - "cloudbaseinit.plugins.windows.azureguestagent.AzureGuestAgentPlugin"


### PR DESCRIPTION
What this PR does / why we need it:
It was identified that the [logging on cloudbase-init wasn't working properly for Azure vms](https://github.com/kubernetes/kubernetes/issues/109444#issuecomment-1113815615). This puts uses the correct COM port so the VM's serial logs can be viewed in case of provisioning errors.

On an azure vm:

```
PS C:\Users\capi> &'C:\Program Files\Cloudbase Solutions\Cloudbase-Init\Python\python.exe' -m serial.tools.list_por
ts
COM2
1 ports found
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/sig windows
/assign @claudiubelu 