### PR TITLE
unpin WS 2022 image

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -65,7 +65,7 @@
 
 # Find KB Article numbers:
 #  - WS 2019 https://support.microsoft.com/en-us/help/4464619
-#  - WS 2022 https://support.microsoft.com/en-us/topic/windows-server-2022-update-history-e1caa597-00c5-4ab9-9f3e-8212fe80b2ee
+#  - WS 2022 https://support.microsoft.com/topic/windows-server-2022-update-history-e1caa597-00c5-4ab9-9f3e-8212fe80b2ee
 # Task to install specific updates by KB. All categories are specified as the module
 # won't install the update unless the category matches. Setting windows_updates_kbs_numbers to []
 # will skip this task.

--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -65,7 +65,7 @@
 
 # Find KB Article numbers:
 #  - WS 2019 https://support.microsoft.com/en-us/help/4464619
-#  - WS 2004 https://support.microsoft.com/en-us/help/4555932
+#  - WS 2022 https://support.microsoft.com/en-us/topic/windows-server-2022-update-history-e1caa597-00c5-4ab9-9f3e-8212fe80b2ee
 # Task to install specific updates by KB. All categories are specified as the module
 # won't install the update unless the category matches. Setting windows_updates_kbs_numbers to []
 # will skip this task.

--- a/images/capi/packer/azure/windows-2022-containerd.json
+++ b/images/capi/packer/azure/windows-2022-containerd.json
@@ -7,7 +7,7 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2022-Datacenter-Core-smalldisk",
-  "image_version": "20348.405.2112080106",
+  "image_version": "latest",
   "load_additional_components": "false",
   "runtime": "containerd",
   "vm_size": "Standard_D4s_v3",


### PR DESCRIPTION
What this PR does / why we need it:

This is a follow up to https://github.com/kubernetes-sigs/image-builder/pull/790/files which pinned WS2022 image because of bugs in azure vhd publishing.  This moves it back to floating the latest version.

This will allow us to get the latest fixes for node ports in WS2022

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/sig windows
/assign @marosset @ionutbalutoiu 