### PR TITLE
Update Azure scripts for new naming scheme

### DIFF
--- a/images/capi/packer/azure/.pipelines/create-sku.yaml
+++ b/images/capi/packer/azure/.pipelines/create-sku.yaml
@@ -1,15 +1,16 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
 # - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
-# - AZURE_TENANT_ID - tenant ID
 # - AZURE_CLIENT_ID - Service principal ID
 # - AZURE_CLIENT_SECRET - Service principal secret
+# - AZURE_TENANT_ID - tenant ID
 # - KUBERNETES_VERSION - version of Kubernetes to create the sku for, e.g. `1.16.2`
-# - PUBLISHER - the name of the publisher to create the sku for
 # - OFFER - the name of the offer to create the sku for
-# - SKU_TEMPLATE_FILE - the base template file to use for the sku
 # - OS - target of build e.g. `Ubuntu/Windows`
-# - OS_VERSION - target of build e.g. `18.04/2004/2019`
+# - OS_VERSION - target of build e.g. `18.04/2004/2019/2022-containerd`
+# - PUBLISHER - the name of the publisher to create the sku for
+# - SKU_TEMPLATE_FILE - the base template file to use for the sku
+# - VM_GENERATION - VM generation to use, e.g. `gen2`
 
 jobs:
 - job: create_sku

--- a/images/capi/packer/azure/scripts/new-disk-version.sh
+++ b/images/capi/packer/azure/scripts/new-disk-version.sh
@@ -50,8 +50,18 @@ echo "VHD publishing info:"
 cat $VHD_INFO
 echo
 
+
+# get Kubernetes version and split into major, minor, and patch
+k8s_version=$(< $SKU_INFO jq -r ".k8s_version")
+IFS='.' # set period (.) as delimiter
+read -ra ADDR <<< "${k8s_version}" # str is read into an array as tokens separated by IFS
+IFS=' ' # reset to default value after usage
+major=${ADDR[0]}
+minor=${ADDR[1]}
+patch=${ADDR[2]}
+
 # generate image version
-image_version=$(date +"%Y.%m.%d")
+image_version=${major}${minor}.${patch}.$(date +"%Y%m%d")
 
 # generate media name
 sku_id=$(< $SKU_INFO jq -r ".sku_id")
@@ -63,8 +73,6 @@ published_date=$(date +"%m/%d/%Y")
 # get vhd url
 vhd_url=$(< $VHD_INFO jq -r ".vhd_url")
 
-# get Kubernetes version
-k8s_version=$(< $SKU_INFO jq -r ".k8s_version")
 label="Kubernetes $k8s_version $OS $OS_VERSION"
 description="Kubernetes $k8s_version $OS $OS_VERSION"
 

--- a/images/capi/packer/azure/scripts/new-sku.sh
+++ b/images/capi/packer/azure/scripts/new-sku.sh
@@ -2,18 +2,20 @@
 
 OS=${OS:-"Ubuntu"}
 OS_VERSION=${OS_VERSION:-"18.04"}
+VM_GENERATION=${VM_GENERATION:-"gen1"}
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
 required_env_vars=(
-    "KUBERNETES_VERSION"
-    "SKU_TEMPLATE_FILE"
-    "AZURE_TENANT_ID"
     "AZURE_CLIENT_ID"
     "AZURE_CLIENT_SECRET"
-    "PUBLISHER"
+    "AZURE_TENANT_ID"
+    "KUBERNETES_VERSION"
     "OFFER"
     "OS"
     "OS_VERSION"
+    "PUBLISHER"
+    "SKU_TEMPLATE_FILE"
+    "VM_GENERATION"
 )
 
 for v in "${required_env_vars[@]}"
@@ -29,17 +31,9 @@ if [ ! -f "$SKU_TEMPLATE_FILE" ]; then
     exit 1
 fi
 
-IFS='.' # set period (.) as delimiter
-read -ra ADDR <<< "${KUBERNETES_VERSION}" # str is read into an array as tokens separated by IFS
-IFS=' ' # reset to default value after usage
-
-major=${ADDR[0]}
-minor=${ADDR[1]}
-patch=${ADDR[2]}
-
 os=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
 version=$(echo "$OS_VERSION" | tr '[:upper:]' '[:lower:]' | tr -d .)
-sku_id="k8s-${major}dot${minor}dot${patch}-${os}-${version}"
+sku_id="${os}-${version}-${VM_GENERATION}"
 
 if [ "$OS" == "Ubuntu" ]; then
     os_type="Ubuntu"


### PR DESCRIPTION
What this PR does / why we need it:

The Azure Marketplace offer used to host CAPZ reference images has a limit on SKUs, and we've used too many. This changes the publishing scripts according to our plan to conserve SKUs and use more versions underneath.

Which issue(s) this PR fixes:

N/A

**Additional context**
