### PR TITLE
Fix QEMU boot_media_path overrides

### DIFF
--- a/images/capi/packer/qemu/qemu-centos-7.json
+++ b/images/capi/packer/qemu/qemu-centos-7.json
@@ -2,7 +2,6 @@
   "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python extra_arguments =vvvv",
   "boot_command_prefix": "<tab> text ks=",
   "boot_command_suffix": "/7/ks.cfg<enter><wait>",
-  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
   "build_name": "centos-7",
   "distro_arch": "amd64",
   "distro_name": "centos",

--- a/images/capi/packer/qemu/qemu-flatcar.json
+++ b/images/capi/packer/qemu/qemu-flatcar.json
@@ -1,6 +1,7 @@
 {
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
   "boot_command_prefix": "curl -sLo /tmp/ignition.json https://raw.githubusercontent.com/flatcar-linux/flatcar-packer-qemu/917f209e1afd262e71f41c65c1295f29c08cb8c6/ignition-builder.json<enter>sudo flatcar-install -d /dev/sda -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json<enter>sudo reboot<enter><wait{{user `install_wait`}}>",
+  "boot_media_path": "",
   "boot_wait": "120s",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",

--- a/images/capi/packer/qemu/qemu-rockylinux-8.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-8.json
@@ -1,7 +1,6 @@
 {
   "boot_command_prefix": "<up><tab> text inst.ks=",
   "boot_command_suffix": "/8/ks.cfg<enter><wait><enter>",
-  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
   "build_name": "rockylinux-8",
   "distro_arch": "amd64",
   "distro_name": "rockylinux",


### PR DESCRIPTION
What this PR does / why we need it:
Right now we're overriding the `boot_media_path` var for two QEMU distros unnecessarily and aren't overriding it for Flatcar where an override is actually necessary. This PR fixes both problems.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
See the commit messages for more context.