### PR TITLE
Fix regression in Flatcar provisioner

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -91,7 +91,7 @@
       "environment_vars": [
         "BUILD_NAME={{user `build_name`}}"
       ],
-      "execute_command": "if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/bootstrap-flatcar.sh",
       "type": "shell"
     },

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -88,9 +88,6 @@
       "type": "shell"
     },
     {
-      "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
-      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/bootstrap-flatcar.sh",
       "type": "shell"

--- a/images/capi/packer/files/bootstrap-flatcar.sh
+++ b/images/capi/packer/files/bootstrap-flatcar.sh
@@ -3,8 +3,6 @@ set -e
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-[[ "$BUILD_NAME" != *"flatcar"* ]] && exit 0
-
 BINDIR="/opt/bin"
 BUILDER_ENV="/opt/bin/builder-env"
 

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -46,9 +46,6 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
-      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/bootstrap-flatcar.sh",
       "type": "shell"

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -49,7 +49,7 @@
       "environment_vars": [
         "BUILD_NAME={{user `build_name`}}"
       ],
-      "execute_command": "if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/bootstrap-flatcar.sh",
       "type": "shell"
     },

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -84,9 +84,6 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
-      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "only": [
         "flatcar"

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -87,7 +87,7 @@
       "environment_vars": [
         "BUILD_NAME={{user `build_name`}}"
       ],
-      "execute_command": "if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "only": [
         "flatcar"
       ],


### PR DESCRIPTION
What this PR does / why we need it:

In #883 I've accidentally introduced a regression which seems to have broken the AMI, QEMU and raw Flatcar builds (other distros weren't affected).

Turns out that removing the `BUILD_NAME` assignment inside `execute_command` was a mistake because variables defined within `environment_vars` don't affect `execute_command`, which made `if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]` always evaluate to false.

Therefore, we first revert 4fb09d311a139aa67ded9c7cdcc3f8d35bd50c07 to fix the build.

Now, we are left with two "layers" of conditionals: Inside `execute_command` and inside `bootstrap-flatcar.sh` Even though I initially thought it'd be good to keep the `if` inside `bootstrap-flatcar.sh` as a failsafe, I no longer think so, hence the 2nd commit. See the commit message for a rationale.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
To test this PR, ensure the following builds pass:

```
make build-qemu-flatcar
make build-qemu-ubuntu-1804
```