### PR TITLE
ova: Remove downgrade of cloud-init, no longer install guestinfo datasource when not needed

### DIFF
--- a/images/capi/ansible/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/roles/providers/defaults/main.yml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-cloud_init_deb_download_url: "https://launchpad.net/ubuntu/+source/cloud-init/21.1-19-gbad84ad4-0ubuntu1~20.04.2/+build/21434629/+files/cloud-init_21.1-19-gbad84ad4-0ubuntu1~20.04.2_all.deb"
 networkd_dispatcher_download_url: "https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.bz2"
 packer_builder_type: ""
 build_target: "virt"

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -33,18 +33,8 @@
     build_target is not search('raw')
 
 - include_tasks: raw.yml
-  when: packer_builder_type is search('qemu') and 
+  when: packer_builder_type is search('qemu') and
     build_target is search('raw')
-
-- include_tasks: vmware-photon.yml
-  when: (packer_builder_type is search('vmware') or
-    packer_builder_type is search('vsphere')) and
-    ansible_os_family == "VMware Photon OS"
-
-- include_tasks: vmware-ubuntu.yml
-  when: (packer_builder_type is search('vmware') or
-    packer_builder_type is search('vsphere')) and
-    ansible_distribution == "Ubuntu"
 
 # Create a boot order configuration
 # b/w containerd and cloud final, cloud config services

--- a/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 ---
+- name: Install cloud-init and tools for VMware Photon OS
+  command: tdnf install {{ packages }} -y
+  vars:
+    packages: "cloud-init cloud-utils python3-netifaces"
+
+- name: Remove cloud-init /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
+  file:
+    path: /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
+    state: absent
 
 - name: Install networkd-dispatcher service (Download from source)
   unarchive:

--- a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
@@ -1,0 +1,51 @@
+# Copyright 2022 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Install cloud-init packages
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+    - cloud-init
+    - cloud-utils-growpart
+    - python2-pip
+
+# pip on CentOS needs to be upgraded, but since it's still
+# Python 2.7, need < 21.0
+- name: Upgrade pip
+  pip:
+    name: pip<21.0
+    state: forcereinstall
+  when: ansible_distribution_major_version == '7'
+
+# Directly installing Guestinfo datasource is needed so long as
+# cloud-init is < 21.3
+- name: Download cloud-init datasource for VMware Guestinfo
+  get_url:
+    url:  '{{ guestinfo_datasource_script }}'
+    dest: /tmp/cloud-init-vmware.sh
+    mode: 0700
+
+- name: Execute cloud-init-vmware.sh
+  shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh
+  environment:
+    REPO_SLUG: '{{ guestinfo_datasource_slug }}'
+    GIT_REF:   '{{ guestinfo_datasource_ref }}'
+
+- name: Remove cloud-init-vmware.sh
+  file:
+    path:  /tmp/cloud-init-vmware.sh
+    state: absent

--- a/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
@@ -13,6 +13,24 @@
 # limitations under the License.
 
 ---
+- name: Install cloud-init packages
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+  vars:
+    packages:
+    - cloud-init
+    - cloud-guest-utils
+    - cloud-initramfs-copymods
+    - cloud-initramfs-dyn-netconf
+
+- name: Disable Hyper-V KVP protocol daemon on Ubuntu
+  systemd:
+    name: hv-kvp-daemon
+    state: stopped
+    enabled: false
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   template:
     src: "{{ item.src }}"

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -25,17 +25,6 @@
     - cloud-initramfs-dyn-netconf
   when: ansible_os_family == "Debian"
 
-- name: Download cloud-init_21.1-19 from launchpad
-  get_url:
-    url: "{{ cloud_init_deb_download_url }}"
-    dest: /tmp
-  register: cloud_init_deb_file
-  when: ansible_os_family == "Debian" and ansible_distribution_version == "20.04"
-
-- name: Install cloud-init v21.1-19 deb
-  command: "dpkg -i {{ cloud_init_deb_file.dest }}"
-  when: ansible_os_family == "Debian" and ansible_distribution_version == "20.04"
-
 - name: Install cloud-init packages
   yum:
     name: "{{ packages }}"
@@ -53,15 +42,12 @@
     packages: "cloud-init cloud-utils python3-netifaces"
   when: ansible_os_family == "VMware Photon OS"
 
-- name: Downgrade to cloud-init 21.2-4.ph3
-  command: "tdnf downgrade cloud-init=21.2-4.ph3 -y"
-  when: ansible_os_family == "VMware Photon OS"
-
 - name: Download cloud-init datasource for VMware Guestinfo
   get_url:
     url:  '{{ guestinfo_datasource_script }}'
     dest: /tmp/cloud-init-vmware.sh
     mode: 0700
+  when: ansible_os_family == "RedHat"
 
 # pip on CentOS needs to be upgraded, but since it's still
 # Python 2.7, need < 21.0
@@ -76,11 +62,13 @@
   environment:
     REPO_SLUG: '{{ guestinfo_datasource_slug }}'
     GIT_REF:   '{{ guestinfo_datasource_ref }}'
+  when: ansible_os_family == "RedHat"
 
 - name: Remove cloud-init-vmware.sh
   file:
     path:  /tmp/cloud-init-vmware.sh
     state: absent
+  when: ansible_os_family == "RedHat"
 
 - name: Remove cloud-init /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
   file:

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -12,82 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Install cloud-init packages
-  apt:
-    name: "{{ packages }}"
-    state: present
-    force_apt_get: yes
-  vars:
-    packages:
-    - cloud-init
-    - cloud-guest-utils
-    - cloud-initramfs-copymods
-    - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
-
-- name: Install cloud-init packages
-  yum:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-    - cloud-init
-    - cloud-utils-growpart
-    - python2-pip
-  when: ansible_os_family == "RedHat"
-
-- name: Install cloud-init and tools for VMware Photon OS
-  command: tdnf install {{ packages }} -y
-  vars:
-    packages: "cloud-init cloud-utils python3-netifaces"
+- include_tasks: vmware-photon.yml
   when: ansible_os_family == "VMware Photon OS"
 
-- name: Download cloud-init datasource for VMware Guestinfo
-  get_url:
-    url:  '{{ guestinfo_datasource_script }}'
-    dest: /tmp/cloud-init-vmware.sh
-    mode: 0700
-  when: ansible_os_family == "RedHat"
-
-# pip on CentOS needs to be upgraded, but since it's still
-# Python 2.7, need < 21.0
-- name: Upgrade pip
-  pip:
-    name: pip<21.0
-    state: forcereinstall
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '7'
-
-- name: Execute cloud-init-vmware.sh
-  shell: bash -o errexit -o pipefail /tmp/cloud-init-vmware.sh
-  environment:
-    REPO_SLUG: '{{ guestinfo_datasource_slug }}'
-    GIT_REF:   '{{ guestinfo_datasource_ref }}'
-  when: ansible_os_family == "RedHat"
-
-- name: Remove cloud-init-vmware.sh
-  file:
-    path:  /tmp/cloud-init-vmware.sh
-    state: absent
-  when: ansible_os_family == "RedHat"
-
-- name: Remove cloud-init /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
-  file:
-    path: /etc/cloud/cloud.cfg.d/99-disable-networking-config.cfg
-    state: absent
-  when: ansible_os_family == "VMware Photon OS"
-
-#- name: Unlock password
-#  replace:
-#    path: /etc/cloud/cloud.cfg
-#    regexp: '(?i)lock_passwd: True'
-#    replace: 'lock_passwd: False'
-
-- name: Disable Hyper-V KVP protocol daemon on Ubuntu
-  systemd:
-    name: hv-kvp-daemon
-    state: stopped
-    enabled: false
+- include_tasks: vmware-ubuntu.yml
   when: ansible_os_family == "Debian"
+
+- include_tasks: vmware-redhat.yml
+  when: ansible_os_family == "RedHat"
 
 - name: Create provider vmtools config drop-in file
   copy:


### PR DESCRIPTION
What this PR does / why we need it:
Commit 1:
    With cloud-init v22.1 available, no longer a need to downgrade on photon
    and Ubuntu. EL distros are still not >- 21.3, so they still need to the
    VMware Guestinfo Datasource.

Commit 2:
    A lot of distro-specific logic was in main.yml, while we already had a
    couple of vmware-distro.yml files to be included. this patch adds a
    vmware-redhat.yml file, and makes sure all vmware-distro files are
    included by vmware.yml. This refactoring makes it much easier to see
    what logic is running under what circumstances.

It may be easier to review this as separate commits (not PRs). Just a friendly reminder that that view is available.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Fixes #675

**Additional context**
/assign @kkeshavamurthy 