### PR TITLE
Modify cloud.cfg to preserve hostname on reboot for OVAs

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/systemd/system/modify-cloud-init-cfg.service
+++ b/images/capi/ansible/roles/providers/files/etc/systemd/system/modify-cloud-init-cfg.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Modify cloud-init config
+After=cloud-final.service
+AssertFileIsExecutable=/usr/local/bin/modify-cloud-init-cfg.sh
+
+[Install]
+WantedBy=cloud-init.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/modify-cloud-init-cfg.sh
+SuccessExitStatus=0

--- a/images/capi/ansible/roles/providers/files/usr/local/bin/modify-cloud-init-cfg.sh
+++ b/images/capi/ansible/roles/providers/files/usr/local/bin/modify-cloud-init-cfg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sed -i 's/preserve_hostname'":"' false/preserve_hostname'":"' true/' /etc/cloud/cloud.cfg

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -28,3 +28,26 @@
     owner: root
     group: root
     mode: 0644
+
+- name: Create service to modify cloud-init config
+  copy:
+    src: files/etc/systemd/system/modify-cloud-init-cfg.service
+    dest: /etc/systemd/system/modify-cloud-init-cfg.service
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Copy cloud-init modification script
+  copy:
+    src: files/usr/local/bin/modify-cloud-init-cfg.sh
+    dest: /usr/local/bin/modify-cloud-init-cfg.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Enable modify-cloud-init-cfg.service
+  systemd:
+    name: modify-cloud-init-cfg.service
+    daemon_reload: yes
+    enabled: True
+    state: stopped


### PR DESCRIPTION
What this PR does / why we need it:
We've noticed that FQDN hostname gets truncated on reboots on OVAs sometimes. 
Ref: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1044
Even though the bug says it's not reproducible anymore, we do see it. 

This fix addresses the problem by modifying `preserve_hostname: false` to `preserve_hostname: true` after firstboot of the OVA. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers
/assign @codenrhoden 