### PR TITLE
tune node images for max etcd network performance

### DIFF
--- a/images/capi/ansible/roles/node/files/etc/udev/rules.d/90-etcd-tuning.rules
+++ b/images/capi/ansible/roles/node/files/etc/udev/rules.d/90-etcd-tuning.rules
@@ -1,0 +1,15 @@
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="pci|xen|vmbus" RUN+="/usr/local/bin/etcd-network-tuning.sh $name"

--- a/images/capi/ansible/roles/node/files/usr/local/bin/etcd-network-tuning.sh
+++ b/images/capi/ansible/roles/node/files/usr/local/bin/etcd-network-tuning.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit  # exits immediately on any unexpected error (does not bypass traps)
+set -o nounset  # will error if variables are used without first being defined
+set -o pipefail # any non-zero exit code in a piped command causes the pipeline to fail with that code
+
+trap on_exit ERR
+on_exit() {
+    echo "Error setting etcd network tuning parameters for interface: ${DEV}" | systemd-cat -p emerg -t etcd-tuning
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Error: Usage: /usr/local/bin/etcd-network-tuning.sh <dev>" | systemd-cat -p emerg -t etcd-tuning
+    exit 1
+fi
+
+DEV=$1
+echo "Setting etcd network tuning parameters for interface: ${DEV}" | systemd-cat -p info -t etcd-tuning
+tc qdisc add dev ${DEV} root handle 1: prio bands 3
+tc filter add dev ${DEV} parent 1: protocol ip prio 1 u32 match ip sport 2380 0xffff flowid 1:1
+tc filter add dev ${DEV} parent 1: protocol ip prio 1 u32 match ip dport 2380 0xffff flowid 1:1
+tc filter add dev ${DEV} parent 1: protocol ip prio 2 u32 match ip sport 2379 0xffff flowid 1:1
+tc filter add dev ${DEV} parent 1: protocol ip prio 2 u32 match ip dport 2379 0xffff flowid 1:1
+

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -103,3 +103,15 @@
     regexp: "^(?!.*transparent_hugepage=madvise)(GRUB_CMDLINE_LINUX=.*)(\"$)"
     line: '\1 transparent_hugepage=madvise"'
   when: ansible_os_family == "RedHat"
+
+- name: Copy udev etcd network tuning rules
+  copy:
+    src: etc/udev/rules.d/90-etcd-tuning.rules
+    dest: /etc/udev/rules.d/90-etcd-tuning.rules
+    mode: 0744
+
+- name: Copy etcd network tuning script
+  copy:
+    src: usr/local/bin/etcd-network-tuning.sh
+    dest: /usr/local/bin/etcd-network-tuning.sh
+    mode: 0755


### PR DESCRIPTION
What this PR does / why we need it:
Fixes #846 

Traffic control rules are added only to the "physical" ethernet devices and not the virtual/tap interfaces on the node. This is done by using the `SUBSYSTEMS` filter. I've tested it on the following providers
vSphere & GCP  -> `SUBSYSTEMS==pci`
Azure -> `SUBSYSTEMS==vmbus`
AWS -> `SUBSYSTEMS==xen`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers