### PR TITLE
Pause before and retry Azure ansible provisioner

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -121,6 +121,8 @@
         "--extra-vars",
         "gmsa_keyvault_url={{user `gmsa_keyvault_url`}}"
       ],
+      "max_retries": 5,
+      "pause_before": "15s",
       "playbook_file": "ansible/windows/node_windows.yml",
       "type": "ansible",
       "use_proxy": false,


### PR DESCRIPTION
What this PR does / why we need it:

In our internal Azure pipeline, this packer build usually fails because WinRM isn't quite ready for a new connection when ansible begins its first "gathering facts" stage. Adding a 15 second pause and retrying up to five times makes it reliable.

Which issue(s) this PR fixes:

N/A

**Additional context**

I've tested this several times on our pipeline and it seems either a 15-second pause or a single retry is enough to fix things.