### PR TITLE
Improve bootstrap-flatcar.sh

### DIFF
--- a/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
+++ b/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
@@ -1,13 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script installs PyPy as a Python interpreter on a Flatcar instance.
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
 BINDIR="/opt/bin"
 BUILDER_ENV="/opt/bin/builder-env"
+
+set -x
 
 mkdir -p ${BINDIR}
 
@@ -20,13 +24,13 @@ fi
 PYPY_VERSION=7.2.0
 PYTHON3_VERSION=3.6
 
-wget -O - https://github.com/squeaky-pl/portable-pypy/releases/download/pypy-${PYPY_VERSION}/pypy-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
+curl -sfL https://github.com/squeaky-pl/portable-pypy/releases/download/pypy-${PYPY_VERSION}/pypy-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
 mv -n pypy-${PYPY_VERSION}-linux_x86_64-portable pypy2
 ln -s ./pypy2/bin/pypy python2
 ln -s ./pypy2/bin/pypy python
 
-wget -O - https://github.com/squeaky-pl/portable-pypy/releases/download/pypy${PYTHON_VERSION}-${PYPY_VERSION}/pypy${PYTHON_VERSION}-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
-mv -n pypy${PYTHON_VERSION}-${PYPY_VERSION}-linux_x86_64-portable pypy3
+curl -sfL  https://github.com/squeaky-pl/portable-pypy/releases/download/pypy${PYTHON3_VERSION}-${PYPY_VERSION}/pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
+mv -n pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable pypy3
 ln -s ./pypy3/bin/pypy3 python3
 
 ${BINDIR}/python --version


### PR DESCRIPTION
There were two issues I had:

- PYTHON_VERSION was not defined (only PYTHON3_VERSION) and `set -o nounset` helps catching that
- `set -o errexit` is the same as `set -e` so there is no change in that regard
- I think `set -o pipefail` just makes sense with `set -o errexit`

I also added:

- `set -x` - to make the debugging easier
- replaced `wget -O -` with `curl -sfL` to reduce the amount of output , because wget is printing all those dots and it's difficult to control that

Extracted from https://github.com/kubernetes-sigs/image-builder/pull/907