### PR TITLE
Don't recreate Azure resource group if it already exists

### DIFF
--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -10,7 +10,9 @@ eval "$tracestate"
 
 export RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-cluster-api-images}"
 export AZURE_LOCATION="${AZURE_LOCATION:-southcentralus}"
-az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION} --tags ${TAGS:-}
+if ! az group show -n ${RESOURCE_GROUP_NAME} -o none 2>/dev/null; then
+  az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION} --tags ${TAGS:-}
+fi
 CREATE_TIME="$(date +%s)"
 RANDOM_SUFFIX="$(head /dev/urandom | LC_ALL=C tr -dc a-z | head -c 4 ; echo '')"
 export GALLERY_NAME="${GALLERY_NAME:-ClusterAPI${CREATE_TIME}${RANDOM_SUFFIX}}"

--- a/images/capi/packer/azure/scripts/init-vhd.sh
+++ b/images/capi/packer/azure/scripts/init-vhd.sh
@@ -12,7 +12,9 @@ eval "$tracestate"
 echo "Create storage account"
 export RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-cluster-api-images}"
 export AZURE_LOCATION="${AZURE_LOCATION:-southcentralus}"
-az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION} --tags ${TAGS:-}
+if ! az group show -n ${RESOURCE_GROUP_NAME} -o none 2>/dev/null; then
+  az group create -n ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION} --tags ${TAGS:-}
+fi
 CREATE_TIME="$(date +%s)"
 RANDOM_SUFFIX="$(head /dev/urandom | LC_ALL=C tr -dc a-z | head -c 4 ; echo '')"
 export STORAGE_ACCOUNT_NAME="${STORAGE_ACCOUNT_NAME:-capi${CREATE_TIME}${RANDOM_SUFFIX}}"


### PR DESCRIPTION
What this PR does / why we need it:

Checks to see if an Azure resource group used for image building exists before creating it. `az group create` when a RG already exists has the effect of overwriting its tags, which isn't desirable since we use some user-defined tags.

Which issue(s) this PR fixes: 

N/A

**Additional context**: