### PR TITLE
prevent package upgrades on node images

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -56,6 +56,9 @@
     autoremove: yes
     force_apt_get: yes
 
+- name: apt-mark all installed packages
+  shell: dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
+
 - name: Remove apt package lists
   file:
     state: "{{ item.state }}"

--- a/images/capi/ansible/roles/sysprep/tasks/photon.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/photon.yml
@@ -27,6 +27,20 @@
 
 - import_tasks: rpm_repos.yml
 
+- name: Get installed packages
+  shell: tdnf list installed | cut -d ' ' -f 1
+  register: packages
+
+- name: create a package list
+  set_fact:
+    package_list: "{{ packages.stdout_lines | join(' ') }}"
+
+- name: exclude packages from upgrade
+  lineinfile:
+    path: /etc/tdnf/tdnf.conf
+    regexp: '^excludepkgs='
+    line: excludepkgs={{ package_list }}
+
 - name: Remove tdnf package caches
   command: /usr/bin/tdnf -y clean all
 

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -34,6 +34,19 @@
     masked: yes
   when: ansible_memory_mb.swap.total != 0 and ansible_distribution_major_version|int == 8
 
+- name: Get installed packages
+  package_facts:
+
+- name: create the package list
+  set_fact:
+    package_list: "{{ ansible_facts.packages.keys() | join(' ') }}"
+
+- name: exclude the packages from upgrades
+  lineinfile:
+    path: /etc/yum.conf
+    regexp: '^exclude='
+    line: exclude={{ package_list }}
+
 - name: Remove RHEL subscription
   block:
     - name: Remove subscriptions


### PR DESCRIPTION
What this PR does / why we need it:
Customers sometimes end up upgrading the node images unintentionally and this breaks a lot of the functionality since the VMs are supposed to be immutable. 
This PR just make the upgrades a little bit harder to do by locking all the packages in the `sysprep` role. A root user can still remove the hold/exclution if needed. 
Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @codenrhoden 