### PR TITLE
Sync Azure maintainers with CAPZ project

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -40,8 +40,8 @@ aliases:
     - alexeldeib
     - CecileRobertMichon
     - devigned
-    - nader-ziada
-    - shysank
+    - jackfrancis
+    - mboersma
   cluster-api-gcp-maintainers:
     - cpanato
     - detiber


### PR DESCRIPTION
What this PR does / why we need it:

Adds @mboersma and @jackfrancis to `cluster-api-azure-maintainers`, and removes inactive maintainers @nader-ziada and @shysank. See https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Which issue(s) this PR fixes: 

See #911 and #913

**Additional context**
