### PR TITLE
Hold packages before reverting custom repo configs

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -17,6 +17,9 @@
     last_log_mode:   "0664"
     machine_id_mode: "0644"
 
+- name: apt-mark all installed packages
+  shell: dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
+
 - name: Remove extra repos
   file:
     path: "/etc/apt/sources.list.d/{{ item | basename }}"
@@ -55,9 +58,6 @@
     autoclean: yes
     autoremove: yes
     force_apt_get: yes
-
-- name: apt-mark all installed packages
-  shell: dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
 
 - name: Remove apt package lists
   file:

--- a/images/capi/ansible/roles/sysprep/tasks/photon.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/photon.yml
@@ -25,8 +25,6 @@
     state: absent
     path: /root/anaconda-ks.cfg
 
-- import_tasks: rpm_repos.yml
-
 - name: Get installed packages
   shell: tdnf list installed | cut -d ' ' -f 1
   register: packages
@@ -40,6 +38,8 @@
     path: /etc/tdnf/tdnf.conf
     regexp: '^excludepkgs='
     line: excludepkgs={{ package_list }}
+
+- import_tasks: rpm_repos.yml
 
 - name: Remove tdnf package caches
   command: /usr/bin/tdnf -y clean all

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -17,6 +17,19 @@
     last_log_mode:   "0644"
     machine_id_mode: "0444"
 
+- name: Get installed packages
+  package_facts:
+
+- name: create the package list
+  set_fact:
+    package_list: "{{ ansible_facts.packages.keys() | join(' ') }}"
+
+- name: exclude the packages from upgrades
+  lineinfile:
+    path: /etc/yum.conf
+    regexp: '^exclude='
+    line: exclude={{ package_list }}
+
 - import_tasks: rpm_repos.yml
 
 # Oracle Linux does not have temp-disk-swapfile service
@@ -33,19 +46,6 @@
     enabled: no
     masked: yes
   when: ansible_memory_mb.swap.total != 0 and ansible_distribution_major_version|int == 8
-
-- name: Get installed packages
-  package_facts:
-
-- name: create the package list
-  set_fact:
-    package_list: "{{ ansible_facts.packages.keys() | join(' ') }}"
-
-- name: exclude the packages from upgrades
-  lineinfile:
-    path: /etc/yum.conf
-    regexp: '^exclude='
-    line: exclude={{ package_list }}
 
 - name: Remove RHEL subscription
   block:


### PR DESCRIPTION
What this PR does / why we need it:
When custom repos are used to pull packages, #920 errors out since we clear/revert custom repo configs before holding  the packages. This results in errors like this
```
/home/builder# apt-mark hold systemd-timesyncd
E: Can't select installed nor candidate version from package 'systemd-timesyncd' as it has neither of them
E: No packages found
```
To get around this either we need to run a `apt update` or run the tasks before reverting custom repo configs. 


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

/assign @codenrhoden @SanikaGawhane 