### PR TITLE
Adding containerd_timeout variable for Windows

### DIFF
--- a/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
+++ b/images/capi/ansible/windows/roles/runtimes/tasks/containerd.yml
@@ -18,6 +18,7 @@
     dest: '{{ tempdir.stdout | trim }}\containerd.tar.gz'
     checksum: '{{ containerd_sha256 }}'
     checksum_algorithm: "sha256"
+    url_timeout: 300
   register: containerd
   retries: 5
   delay: 3
@@ -108,4 +109,3 @@
   when: (prepull | bool)
   vars:
     images: "{{ prepull_images[distribution_version] | default([]) }}"
-  


### PR DESCRIPTION
What this PR does / why we need it:
A few scenarios can have the win_get_url take more than the default 30 seconds for containerd download, this PR allows the user to increase the default timeout.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers