### PR TITLE
Add GPU driver enabled Ubuntu(18.04 & 20.04) GCE image

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -348,7 +348,7 @@ NODE_OVA_VSPHERE_BASE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-base-,$(PLATF
 NODE_OVA_VSPHERE_CLONE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-clone-,$(PLATFORMS_AND_VERSIONS))
 
 AMI_BUILD_NAMES			   ?= ami-centos-7 ami-ubuntu-2004 ami-ubuntu-2204 ami-amazon-2 ami-flatcar ami-windows-2019 ami-rockylinux-8 ami-rhel-8
-GCE_BUILD_NAMES			   ?= gce-ubuntu-2004 gce-ubuntu-2204 gce-rhel-8
+GCE_BUILD_NAMES			   ?= gce-ubuntu-2004 gce-ubuntu-2204 gce-rhel-8 gce-ubuntu-2004-gpu
 
 # Make needs these lists to be space delimited, no quotes
 VHD_TARGETS := $(shell grep VHD_TARGETS azure_targets.sh | sed 's/VHD_TARGETS=//' | tr -d \")
@@ -361,6 +361,7 @@ AZURE_BUILD_SIG_GEN2_NAMES ?= $(addsuffix -gen2,$(addprefix azure-sig-,$(SIG_GEN
 AZURE_BUILD_SIG_CVM_NAMES ?= $(addsuffix -cvm,$(addprefix azure-sig-,$(SIG_CVM_TARGETS)))
 
 OCI_BUILD_NAMES			   ?= oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-oracle-linux-9 oci-windows-2019 oci-windows-2022
+GCE_BUILD_NAMES_GPU			   ?= $(addprefix gce-ubuntu-2004-gpu,$(GCE_BUILD_NAMES))
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-2004
 
@@ -683,6 +684,7 @@ build-do-all: $(DO_BUILD_TARGETS) ## Builds all DigitalOcean Snapshot
 build-gce-ubuntu-2004: ## Builds the GCE ubuntu-2004 image
 build-gce-ubuntu-2204: ## Builds the GCE ubuntu-2204 image
 build-gce-rhel-8: ## Builds the GCE rhel-8 image
+build-gce-ubuntu-2004-gpu: ## Builds the GCE ubuntu-2004-gpu image
 build-gce-all: $(GCE_BUILD_TARGETS) ## Builds all GCE image
 
 build-node-ova-local-centos-7: ## Builds CentOS 7 Node OVA w local hypervisor
@@ -860,6 +862,7 @@ validate-openstack-all: $(OPENSTACK_VALIDATE_TARGETS) ## Validates all Openstack
 validate-gce-ubuntu-2004: ## Validates Ubuntu 20.04 GCE Snapshot Packer config
 validate-gce-ubuntu-2204: ## Validates Ubuntu 22.04 GCE Snapshot Packer config
 validate-gce-rhel-8: ## Validates RHEL 8 GCE Snapshot Packer config
+validate-gce-ubuntu-2004-gpu: ## Validates Ubuntu 20.04 with GPU driver GCE Snapshot Packer config
 validate-gce-all: $(GCE_VALIDATE_TARGETS) ## Validates all GCE Snapshot Packer config
 
 validate-node-ova-local-centos-7: ## Validates CentOS 7 Node OVA Packer config w local hypervisor

--- a/images/capi/packer/gce/files/bootstrap-ubuntu-gpu.sh
+++ b/images/capi/packer/gce/files/bootstrap-ubuntu-gpu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+wget https://raw.githubusercontent.com/GoogleCloudPlatform/compute-gpu-installation/main/linux/install_gpu_driver.py -O install_gpu_driver.py
+
+sudo python3 install_gpu_driver.py

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -1,6 +1,8 @@
 {
   "builders": [
     {
+      "accelerator_count": "{{user `accelerator_count`}}",
+      "accelerator_type": "{{user `accelerator_type`}}",
       "disable_default_service_account": "{{ user `disable_default_service_account` }}",
       "image_family": "{{user `image_family` | clean_resource_name}}",
       "image_name": "{{user `image_name` | clean_resource_name}}",
@@ -13,6 +15,7 @@
       },
       "machine_type": "{{ user `machine_type` }}",
       "name": "{{user `build_name`}}",
+      "on_host_maintenance": "{{user `on_host_maintenance`}}",
       "project_id": "{{ user `project_id` }}",
       "service_account_email": "{{ user `service_account_email` }}",
       "source_image_family": "{{ user `source_image_family` }}",
@@ -24,10 +27,17 @@
   ],
   "provisioners": [
     {
+      "execute_command": "BUILD_NAME={{ user `build_name` }}; if [[ \"${BUILD_NAME}\" == *\"ubuntu-1804-gpu\"* || \"${BUILD_NAME}\" == *\"ubuntu-2004-gpu\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
+      "script": "./packer/gce/files/bootstrap-ubuntu-gpu.sh",
+      "type": "shell"
+    },
+    {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'"
       ],
       "extra_arguments": [
+        "--scp-extra-args",
+        "{{user `ansible_scp_extra_args`}}",
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",

--- a/images/capi/packer/gce/ubuntu-1804-gpu.json
+++ b/images/capi/packer/gce/ubuntu-1804-gpu.json
@@ -1,0 +1,11 @@
+{
+  "accelerator_name": "nvidia-tesla-t4",
+  "accelerator_type": "projects/{{ user `project_id` }}/zones/{{ user `zone` }}/acceleratorTypes/{{ user `accelerator_name` }}",
+  "base_image": "ubuntu-1804",
+  "build_name": "ubuntu-1804-gpu",
+  "distribution": "Ubuntu",
+  "distribution_release": "bionic",
+  "distribution_version": "1804",
+  "on_host_maintenance": "TERMINATE",
+  "zone": "us-central1-a"
+}

--- a/images/capi/packer/gce/ubuntu-2004-gpu.json
+++ b/images/capi/packer/gce/ubuntu-2004-gpu.json
@@ -1,0 +1,11 @@
+{
+  "accelerator_name": "nvidia-tesla-t4",
+  "accelerator_type": "projects/{{ user `project_id` }}/zones/{{ user `zone` }}/acceleratorTypes/{{ user `accelerator_name` }}",
+  "base_image": "ubuntu-2004",
+  "build_name": "ubuntu-2004-gpu",
+  "distribution": "Ubuntu",
+  "distribution_release": "focal",
+  "distribution_version": "2004",
+  "on_host_maintenance": "TERMINATE",
+  "zone": "us-central1-a"
+}

--- a/images/capi/packer/gce/ubuntu-2004-gpu.json
+++ b/images/capi/packer/gce/ubuntu-2004-gpu.json
@@ -7,5 +7,7 @@
   "distribution_release": "focal",
   "distribution_version": "2004",
   "on_host_maintenance": "TERMINATE",
+  "source_image_family": "ubuntu-2004-lts",
+  "ssh_username": "ubuntu",
   "zone": "us-central1-a"
 }

--- a/images/capi/packer/gce/ubuntu-2004.json
+++ b/images/capi/packer/gce/ubuntu-2004.json
@@ -1,4 +1,5 @@
 {
+  "base_image": "ubuntu-2004",
   "build_name": "ubuntu-2004",
   "distribution": "ubuntu",
   "distribution_release": "focal",

--- a/images/capi/packer/gce/ubuntu-2204-gpu.json
+++ b/images/capi/packer/gce/ubuntu-2204-gpu.json
@@ -1,11 +1,13 @@
 {
   "accelerator_name": "nvidia-tesla-t4",
   "accelerator_type": "projects/{{ user `project_id` }}/zones/{{ user `zone` }}/acceleratorTypes/{{ user `accelerator_name` }}",
-  "base_image": "ubuntu-1804",
-  "build_name": "ubuntu-1804-gpu",
+  "base_image": "ubuntu-2204",
+  "build_name": "ubuntu-2204-gpu",
   "distribution": "Ubuntu",
-  "distribution_release": "bionic",
-  "distribution_version": "1804",
+  "distribution_release": "focal",
+  "distribution_version": "2204",
   "on_host_maintenance": "TERMINATE",
+  "source_image_family": "ubuntu-2204-lts",
+  "ssh_username": "ubuntu",
   "zone": "us-central1-a"
 }

--- a/images/capi/packer/gce/ubuntu-2204.json
+++ b/images/capi/packer/gce/ubuntu-2204.json
@@ -1,4 +1,5 @@
 {
+  "base_image": "ubuntu-2204",
   "build_name": "ubuntu-2204",
   "distribution": "ubuntu",
   "distribution_release": "jammy",


### PR DESCRIPTION
What this PR does / why we need it:

Creates the Ubuntu (18.04 & 20.04) GCE image with GPU drivers pre-installed.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Waiting for [907](https://github.com/kubernetes-sigs/image-builder/pull/907) to be merged so that we can be sure about the ssh connection.