### PR TITLE
use pause image from mcr.microsoft.com for azure images

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -385,7 +385,7 @@ $(GCE_VALIDATE_TARGETS): deps-gce
 
 .PHONY: $(AZURE_BUILD_VHD_TARGETS)
 $(AZURE_BUILD_VHD_TARGETS): deps-azure
-	. $(abspath packer/azure/scripts/init-vhd.sh) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-vhd.json)" -var-file="$(abspath packer/azure/$(subst build-azure-vhd-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+	. $(abspath packer/azure/scripts/init-vhd.sh) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-vhd.json)" -var-file="$(abspath packer/azure/$(subst build-azure-vhd-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) -var-file="$(abspath packer/azure/common.json)" packer/azure/packer$(findstring -windows,$@).json 
 
 .PHONY: $(AZURE_VALIDATE_VHD_TARGETS)
 $(AZURE_VALIDATE_VHD_TARGETS): deps-azure

--- a/images/capi/packer/azure/common.json
+++ b/images/capi/packer/azure/common.json
@@ -1,0 +1,3 @@
+{
+  "pause_image": "mcr.microsoft.com/oss/kubernetes/pause:3.8"
+}


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

What this PR does / why we need it:

This PR makes it so the pause/infra image used when building Azure VHDs comes from mcr.microsoft.com.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers