### PR TITLE
Bump Photon-3 Base ISO to use Rev3 Update1

### DIFF
--- a/images/capi/packer/ova/photon-3.json
+++ b/images/capi/packer/ova/photon-3.json
@@ -7,9 +7,9 @@
   "distro_name": "photon",
   "distro_version": "3",
   "guest_os_type": "vmware-photon-64",
-  "iso_checksum": "c2883a42e402a2330d9c39b4d1e071cf9b3b5898",
+  "iso_checksum": "76fbe13df3f7340c94cf5706a0ec33ffc377c47e",
   "iso_checksum_type": "sha1",
-  "iso_url": "https://packages.vmware.com/photon/3.0/Rev3/iso/photon-minimal-3.0-a383732.iso",
+  "iso_url": "https://packages.vmware.com/photon/3.0/Rev3/iso/Update1/photon-minimal-3.0-913b49438.iso",
   "os_display_name": "VMware Photon OS 64-bit",
   "shutdown_command": "shutdown now",
   "vsphere_guest_os_type": "vmwarePhoton64Guest"


### PR DESCRIPTION
What this PR does / why we need it:
Photon-3 recently released a Rev3 Update1 ISO. 
https://github.com/vmware/photon/wiki/Downloading-Photon-OS#photon-os-30-revision-3-update1-binaries

So, bumping the defaults to use the latest ISO. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers