### PR TITLE
expose advanced packer googlecompute auth options to users

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.7.2"
+_version="1.7.10"
 
 # Change directories to the parent directory of the one in which this
 # script is located.

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -1,9 +1,11 @@
 {
   "builders": [
     {
+      "account_file": "{{ user `service_account_key_file` }}",
       "disable_default_service_account": "{{ user `disable_default_service_account` }}",
       "image_family": "capi-{{user `build_name`}}-k8s-{{user `kubernetes_series` | clean_resource_name}}",
       "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver` | clean_resource_name}}-{{user `build_timestamp`}}",
+      "impersonate_service_account": "{{ user `impersonate_service_account` }}",
       "labels": {
         "build_timestamp": "{{user `build_timestamp`}}",
         "distribution": "ubuntu",
@@ -13,10 +15,13 @@
       },
       "machine_type": "{{ user `machine_type` }}",
       "name": "{{user `build_name`}}",
+      "network": "{{ user `network` }}",
+      "network_project_id": "{{ user `network_project_id` }}",
       "project_id": "{{ user `project_id` }}",
       "service_account_email": "{{ user `service_account_email` }}",
       "source_image_family": "{{ user `source_image_family` }}",
       "ssh_username": "ubuntu",
+      "subnetwork": "{{ user `subnetwork` }}",
       "type": "googlecompute",
       "zone": "{{ user `zone` }}"
     }
@@ -92,6 +97,7 @@
     "disable_default_service_account": "",
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "impersonate_service_account": "{{ env `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` }}",
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_http_source": null,
     "kubernetes_cni_rpm_version": null,
@@ -111,9 +117,13 @@
     "kubernetes_series": null,
     "kubernetes_source_type": null,
     "machine_type": "n1-standard-1",
+    "network": "",
+    "network_project_id": "",
     "project_id": "{{env `GCP_PROJECT_ID`}}",
     "service_account_email": "",
+    "service_account_key_file": "",
     "source_image_family": "{{user `build_name`}}-lts",
+    "subnetwork": "",
     "zone": null
   }
 }

--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -1,6 +1,7 @@
 {
   "builders": [
     {
+      "access_token": "{{ user `oauth_token` }}",
       "account_file": "{{ user `service_account_key_file` }}",
       "disable_default_service_account": "{{ user `disable_default_service_account` }}",
       "image_family": "capi-{{user `build_name`}}-k8s-{{user `kubernetes_series` | clean_resource_name}}",
@@ -18,6 +19,9 @@
       "network": "{{ user `network` }}",
       "network_project_id": "{{ user `network_project_id` }}",
       "project_id": "{{ user `project_id` }}",
+      "scopes": [
+        "https://www.googleapis.com/auth/cloud-platform"
+      ],
       "service_account_email": "{{ user `service_account_email` }}",
       "source_image_family": "{{ user `source_image_family` }}",
       "ssh_username": "ubuntu",
@@ -119,6 +123,7 @@
     "machine_type": "n1-standard-1",
     "network": "",
     "network_project_id": "",
+    "oauth_token": "",
     "project_id": "{{env `GCP_PROJECT_ID`}}",
     "service_account_email": "",
     "service_account_key_file": "",


### PR DESCRIPTION
What this PR does / why we need it:

Exposes some more of the knobs that come with the `googlecompute` packer builder.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #941 

**Additional context**
I'd have liked to make some more settings configurable, such as those related to [`iap`](https://www.packer.io/plugins/builders/googlecompute#use_iap) and [`oslogin`](https://www.packer.io/plugins/builders/googlecompute#use_os_login), but as far as I can tell that's not possible with the JSON format (if it is, please do point me in the right direction so I can add that) and thus blocked-ish by #814 

The choice of `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` as an environment variable name is in line with [what the Terraform does](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#impersonate_service_account) but not a standard for Google tooling (though I wish it was... x)) and can be removed or renamed if needed.