### PR TITLE
feat: expose os_disk_size_db to allow overriding

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -20,6 +20,7 @@
       "image_version": "{{user `image_version`}}",
       "location": "{{user `azure_location`}}",
       "name": "vhd-{{user `build_name`}}",
+      "os_disk_size_gb": "{{user `os_disk_size_gb`}}",
       "os_type": "Windows",
       "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
       "resource_group_name": "{{user `resource_group_name`}}",
@@ -55,6 +56,7 @@
       "managed_image_name": "{{user `image_name`}}-{{user `build_timestamp`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "name": "sig-{{user `build_name`}}",
+      "os_disk_size_gb": "{{user `os_disk_size_gb`}}",
       "os_type": "Windows",
       "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
       "shared_image_gallery_destination": {
@@ -207,6 +209,7 @@
     "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/binaries/node/windows/{{user `kubernetes_goarch`}}",
     "manifest_output": "manifest.json",
     "nssm_url": null,
+    "os_disk_size_gb": "",
     "prepull": null,
     "private_virtual_network_with_public_ip": "",
     "subscription_id": null,

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -21,6 +21,7 @@
       "image_version": "{{user `image_version`}}",
       "location": "{{user `azure_location`}}",
       "name": "vhd-{{user `build_name`}}",
+      "os_disk_size_gb": "{{user `os_disk_size_gb`}}",
       "os_type": "Linux",
       "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
       "resource_group_name": "{{user `resource_group_name`}}",
@@ -54,6 +55,7 @@
       "managed_image_name": "{{user `image_name`}}-{{user `build_timestamp`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "name": "sig-{{user `build_name`}}",
+      "os_disk_size_gb": "{{user `os_disk_size_gb`}}",
       "os_type": "Linux",
       "plan_info": {
         "plan_name": "{{user `plan_image_sku`}}",
@@ -231,6 +233,7 @@
     "kubernetes_series": null,
     "kubernetes_source_type": null,
     "manifest_output": "manifest.json",
+    "os_disk_size_gb": "",
     "plan_image_offer": "",
     "plan_image_publisher": "",
     "plan_image_sku": "",


### PR DESCRIPTION
What this PR does / why we need it:

Allows overriding VM os disk size.