### PR TITLE
updating dynamic port range for windows to address some collisions

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -133,8 +133,8 @@
     data: 1
     type: dword
 
-- name: Expand dynamic port range to 33000-65535 to avoid port exhaustion
-  win_shell: netsh int ipv4 set dynamicportrange tcp 33000 32536
+- name: Expand dynamic port range to 34000-65535 to avoid port exhaustion
+  win_shell: netsh int ipv4 set dynamicportrange tcp 34000 31536
 
 - name: Add required Windows Features
   win_feature:

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -159,8 +159,8 @@ command:
     exit-status: 0
     exec: netsh int ipv4 show dynamicportrange tcp
     stdout:
-    - "Start Port      : 33000"
-    - "Number of Ports : 32536"
+    - "Start Port      : 34000"
+    - "Number of Ports : 31536"
     timeout: 30000
 {{end}}
 


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

What this PR does / why we need it:
This fixes some issues where ports inside the current dynamic range (33000-65535) are being used by Windows components.
This can random issues if container workloads are allocated ports that are already in use.
Lots of details in https://github.com/kubernetes/kubernetes/issues/107114

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes https://github.com/kubernetes/kubernetes/issues/107114

**Additional context**
Add any other context for the reviewers

/sig windows