### PR TITLE
upgrade packer to 1.8.3

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.7.2"
+_version="1.8.3"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Upgrade packer version to latest 1.8.x version. Among other changes, this allows to specify the `shared_image_gallery.storage_account_type` for azure builds. 
