### PR TITLE
fix: image name different among runtimes

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -53,7 +53,7 @@
       "image_sku": "{{user `image_sku`}}",
       "image_version": "{{user `image_version`}}",
       "location": "{{user `azure_location`}}",
-      "managed_image_name": "{{user `image_name`}}-{{user `build_timestamp`}}",
+      "managed_image_name": "{{user `image_name`}}-{{user `runtime`}}-{{user `build_timestamp`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
       "name": "sig-{{user `build_name`}}",
       "os_disk_size_gb": "{{user `os_disk_size_gb`}}",


### PR DESCRIPTION
What this PR does / why we need it:
Adjusts `managed_image_name` to incorporate the runtime. This should avoid the flaky tests issue. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #949

**Additional context**
I haven't tried this change yet, but I'm quite sure this is the issue. I believe this should not have an impact otherwise since usually one would use the shared image gallery one. 