### PR TITLE
feat: allow setting storage_account_type

### DIFF
--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -55,6 +55,7 @@
       "location": "{{user `azure_location`}}",
       "managed_image_name": "{{user `image_name`}}-{{user `build_timestamp`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "{{user `storage_account_type`}}",
       "name": "sig-{{user `build_name`}}",
       "os_disk_size_gb": "{{user `os_disk_size_gb`}}",
       "os_type": "Windows",
@@ -66,7 +67,8 @@
         "replication_regions": [
           "{{user `replication_regions`}}"
         ],
-        "resource_group": "{{user `resource_group_name`}}"
+        "resource_group": "{{user `resource_group_name`}}",
+        "storage_account_type": "{{user `storage_account_type`}}"
       },
       "subscription_id": "{{user `subscription_id`}}",
       "type": "azure-arm",
@@ -212,6 +214,7 @@
     "os_disk_size_gb": "",
     "prepull": null,
     "private_virtual_network_with_public_ip": "",
+    "storage_account_type": "",
     "subscription_id": null,
     "virtual_network_name": "",
     "virtual_network_resource_group_name": "",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -54,6 +54,7 @@
       "location": "{{user `azure_location`}}",
       "managed_image_name": "{{user `image_name`}}-{{user `build_timestamp`}}",
       "managed_image_resource_group_name": "{{user `resource_group_name`}}",
+      "managed_image_storage_account_type": "{{user `storage_account_type`}}",
       "name": "sig-{{user `build_name`}}",
       "os_disk_size_gb": "{{user `os_disk_size_gb`}}",
       "os_type": "Linux",
@@ -70,7 +71,8 @@
         "replication_regions": [
           "{{user `replication_regions`}}"
         ],
-        "resource_group": "{{user `resource_group_name`}}"
+        "resource_group": "{{user `resource_group_name`}}",
+        "storage_account_type": "{{user `storage_account_type`}}"
       },
       "ssh_username": "packer",
       "subscription_id": "{{user `subscription_id`}}",
@@ -239,6 +241,7 @@
     "plan_image_sku": "",
     "private_virtual_network_with_public_ip": "",
     "provisioner_remote_folder": "/tmp",
+    "storage_account_type": "",
     "subscription_id": null,
     "virtual_network_name": "",
     "virtual_network_resource_group_name": "",


### PR DESCRIPTION
What this PR does / why we need it:
Adds another setting to override `storage_account_type` for the managed image as well as the shared image gallery. Enables users to use e.g. SSDs. 

**Additional context**
required an upgrade to packer (#948) which is merged meanwhile. 