### PR TITLE
upgrade pip to fix azure-cli installation flakes

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/debian.yml
+++ b/images/capi/ansible/roles/providers/tasks/debian.yml
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+- name: upgrade pip to latest
+  pip:
+    name: pip
+    executable: pip3
+    state: latest
+
 - name: install Azure clients
   pip:
     executable: pip3


### PR DESCRIPTION
What this PR does / why we need it:
Fixes #766 

Upgrading pip seems to be have fixed the azure-cli installation issues in my testing. 
I'm upgrading it to latest on both 18.04 & 20.04. Let me know if I should restrict it to just 18.04. 