### PR TITLE
Set default Flatcar version to "current"

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -257,7 +257,7 @@ WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
 
 # Set Flatcar Container Linux channel and version if not supplied
 FLATCAR_CHANNEL ?= stable
-FLATCAR_VERSION ?= 3033.2.4
+FLATCAR_VERSION ?= current
 ifeq ($(FLATCAR_VERSION),current)
 override FLATCAR_VERSION := $(shell hack/image-grok-latest-flatcar-version.sh $(FLATCAR_CHANNEL))
 endif


### PR DESCRIPTION
What this PR does / why we need it:

Specifying the special value `current` makes the build process figure out the most recent Flatcar release on the selected channel (e.g. `stable`) and use that version when building the image.  We want to ensure users who don't have an opinion on which Flatcar version to use get the latest version which may contain important security patches and bug fixes.  Users can still build specific versions by setting the `FLATCAR_VERSION` environment variable.

cc @t-lo @jepio 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
None