### PR TITLE
Add timeout and retry when installing baseline dependencies.

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -78,16 +78,28 @@
     update_cache: True
     name: "{{ debs }}"
     state: latest
-
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
+  
 - name: install extra debs
   apt:
     force_apt_get: True
     name: "{{ extra_debs.split() }}"
     state: latest
-
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10
+  
 - name: install pinned debs
   apt:
     force_apt_get: True
     name: "{{ pinned_debs }}"
     state: present
     force: yes
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10


### PR DESCRIPTION
What this PR does / why we need it:

The image-builder hits the ansible issue https://github.com/ansible/ansible/issues/51663 when it's trying to install baseline dependencies with `apt` module. Here we need lock timeout and retry unless there is a better way.


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers