### PR TITLE
Support setting oem_id for Flatcar QEMU images

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/flatcar.yml
@@ -50,3 +50,8 @@
   shell: |
     echo 'set linux_append="$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"' >> /usr/share/oem/grub.cfg
   when: kubernetes_semver is version('v1.21.0', '<')
+
+- name: Set oem_id in grub
+  shell: |
+    echo 'set oem_id="{{oem_id}}"' >> /usr/share/oem/grub.cfg
+  when: (oem_id is defined) and (oem_id != "")

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -161,6 +161,7 @@
     "kubernetes_source_type": null,
     "machine_id_mode": "444",
     "memory": "2048",
+    "oem_id": "",
     "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "python_path": "",
     "qemu_binary": "qemu-system-x86_64",

--- a/images/capi/packer/qemu/qemu-flatcar.json
+++ b/images/capi/packer/qemu/qemu-flatcar.json
@@ -14,6 +14,7 @@
   "iso_url": "https://{{env `FLATCAR_CHANNEL`}}.release.flatcar-linux.net/amd64-usr/{{env `FLATCAR_VERSION`}}/flatcar_production_iso_image.iso",
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
+  "oem_id": "{{env `OEM_ID`}}",
   "os_display_name": "Flatcar Container Linux ({{env `FLATCAR_CHANNEL`}} channel release {{env `FLATCAR_VERSION`}})",
   "python_path": "/opt/bin/builder-env/site-packages",
   "release_version": "{{env `FLATCAR_VERSION`}}",


### PR DESCRIPTION
What this PR does / why we need it:

Allow the ability to set the `oem_id` value for Flatcar images built with QEMU, needed for OpenStack.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #937

**Additional context**
Currently untested but wanted to get feedback early that this is the appropriate approach to take.