### PR TITLE
Update pyOpenSSL to latest

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/debian.yml
+++ b/images/capi/ansible/roles/providers/tasks/debian.yml
@@ -18,6 +18,12 @@
     executable: pip3
     state: latest
 
+- name: upgrade pyOpenSSL to latest
+  pip:
+    name: pyOpenSSL
+    executable: pip3
+    state: latest
+
 - name: install Azure clients
   pip:
     executable: pip3


### PR DESCRIPTION
Signed-off-by: Sriraman S <ssriraman@vmware.com>

**What this PR does / why we need it:**
This PR updates the pyOpenSSL package to the latest. This will fix the issue of iptables-persistent package installation failing.

**Which issue(s) this PR fixes:** Fixes #967

**Additional context**
Looks like the latest version of iptables-persistent package uses updated version of cryptography which needs later versions of openssl. This causes issue with flag 'X509_V_FLAG_CB_ISSUER_CHECK' and causes the installation to fail. Upgrading the pyOpenSSL package to the latest resolves the issue.
Important to note here is that if we try to install iptables-persistent package directly using apt, it sails through and only issue is when trying to install using Ansible.