### PR TITLE
Fix Flatcar detection in node role

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -18,6 +18,14 @@
 - import_tasks: amazonLinux2.yml
   when: ansible_distribution == "Amazon"
 
+# This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
+- name: Override Flatcar's OS family
+  set_fact:
+    ansible_os_family: Flatcar
+  when: ansible_os_family == "Flatcar Container Linux by Kinvolk"
+  tags:
+    - facts
+
 - name: Ensure overlay module is present
   modprobe:
     name: overlay

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -22,5 +22,6 @@ rpms: ""
 extra_rpms: ""
 
 disable_public_repos: false
+external_binary_path: "{{ '/opt/bin' if ansible_os_family == 'Flatcar' else '/usr/local/bin' }}"
 extra_repos: ""
 pip_conf_file: ""

--- a/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
@@ -10,15 +10,9 @@
   tags:
     - facts
 
-- name: Force binaries directory for Flatcar Container Linux
-  set_fact:
-    bin_dir: "/opt/bin"
-  tags:
-    - facts
-
 - name: Set the ansible_python_interpreter fact
   set_fact:
-    ansible_python_interpreter: "{{ bin_dir }}/python"
+    ansible_python_interpreter: "{{ external_binary_path }}/python"
   tags:
     - facts
 


### PR DESCRIPTION
What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #969

**Additional context**
Possibly there is a better place to put that. This detection is already happening in:

* `images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml`
* `images/capi/ansible/roles/setup/tasks/main.yml`