### PR TITLE
Update references following Flatcar GitHub org rename

### DIFF
--- a/images/capi/hack/boxes-flatcar.sh
+++ b/images/capi/hack/boxes-flatcar.sh
@@ -6,7 +6,7 @@ export VAGRANT_VAGRANTFILE=${VAGRANT_VAGRANTFILE:-/tmp/Vagrantfile.builder-flatc
 
 fetch_vagrantfile() {
     curl -sSL -o ${VAGRANT_VAGRANTFILE} \
-        https://raw.githubusercontent.com/flatcar-linux/flatcar-packer-qemu/builder-ignition/Vagrantfile.builder-flatcar
+        https://raw.githubusercontent.com/flatcar/flatcar-packer-qemu/builder-ignition/Vagrantfile.builder-flatcar
 }
 
 list_boxes() {

--- a/images/capi/hack/ensure-ct.sh
+++ b/images/capi/hack/ensure-ct.sh
@@ -37,7 +37,7 @@ if [[ ${HOSTOS} == "linux" ]]; then
 elif [[ ${HOSTOS} == "darwin" ]]; then
   _binfile="ct-${_version}-x86_64-apple-darwin"
 fi
-_bin_url="https://github.com/flatcar-linux/container-linux-config-transpiler/releases/download/${_version}/${_binfile}"
+_bin_url="https://github.com/flatcar/container-linux-config-transpiler/releases/download/${_version}/${_binfile}"
 curl -SsL "${_bin_url}" -o ct
 chmod 0755 ct
 echo "'ct' has been installed to $(pwd), make sure this directory is in your \$PATH"

--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -35,7 +35,7 @@ fetch_vagrant_ssh_keys() {
 
 fetch_vagrantfile() {
     curl -sSL -o ${VAGRANT_VAGRANTFILE} \
-        https://raw.githubusercontent.com/flatcar-linux/flatcar-packer-qemu/builder-ignition/Vagrantfile.builder-flatcar
+        https://raw.githubusercontent.com/flatcar/flatcar-packer-qemu/builder-ignition/Vagrantfile.builder-flatcar
 }
 # --
 

--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -19,7 +19,7 @@ check_for_release() {
     channel="$1"
     release="$2"
     curl -L -s \
-         "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
+         "https://www.flatcar.org/releases-json/releases-$channel.json" \
         | jq -r 'to_entries[] | "\(.key)"' \
         | grep -q "$release"
 }

--- a/images/capi/hack/image-grok-latest-flatcar-version.sh
+++ b/images/capi/hack/image-grok-latest-flatcar-version.sh
@@ -5,7 +5,7 @@
 channel="$1"
 
 curl -L -s \
-     "https://www.flatcar-linux.org/releases-json/releases-$channel.json" \
+     "https://www.flatcar.org/releases-json/releases-$channel.json" \
     | jq -r 'to_entries[] | "\(.key)"' \
     | grep -v "current" \
     | sort --version-sort \

--- a/images/capi/packer/files/flatcar/README.md
+++ b/images/capi/packer/files/flatcar/README.md
@@ -37,6 +37,6 @@ To change an existing Ignition file, do the following:
   `ignition`.
 1. Commit the changes and open a PR to merge them.
 
-[1]: https://flatcar-linux.org/docs/latest/provisioning/cl-config/
-[2]: https://flatcar-linux.org/docs/latest/provisioning/ignition/
-[3]: https://flatcar-linux.org/docs/latest/provisioning/config-transpiler/
+[1]: https://flatcar.org/docs/latest/provisioning/cl-config/
+[2]: https://flatcar.org/docs/latest/provisioning/ignition/
+[3]: https://flatcar.org/docs/latest/provisioning/config-transpiler/

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -14,7 +14,7 @@ service:
     running: false
   {{if ne .Vars.OS "flatcar"}}
   # TODO: auditd was added to Flatcar in 
-  # https://github.com/flatcar-linux/coreos-overlay/commit/b3194ee538bf7ddb8f699d37a8be81ab106079c3
+  # https://github.com/flatcar/coreos-overlay/commit/b3194ee538bf7ddb8f699d37a8be81ab106079c3
   # but isn't available in the various channels yet.
   # Remove the conditional when auditd is available in Flatcar stable (supposed to happen
   # once the major release number of the stable channel is larger than 3140).


### PR DESCRIPTION
What this PR does / why we need it:

The flatcar-linux GitHub organization is being renamed to "flatcar". This PR updates all references accordingly.

Upstream issue: https://github.com/flatcar-linux/Flatcar/issues/836

I'm opening this PR in advance to allow quick merging once the rename occurs. I'll mark it as on hold in the meantime.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
None

## TODO

- [x] Ensure the following scripts work following the rename:
  - images/capi/hack/boxes-flatcar.sh
  - images/capi/hack/ensure-ct.sh
  - images/capi/hack/image-build-flatcar.sh
- [x] Ensure [this](https://github.com/flatcar/coreos-overlay/commit/b3194ee538bf7ddb8f699d37a8be81ab106079c3) link works in https://github.com/kubernetes-sigs/image-builder/blob/4b95dcdafd7afb65fe06e917a13d6a1b6a3e4668/images/capi/packer/goss/goss-service.yaml.