### PR TITLE
Expose AWS_SESSION_TOKEN as a user variable

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -59,6 +59,7 @@
         "source_ami": "{{user `source_ami`}}"
       },
       "temporary_security_group_source_cidrs": "{{ user `temporary_security_group_source_cidrs` }}",
+      "token": "{{ user `aws_session_token` }}",
       "type": "amazon-ebs",
       "user_data_file": "packer/ami/scripts/winrm_bootstrap.txt",
       "vpc_id": "{{ user `vpc_id` }}",
@@ -168,6 +169,7 @@
     "aws_region": "us-east-1",
     "aws_secret_key": "",
     "aws_security_group_ids": "",
+    "aws_session_token": "",
     "build_name": null,
     "build_timestamp": "{{timestamp}}",
     "builder_instance_type": "t3.large",

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -59,6 +59,7 @@
         "source_ami": "{{user `source_ami`}}"
       },
       "temporary_security_group_source_cidrs": "{{ user `temporary_security_group_source_cidrs` }}",
+      "token": "{{ user `aws_session_token` }}",
       "type": "amazon-ebs",
       "user_data": "{{ user `user_data` }}",
       "vpc_id": "{{ user `vpc_id` }}"
@@ -154,6 +155,7 @@
     "aws_region": "us-east-1",
     "aws_secret_key": "",
     "aws_security_group_ids": "",
+    "aws_session_token": "",
     "build_timestamp": "{{timestamp}}",
     "builder_instance_type": "t3.small",
     "containerd_sha256": null,


### PR DESCRIPTION
When uses STS credentials (in our case provided by vault) you also need to specify the session token. This PR exposes that as a user variable.

What this PR does / why we need it: Currently AWS AMIs cannot be built using STS based AWS credentials

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers