### PR TITLE
Update gce nightly build images

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-21.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-21.json
@@ -1,8 +1,0 @@
-{
-  "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.21.14-00",
-  "kubernetes_rpm_version": "1.21.14-0",
-  "kubernetes_semver": "v1.21.14",
-  "kubernetes_series": "v1.21",
-  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
-}

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-22.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-22.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.22.11-00",
-  "kubernetes_rpm_version": "1.22.11-0",
-  "kubernetes_semver": "v1.22.11",
+  "kubernetes_deb_version": "1.22.14-00",
+  "kubernetes_rpm_version": "1.22.14-0",
+  "kubernetes_semver": "v1.22.14",
   "kubernetes_series": "v1.22",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-23.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-23.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.23.8-00",
-  "kubernetes_rpm_version": "1.23.8-0",
-  "kubernetes_semver": "v1.23.8",
+  "kubernetes_deb_version": "1.23.11-00",
+  "kubernetes_rpm_version": "1.23.11-0",
+  "kubernetes_semver": "v1.23.11",
   "kubernetes_series": "v1.23",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.24.2-00",
-  "kubernetes_rpm_version": "1.24.2-0",
-  "kubernetes_semver": "v1.24.2",
+  "kubernetes_deb_version": "1.24.5-00",
+  "kubernetes_rpm_version": "1.24.5-0",
+  "kubernetes_semver": "v1.24.5",
   "kubernetes_series": "v1.24",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
@@ -1,0 +1,8 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.25.1-00",
+  "kubernetes_rpm_version": "1.25.1-0",
+  "kubernetes_semver": "v1.25.1",
+  "kubernetes_series": "v1.25",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
What this PR does / why we need it:

- remove 1.21 build since it is eol
- update 1.22/1.23/1.24 k8s
- add 1.25 to build the image

/assign @dims @richardcase @codenrhoden 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers