### PR TITLE
docs: expanding Azure documentation with optional environment variable GALLERY_NAME

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -7,7 +7,7 @@ These images are designed for use with [Cluster API Provider Azure](https://capz
 - An Azure account
 - The Azure CLI installed and configured
 - Set environment variables for `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
-- Set optional environment variables `RESOURCE_GROUP_NAME`, `STORAGE_ACCOUNT_NAME` & `AZURE_LOCATION` to override the default values
+- Set optional environment variables `RESOURCE_GROUP_NAME`, `STORAGE_ACCOUNT_NAME`, `AZURE_LOCATION` & `GALLERY_NAME` to override the default values
 
 ## Building Images
 


### PR DESCRIPTION
**Additional context**

This PR adds a reference to `GALLERY_NAME` environment variable in Azure's provider documentation that can be set up to keep a consistent gallery name used to store the built images.