### PR TITLE
Pin openssl and crypto packages to known working versions

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/debian.yml
+++ b/images/capi/ansible/roles/providers/tasks/debian.yml
@@ -18,11 +18,12 @@
     executable: pip3
     state: latest
 
-- name: upgrade pyOpenSSL to latest
+- name: upgrade pyOpenSSL and cryptography
   pip:
-    name: pyOpenSSL
+    name:
+      - pyOpenSSL==22.0.*
+      - cryptography==38.0.*
     executable: pip3
-    state: latest
 
 - name: install Azure clients
   pip:


### PR DESCRIPTION
What this PR does / why we need it:

Even after #968, we are still getting these errors in our image-builder pipeline:

> File \"/usr/lib/python3/dist-packages/OpenSSL/crypto.py\", line 1570, in X509StoreFlags\n    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK\nAttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'\nConnection to 127.0.0.1 closed.\r\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error"

Upgrading both pyOpenSSL and its main dependency cryptography in one `pip` command is one fix. This PR pins the known working minor versions of both packages.

Which issue(s) this PR fixes:

N/A

**Additional context**
