### PR TITLE
Updated kubernetes-cni .deb to v1.1.1

### DIFF
--- a/images/capi/packer/config/cni.json
+++ b/images/capi/packer/config/cni.json
@@ -1,9 +1,9 @@
 {
-  "kubernetes_cni_deb_version": "0.8.7-00",
-  "kubernetes_cni_http_checksum": "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v0.8.7/cni-plugins-linux-{{user `kubernetes_cni_http_checksum_arch`}}-v0.8.7.tgz.sha256",
+  "kubernetes_cni_deb_version": "1.1.1-00",
+  "kubernetes_cni_http_checksum": "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v1.1.1/cni-plugins-linux-{{user `kubernetes_cni_http_checksum_arch`}}-v1.1.1.tgz.sha256",
   "kubernetes_cni_http_checksum_arch": "amd64",
   "kubernetes_cni_http_source": "https://github.com/containernetworking/plugins/releases/download",
-  "kubernetes_cni_rpm_version": "0.8.7-0",
-  "kubernetes_cni_semver": "v0.8.7",
+  "kubernetes_cni_rpm_version": "1.1.1-0",
+  "kubernetes_cni_semver": "v1.1.1",
   "kubernetes_cni_source_type": "pkg"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Updates the Debian package for `kubernetes-cni` to v1.1.1. The previous version v0.8.7 started failing builds on our pipeline for new k8s patches:

>  "The following packages have unmet dependencies:", " kubeadm : Depends: kubernetes-cni (>= 1.1.1)", " kubelet : Depends: kubernetes-cni (>= 1.1.1)"

Which issue(s) this PR fixes: 

N/A

**Additional context**
