### PR TITLE
remove 1.21 job and add 1.25

### DIFF
--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -40,10 +40,6 @@ groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
 chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
 # use the packer user to run the build
 
-# build image for 1.21
-# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-21.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
-
 # build image for 1.22
 # using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
 su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-22.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
@@ -55,6 +51,10 @@ su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/c
 # build image for 1.24
 # using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
 su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-24.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+
+# build image for 1.25
+# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-25.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
 
 echo "Displaying the generated image information"
 filter="name~cluster-api-ubuntu-*"


### PR DESCRIPTION
Signed-off-by: cpanato <ctadeu@gmail.com>

What this PR does / why we need it:

- remove 1.21 job and add 1.25
follow up of https://github.com/kubernetes-sigs/image-builder/pull/973


/assign @dims @richardcase @codenrhoden @sbueringer 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers