### PR TITLE
Add sbueringer to ClusterAPI maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -32,6 +32,7 @@ aliases:
     - CecileRobertMichon
     - enxebre
     - fabriziopandini
+    - sbueringer
     - vincepri
   cluster-api-aws-maintainers:
     - richardcase


### PR DESCRIPTION
What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
To sync with: https://github.com/kubernetes-sigs/cluster-api/blob/main/OWNERS_ALIASES#L21-L26

**Additional context**
Add any other context for the reviewers