### PR TITLE
feat: add `base_image_ocid` param for CAPI Oracle Cloud provider

### DIFF
--- a/docs/book/src/capi/providers/oci.md
+++ b/docs/book/src/capi/providers/oci.md
@@ -15,7 +15,7 @@ building OCI images are managed by running the following command from images/cap
 make deps-oci
 ```
 
-From the `images/capi` directory, run `make build-do-<OS>` where `<OS>` is
+From the `images/capi` directory, run `make build-oci-<OS>` where `<OS>` is
 the desired operating system. The available choices are listed via `make help`.
 
 ### Configuration

--- a/images/capi/packer/oci/packer.json
+++ b/images/capi/packer/oci/packer.json
@@ -6,6 +6,7 @@
         "operating_system": "{{user `operating_system`}}",
         "operating_system_version": "{{user `operating_system_version`}}"
       },
+      "base_image_ocid": "{{user `base_image_ocid`}}",
       "compartment_ocid": "{{user `compartment_ocid`}}",
       "fingerprint": "{{user `fingerprint`}}",
       "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
@@ -101,6 +102,7 @@
     "ansible_extra_vars": "",
     "ansible_user_vars": "",
     "availability_domain": "{{env `OCI_AVAILABILITY_DOMAIN`}}",
+    "base_image_ocid": "",
     "build_timestamp": "{{timestamp}}",
     "compartment_ocid": "",
     "containerd_sha256": null,


### PR DESCRIPTION
What this PR does / why we need it:
This will allow users to use an existing base image when creating their image for Oracle Cloud. `base_image_ocid` will override the `base_image_filter` if it is set.

We have a use case where someone might want to build on-top of a preexisting image that isn't provided by Oracle. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers