### PR TITLE
Install curl on Photon builds

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -78,6 +78,7 @@ common_photon_rpms:
 - socat
 - tar
 - unzip
+- curl
 
 common_virt_rpms:
 - open-vm-tools


### PR DESCRIPTION
What this PR does / why we need it:
When the base photon image was bumped in this [PR](https://github.com/kubernetes-sigs/image-builder/pull/940), the new base ISOs do not have `curl` pre-installed. 
Due to this the goss binary is having issue downloading and causing ci failures for Photon-3. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers