### PR TITLE
Add cluster-api-nutanix-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -74,6 +74,9 @@ aliases:
     - randomvariable
     - srm09
     - yastij
+  cluster-api-nutanix-maintainers:
+    - tuxtof
+    - deepakm-ntnx
   kops-maintainers:
     - hakman
     - justinsb

--- a/images/capi/packer/nutanix/OWNERS
+++ b/images/capi/packer/nutanix/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-nutanix-maintainers
+
+reviewers:
+  - cluster-api-nutanix-maintainers


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds cluster-api-nutanix-maintainers owners alias with appropriate members to approve and maintain Nutanix image components in /images/capi/nutanix.

There is a dependency on [this issue](https://github.com/kubernetes/org/issues/3730) to have deepakm-nutanix added as a community member. 