### PR TITLE
Update AMI owner ID for centOS AMIs

### DIFF
--- a/images/capi/packer/ami/centos-7.json
+++ b/images/capi/packer/ami/centos-7.json
@@ -1,6 +1,6 @@
 {
   "ami_filter_name": "CentOS Linux 7 x86_64 HVM EBS ENA*",
-  "ami_filter_owners": "410186602215",
+  "ami_filter_owners": "461800378586",
   "build_name": "centos-7",
   "distribution": "CentOS",
   "distribution_release": "Core",


### PR DESCRIPTION
What this PR does / why we need it:
This PR updates AMI owner ID for centOS AMIs to `461800378586`, such that CAPA AMI generation is successful.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #987 

**Additional context**
Add any other context for the reviewers