### PR TITLE
Remove old build targets from Azure test matrix

### DIFF
--- a/images/capi/azure_targets.sh
+++ b/images/capi/azure_targets.sh
@@ -1,3 +1,6 @@
 VHD_TARGETS="ubuntu-1804 ubuntu-2004 centos-7 windows-2019 windows-2019-containerd windows-2022-containerd"
+VHD_CI_TARGETS="ubuntu-2004 centos-7 windows-2019-containerd windows-2022-containerd"
 SIG_TARGETS="ubuntu-1804 ubuntu-2004 centos-7 windows-2019 windows-2019-containerd windows-2022-containerd flatcar"
+SIG_CI_TARGETS="ubuntu-2004 centos-7 windows-2019-containerd windows-2022-containerd flatcar"
 SIG_GEN2_TARGETS="ubuntu-1804 ubuntu-2004 centos-7 flatcar"
+SIG_GEN2_CI_TARGETS="ubuntu-2004 centos-7 flatcar"

--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -35,14 +35,14 @@ mkdir -p "${ARTIFACTS}/azure-sigs" "${ARTIFACTS}/azure-vhds"
 source azure_targets.sh
 
 # Convert single line entries into arrays
-IFS=' ' read -r -a VHD_TARGETS <<< "${VHD_TARGETS}"
-IFS=' ' read -r -a SIG_TARGETS <<< "${SIG_TARGETS}"
-IFS=' ' read -r -a SIG_GEN2_TARGETS <<< "${SIG_GEN2_TARGETS}"
+IFS=' ' read -r -a VHD_CI_TARGETS <<< "${VHD_CI_TARGETS}"
+IFS=' ' read -r -a SIG_CI_TARGETS <<< "${SIG_CI_TARGETS}"
+IFS=' ' read -r -a SIG_GEN2_CI_TARGETS <<< "${SIG_GEN2_CI_TARGETS}"
 
 # Append the "gen2" targets to the original SIG list
-for element in "${SIG_GEN2_TARGETS[@]}"
+for element in "${SIG_GEN2_CI_TARGETS[@]}"
 do
-    SIG_TARGETS+=("${element}-gen2")
+    SIG_CI_TARGETS+=("${element}-gen2")
 done
 
 # shellcheck source=parse-prow-creds.sh
@@ -84,13 +84,13 @@ export PACKER_VAR_FILES="packer/azure/scripts/disable-windows-prepull.json scrip
 
 declare -A PIDS
 if [[ "${AZURE_BUILD_FORMAT:-vhd}" == "sig" ]]; then
-    for target in ${SIG_TARGETS[@]};
+    for target in ${SIG_CI_TARGETS[@]};
     do
         make build-azure-sig-${target} > ${ARTIFACTS}/azure-sigs/${target}.log 2>&1 &
         PIDS["sig-${target}"]=$!
     done
 else
-    for target in ${VHD_TARGETS[@]};
+    for target in ${VHD_CI_TARGETS[@]};
     do
         make build-azure-vhd-${target} > ${ARTIFACTS}/azure-vhds/${target}.log 2>&1 &
         PIDS["vhd-${target}"]=$!


### PR DESCRIPTION
What this PR does / why we need it:

In preparing to [add Ubuntu 22.04 support](https://github.com/kubernetes-sigs/image-builder/pull/961#issuecomment-1263846684) to Azure Cluster API images, we realized that our PR [test matrix is huge](https://github.com/kubernetes-sigs/image-builder/pull/961#issuecomment-1263846684) (up to 20 items, requiring 20 Azure VMs to be provisioned for each CI run). This ~~mostly~~ removes `ubuntu-1804` and `windows-2019` from that matrix, as they are both on the verge of being sunsetted.

Which issue(s) this PR fixes:

N/A

**Additional context**

See also #961

cc: @CecileRobertMichon @jackfrancis @jsturtevant @kkeshavamurthy 