### PR TITLE
Update Azure pub tool to v0.3.3

### DIFF
--- a/images/capi/packer/azure/scripts/new-disk-version.sh
+++ b/images/capi/packer/azure/scripts/new-disk-version.sh
@@ -6,6 +6,7 @@ echo "PWD: $PWD"
 
 OS=${OS:-"Ubuntu"}
 OS_VERSION=${OS_VERSION:-"18.04"}
+PUB_VERSION=${PUB_VERSION:-"v0.3.3"}
 
 required_env_vars=(
     "AZURE_CLIENT_ID"
@@ -13,6 +14,7 @@ required_env_vars=(
     "AZURE_TENANT_ID"
     "OS"
     "OS_VERSION"
+    "PUB_VERSION"
 )
 
 for v in "${required_env_vars[@]}"
@@ -40,7 +42,7 @@ do
 done
 
 echo "Getting pub..."
-(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.3.2/pub_v0.3.2_linux_amd64.tar.gz -o pub; tar -xzf pub)
+(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/${PUB_VERSION}/pub_${PUB_VERSION}_linux_amd64.tar.gz -o pub; tar -xzf pub)
 
 echo "SKU publishing info:"
 cat $SKU_INFO

--- a/images/capi/packer/azure/scripts/new-sku.sh
+++ b/images/capi/packer/azure/scripts/new-sku.sh
@@ -2,6 +2,7 @@
 
 OS=${OS:-"Ubuntu"}
 OS_VERSION=${OS_VERSION:-"18.04"}
+PUB_VERSION=${PUB_VERSION:-"v0.3.3"}
 VM_GENERATION=${VM_GENERATION:-"gen1"}
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
@@ -13,6 +14,7 @@ required_env_vars=(
     "OFFER"
     "OS"
     "OS_VERSION"
+    "PUB_VERSION"
     "PUBLISHER"
     "SKU_TEMPLATE_FILE"
     "VM_GENERATION"
@@ -57,7 +59,7 @@ cat sku.json
 
 echo
 echo "Getting pub..."
-(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/v0.3.2/pub_v0.3.2_linux_amd64.tar.gz -o pub; tar -xzf pub)
+(set -x ; curl -fsSL https://github.com/devigned/pub/releases/download/${PUB_VERSION}/pub_${PUB_VERSION}_linux_amd64.tar.gz -o pub; tar -xzf pub)
 
 echo "Creating new SKU"
 set -x


### PR DESCRIPTION
What this PR does / why we need it:

Updates the version of the [`pub`](https://github.com/devigned/pub/releases/tag/v0.3.3) tool used to interact with Azure Marketplace. Also parameterizes the version with an environment variable so we won't need to open PRs like this in the future.

Which issue(s) this PR fixes: 

N/A

**Additional context**

I've tested this branch in an Azure pipeline job.
