### PR TITLE
Bump dependency versions

### DIFF
--- a/images/capi/ansible/roles/python/defaults/main.yml
+++ b/images/capi/ansible/roles/python/defaults/main.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-pypy_python_version: "3.6"
+pypy_python_version: "3.8"
 pypy_version: "7.2.0"
 pypy_download_path: "/tmp/pypy.tar.bz2"
 pypy_install_path: "/opt"

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.11.5"
+_version="${ANSIBLE_VERSION:-2.13.4}"
 
 # Change directories to the parent directory of the one in which this
 # script is located.

--- a/images/capi/hack/ensure-goss.sh
+++ b/images/capi/hack/ensure-goss.sh
@@ -23,9 +23,9 @@ set -o pipefail
 source hack/utils.sh
 
 # SHA are for amd64 arch.
-_version="3.0.3"
-darwin_sha256="279a33eb3102385ff3c0577b0d35c4f218e54dddb53e549c626aed1741c93f34"
-linux_sha256="687fda0873028fb60443339f47412856d08eea1007d274bda25078df426b21bc"
+_version="3.1.3"
+darwin_sha256="5bf3842073d6dd65edb0ac728037ce9ded4fe3466f496229227633bca730beda"
+linux_sha256="b30fba2e3328ae64b57d3df414eb848fc51a01629f52f9307c67591257565363"
 _bin_url="https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${_version}/packer-provisioner-goss-v${_version}-${HOSTOS}-${HOSTARCH}.tar.gz"
 _tarfile="${HOME}/.packer.d/plugins/packer-provisioner-goss.tar.gz"
 _binfile="${HOME}/.packer.d/plugins/packer-provisioner-goss"

--- a/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
+++ b/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
@@ -18,7 +18,7 @@ if [[ -e ${BINDIR}/.bootstrapped ]]; then
 fi
 
 PYPY_VERSION=7.2.0
-PYTHON3_VERSION=3.6
+PYTHON3_VERSION=3.8
 
 wget -O - https://github.com/squeaky-pl/portable-pypy/releases/download/pypy-${PYPY_VERSION}/pypy-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
 mv -n pypy-${PYPY_VERSION}-linux_x86_64-portable pypy2


### PR DESCRIPTION
Bumps `goss` and `Ansible` to latest versions to allow for building Ubuntu 22.04 images (with updated SSH server)