### PR TITLE
Added QEMU ubuntu 22.04 build

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -81,7 +81,7 @@ deps-osc:
 	hack/ensure-packer.sh
 	hack/ensure-goss.sh
 	packer plugins install github.com/outscale/outscale
-   
+
 .PHONY: deps-gce
 deps-gce: ## Installs/checks dependencies for GCE builds
 deps-gce:
@@ -309,8 +309,7 @@ OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-oracle-linux-8
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
 OSC_BUILD_NAMES 			?=	osc-centos-7 osc-ubuntu-2004
-
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-ubuntu-2204 qemu-ubuntu-2204-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar
@@ -474,7 +473,7 @@ $(OCI_VALIDATE_TARGETS): deps-oci
 	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst validate-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
 
 .PHONY: $(OSC_BUILD_TARGETS)
-$(OSC_BUILD_TARGETS): deps-osc 
+$(OSC_BUILD_TARGETS): deps-osc
 	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/outscale/$(subst build-osc-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/outscale/packer.json
 
 .PHONY: $(OSC_VALIDATE_TARGETS)
@@ -642,6 +641,8 @@ build-qemu-flatcar: ## Builds Flatcar QEMU image
 build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-ubuntu-2004-efi: ## Builds Ubuntu 20.04 QEMU image that EFI boots
+build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
+build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
@@ -746,6 +747,8 @@ validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-ubuntu-2004-efi: ## Validates Ubuntu 20.04 QEMU EFI image packer config
+validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
+validate-qemu-ubuntu-2204-efi: ## Validates Ubuntu 22.04 QEMU EFI image packer config
 validate-qemu-centos-7: ## Validates CentOS 7 QEMU image packer config
 validate-qemu-rhel-8: ## Validates RHEL 8 QEMU image
 validate-qemu-rockylinux-8: ## Validates Rocky Linux 8 QEMU image packer config

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed-efi.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed-efi.cfg
@@ -1,0 +1,15 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+d-i preseed/include string ../base/preseed-efi.cfg

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed-efi.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed-efi.cfg
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2022 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed.cfg
@@ -1,0 +1,15 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+d-i preseed/include string ../base/preseed.cfg

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/preseed.cfg
@@ -1,4 +1,4 @@
-# Copyright 2019 The Kubernetes Authors.
+# Copyright 2022 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
@@ -1,0 +1,13 @@
+{
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>linux /install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost preseed/url=",
+  "boot_command_suffix": "/22.04/preseed-efi.cfg -- <wait><enter>initrd /install/initrd.gz<enter>boot<enter><wait>",
+  "build_name": "ubuntu-2204",
+  "distro_name": "ubuntu",
+  "firmware": "OVMF.fd",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://www.releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now"
+}

--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
@@ -1,0 +1,12 @@
+{
+  "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
+  "boot_command_suffix": "/22.04/preseed.cfg -- <wait><enter><wait>",
+  "build_name": "ubuntu-2204",
+  "distro_name": "ubuntu",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://www.releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
What this PR does / why we need it: Adds Ubuntu 22.04 builds for QEMU platform

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Currently untested / WiP