### PR TITLE
Bump GOSS and packer-plugin-powervs versions

### DIFF
--- a/images/capi/hack/ensure-goss.sh
+++ b/images/capi/hack/ensure-goss.sh
@@ -23,9 +23,9 @@ set -o pipefail
 source hack/utils.sh
 
 # SHA are for amd64 arch.
-_version="3.0.3"
-darwin_sha256="279a33eb3102385ff3c0577b0d35c4f218e54dddb53e549c626aed1741c93f34"
-linux_sha256="687fda0873028fb60443339f47412856d08eea1007d274bda25078df426b21bc"
+_version="3.1.3"
+darwin_sha256="c08f111d26eee291607e0079c5ffd34ca16b25c46f249a9cceea7681adde0b89"
+linux_sha256="1fd925f3d554f3bc7acdaebf2a5d1692a7fb891a6f805f477c1000fd6c4877f4"
 _bin_url="https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${_version}/packer-provisioner-goss-v${_version}-${HOSTOS}-${HOSTARCH}.tar.gz"
 _tarfile="${HOME}/.packer.d/plugins/packer-provisioner-goss.tar.gz"
 _binfile="${HOME}/.packer.d/plugins/packer-provisioner-goss"

--- a/images/capi/hack/ensure-powervs.sh
+++ b/images/capi/hack/ensure-powervs.sh
@@ -31,7 +31,7 @@ if ! (${SED} --version 2>&1 | grep -q GNU); then
   exit 1
 fi
 
-_version="0.1.2"
+_version="0.1.6"
 _chkfile="packer-plugin-powervs_v${_version}_SHA256SUMS"
 _chk_url="https://github.com/ppc64le-cloud/packer-plugin-powervs/releases/download/v${_version}/${_chkfile}"
 _bin_url="https://github.com/ppc64le-cloud/packer-plugin-powervs/releases/download/v${_version}/packer-plugin-powervs_v${_version}_x5.0_${HOSTOS}_${HOSTARCH}.zip"


### PR DESCRIPTION
Bump GOSS and powervs versions to address CVEs - [30323](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-30323/overview/), [30322](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-30322/overview/), [30321](https://osspi.eng.vmware.com/api/v3/vulnerabilities/CVE-2022-30321/overview/)
