### PR TITLE
[capi/qemu] Add ubuntu 22.04 support for qemu

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -328,7 +328,7 @@ DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar
@@ -676,6 +676,7 @@ build-qemu-flatcar: ## Builds Flatcar QEMU image
 build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-ubuntu-2004-efi: ## Builds Ubuntu 20.04 QEMU image that EFI boots
+build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
@@ -799,6 +800,7 @@ validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-ubuntu-2004-efi: ## Validates Ubuntu 20.04 QEMU EFI image packer config
+validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
 validate-qemu-centos-7: ## Validates CentOS 7 QEMU image packer config
 validate-qemu-rhel-8: ## Validates RHEL 8 QEMU image
 validate-qemu-rockylinux-8: ## Validates Rocky Linux 8 QEMU image packer config

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
@@ -83,6 +83,5 @@ autoinstall:
     - swapoff -a
     - rm -f /swapfile
     - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - rm -f /etc/udev/rules.d/70-persistent-net.rules
     - apt-get purge --auto-remove -y
     - rm -rf /var/lib/apt/lists/*

--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
@@ -1,0 +1,12 @@
+{
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "build_name": "ubuntu-2204",
+  "distro_name": "ubuntu",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now",
+  "unmount_iso": "true"
+}


### PR DESCRIPTION
What this PR does / why we need it:
Ubuntu 22.04 replaced preseed by [autoinstall](https://ubuntu.com/server/docs/install/autoinstall). Due to this change, we have to migrate the current preseed config to autoinstall config and provide it via cloud init to the qemu vm.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): partially fixes #960

**Additional context**
Helpfull links:
  - [autoinstall reference manual](https://discourse.ubuntu.com/t/automated-server-install-reference/16613)
  - [autoinstall quickstart](https://discourse.ubuntu.com/t/automated-server-install-quickstart/16614)
  - [disk configuration details by curtin storage documentation](https://curtin.readthedocs.io/en/latest/topics/storage.html)
  
 changed behavior:
   - upgrading packages enabled upon installation
   - official apt mirror enabled upon installation
   - security repo is not disabled during installation
   - `/etc/udev/rules.d/70-persistent-net.rules` file is not deleted anymore, because it is not generated anymore ([details](https://wiki.debian.org/NetworkInterfaceNames))


<sub>Dennis Lerch <dennis.lerch@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>