### PR TITLE
Ensure ubuntu install uses console=ttyS0 kernel args

### DIFF
--- a/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/ova/linux/ubuntu/http/base/preseed.cfg
@@ -14,6 +14,7 @@
 
 # Configure the locale
 d-i debian-installer/locale string en_US.utf8
+d-i debian-installer/add-kernel-opts console=ttyS0
 d-i console-setup/ask_detect boolean false
 d-i console-setup/layout string us
 

--- a/images/capi/packer/raw/linux/ubuntu/http/base/preseed.cfg
+++ b/images/capi/packer/raw/linux/ubuntu/http/base/preseed.cfg
@@ -14,6 +14,7 @@
 
 # Configure the locale
 d-i debian-installer/locale string en_US.utf8
+d-i debian-installer/add-kernel-opts console=ttyS0
 d-i console-setup/ask_detect boolean false
 d-i console-setup/layout string us
 


### PR DESCRIPTION
What this PR does / why we need it:

`virtctl console VM` commands won't show any output unless our VMs default to having a console configured for `ttyS0` 


Which issue(s) this PR fixes: Fixes https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/issues/197
