### PR TITLE
Ensure Azure storage accounts are private

### DIFF
--- a/images/capi/packer/azure/scripts/delete-unused-storage.sh
+++ b/images/capi/packer/azure/scripts/delete-unused-storage.sh
@@ -77,7 +77,7 @@ NOW=$(date +%s)
 # ensure the existence of the archive storage account
 if ! az storage account show -g "${RESOURCE_GROUP}" -n "${ARCHIVE_STORAGE_ACCOUNT}" &> /dev/null; then
   echo "Creating archive storage account ${ARCHIVE_STORAGE_ACCOUNT}..."
-  $ECHO az storage account create -g "${RESOURCE_GROUP}" -n "${ARCHIVE_STORAGE_ACCOUNT}" --access-tier Cool
+  $ECHO az storage account create -g "${RESOURCE_GROUP}" -n "${ARCHIVE_STORAGE_ACCOUNT}" --access-tier Cool --allow-blob-public-access false
 fi
 
 IFS=$'\n'

--- a/images/capi/packer/azure/scripts/init-vhd.sh
+++ b/images/capi/packer/azure/scripts/init-vhd.sh
@@ -19,6 +19,6 @@ CREATE_TIME="$(date +%s)"
 RANDOM_SUFFIX="$(head /dev/urandom | LC_ALL=C tr -dc a-z | head -c 4 ; echo '')"
 export STORAGE_ACCOUNT_NAME="${STORAGE_ACCOUNT_NAME:-capi${CREATE_TIME}${RANDOM_SUFFIX}}"
 az storage account check-name --name ${STORAGE_ACCOUNT_NAME}
-az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME}
+az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} --allow-blob-public-access false
 
 echo "done"


### PR DESCRIPTION
What this PR does / why we need it: By default, Azure storage accounts are public. 

Microsoft recommends to disallow public access to a storage account unless the scenario requires it. Disallowing public access helps to prevent data breaches caused by undesired anonymous access. More info: https://azure.microsoft.com/en-gb/updates/choose-to-allow-or-disallow-blob-public-access-on-azure-storage-accounts/

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers