### PR TITLE
Disable pip version check

### DIFF
--- a/images/capi/hack/ensure-ansible-windows.sh
+++ b/images/capi/hack/ensure-ansible-windows.sh
@@ -27,13 +27,16 @@ _version="0.4.2"
 if [[ ${HOSTOS} == "darwin" ]]; then
     echo "IMPORTANT: Winrm connection plugin for Ansible on MacOS causes connection issues."
     echo "See https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html#what-is-winrm for more details."
-    echo "To fix the issue provide the enviroment variable 'no_proxy=*'" 
+    echo "To fix the issue provide the enviroment variable 'no_proxy=*'"
     echo "Example call to build Windows images on MacOS: 'no_proxy=* make build-<target>'"
 fi
 
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Disable pip's version check and root user warning
+export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 if pip3 show pywinrm >/dev/null 2>&1; then exit 0; fi
 

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -28,6 +28,9 @@ _version="2.11.5"
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
+# Disable pip's version check and root user warning
+export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
+
 if ! command -v ansible >/dev/null 2>&1; then
     ensure_py3
     pip3 install --user "ansible-core==${_version}"

--- a/images/capi/hack/ensure-azure-cli.sh
+++ b/images/capi/hack/ensure-azure-cli.sh
@@ -30,6 +30,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 if command -v az >/dev/null 2>&1; then exit 0; fi
 
+# Disable pip's version check and root user warning
+export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
+
 ensure_py3
 pip install -U pip setuptools
 pip3 install --user "azure-cli==${_version}"

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -75,7 +75,7 @@ ensure_py3_bin() {
   if ! command -v "${1}" >/dev/null 2>&1; then
     echo "User's Python3 binary directory must be in \$PATH" 1>&2
     echo "Location of package is:" 1>&2
-    pip3 show ${2:-$1} | grep "Location"
+    pip3 show --disable-pip-version-check ${2:-$1} | grep "Location"
     echo "\$PATH is currently: $PATH" 1>&2
     exit 1
   fi


### PR DESCRIPTION
What this PR does / why we need it:

Disables `pip3`'s behavior of automatically checking online whether it has a new version available. For some reason, this check fails in our CI environment.

*Previously*
Trying to fix an error that popped up in the `pull-azure-sigs` job. May have to do with `pip` or other packages being updated but not pinned in this project.

```shell
+ WRAPPED_COMMAND_PID=17
+ ./images/capi/scripts/ci-azure-e2e.sh
+ wait 17
hack/ensure-ansible.sh
Collecting ansible-core==2.11.5
  Downloading ansible-core-2.11.5.tar.gz (6.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.8/6.8 MB 45.4 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting jinja2
  Downloading Jinja2-3.1.2-py3-none-any.whl (133 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.1/133.1 kB 16.1 MB/s eta 0:00:00
Requirement already satisfied: PyYAML in /usr/lib/python3/dist-packages (from ansible-core==2.11.5) (3.13)
Collecting cryptography
  Downloading cryptography-38.0.1-cp36-abi3-manylinux_2_28_x86_64.whl (4.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.2/4.2 MB 77.6 MB/s eta 0:00:00
Collecting packaging
  Downloading packaging-21.3-py3-none-any.whl (40 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 40.8/40.8 kB 5.6 MB/s eta 0:00:00
Collecting resolvelib<0.6.0,>=0.5.3
  Downloading resolvelib-0.5.4-py2.py3-none-any.whl (12 kB)
Collecting cffi>=1.12
  Downloading cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (427 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 427.9/427.9 kB 37.8 MB/s eta 0:00:00
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-2.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Collecting pyparsing!=3.0.5,>=2.0.2
  Downloading pyparsing-3.0.9-py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.3/98.3 kB 13.5 MB/s eta 0:00:00
Collecting pycparser
  Downloading pycparser-2.21-py2.py3-none-any.whl (118 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 118.7/118.7 kB 14.1 MB/s eta 0:00:00
Building wheels for collected packages: ansible-core
  Building wheel for ansible-core (setup.py): started
  Building wheel for ansible-core (setup.py): finished with status 'done'
  Created wheel for ansible-core: filename=ansible_core-2.11.5-py3-none-any.whl size=1958072 sha256=9c3c18d0aea7495ea936af593ee74016d8e57ef9f82b9aa16159928349bddb02
  Stored in directory: /root/.cache/pip/wheels/85/5b/29/6265f34d09573e9db339824a7fdfcbc54dea5f7868322855db
Successfully built ansible-core
Installing collected packages: resolvelib, pyparsing, pycparser, MarkupSafe, packaging, jinja2, cffi, cryptography, ansible-core
Successfully installed MarkupSafe-2.1.1 ansible-core-2.11.5 cffi-1.15.1 cryptography-38.0.1 jinja2-3.1.2 packaging-21.3 pycparser-2.21 pyparsing-3.0.9 resolvelib-0.5.4
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/utils/logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "/usr/local/lib/python3.7/dist-packages/pip/_vendor/rich/console.py", line 1673, in print
    extend(render(renderable, render_options))
  File "/usr/local/lib/python3.7/dist-packages/pip/_vendor/rich/console.py", line 1305, in render
    for render_output in iter_render:
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/utils/logging.py", line 134, in __rich_console__
    for line in lines:
  File "/usr/local/lib/python3.7/dist-packages/pip/_vendor/rich/segment.py", line 249, in split_lines
    for segment in segments:
  File "/usr/local/lib/python3.7/dist-packages/pip/_vendor/rich/console.py", line 1283, in render
    renderable = rich_cast(renderable)
  File "/usr/local/lib/python3.7/dist-packages/pip/_vendor/rich/protocol.py", line 36, in rich_cast
    renderable = cast_method()
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/self_outdated_check.py", line 130, in __rich__
    pip_cmd = get_best_invocation_for_this_pip()
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/utils/entrypoints.py", line 60, in get_best_invocation_for_this_pip
    os.path.join(binary_prefix, exe_name),
  File "/usr/lib/python3.7/genericpath.py", line 97, in samefile
    s2 = os.stat(f2)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/pip3.7'
Call stack:
  File "/usr/local/bin/pip3", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/cli/main.py", line 70, in main
    return command.main(cmd_args)
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/cli/base_command.py", line 101, in main
    return self._main(args)
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/cli/base_command.py", line 223, in _main
    self.handle_pip_version_check(options)
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/cli/req_command.py", line 190, in handle_pip_version_check
    pip_self_version_check(session, options)
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/self_outdated_check.py", line 236, in pip_self_version_check
    logger.warning("[present-rich] %s", upgrade_prompt)
  File "/usr/lib/python3.7/logging/__init__.py", line 1395, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/lib/python3.7/logging/__init__.py", line 1519, in _log
    self.handle(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 1529, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 1591, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.7/logging/__init__.py", line 905, in handle
    self.emit(record)
  File "/usr/local/lib/python3.7/dist-packages/pip/_internal/utils/logging.py", line 179, in emit
    self.handleError(record)
Message: '[present-rich] %s'
Arguments: (UpgradePrompt(old='22.2.2', new='22.3'),)
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the 
controller starting with Ansible 2.12. Current version: 3.7.3 (default, Jan 22 
2021, 20:04:44) [GCC 8.3.0]. This feature will be removed from ansible-core in 
version 2.12. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```

Which issue(s) this PR fixes:

Fixes #

**Additional context**
