### PR TITLE
Add support for Ubuntu 2204 for vSphere

### DIFF
--- a/docs/book/src/capi/providers/vsphere.md
+++ b/docs/book/src/capi/providers/vsphere.md
@@ -84,6 +84,7 @@ In addition to the configuration found in `images/capi/packer/config`, the `ova`
 | `rhel-7.json`      | The settings for the RHEL 7 image                            |
 | `ubuntu-1804.json` | The settings for the Ubuntu 18.04 image                      |
 | `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image                      |
+| `ubuntu-2204.json` | The settings for the Ubuntu 22.04 image                        |
 | `vsphere.json`     | Additional settings needed when building on a remote vSphere |
 
 ### Photon specific options

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -284,7 +284,7 @@ FLATCAR_VERSIONS		:=	flatcar
 PHOTON_VERSIONS			:=	photon-3 photon-4
 RHEL_VERSIONS			:=	rhel-7 rhel-8
 ROCKYLINUX_VERSIONS     :=  rockylinux-8
-UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi
+UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi ubuntu-2204
 WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
 
 # Set Flatcar Container Linux channel and version if not supplied
@@ -625,6 +625,7 @@ build-node-ova-vsphere-rhel-8: ## Builds RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
+build-node-ova-vsphere-ubuntu-2204: ## Builds Ubuntu 22.04 Node OVA and template on vSphere
 build-node-ova-vsphere-windows-2019: ## Builds for Windows Server 2019 and template on vSphere
 build-node-ova-vsphere-windows-2004: ## Builds for Windows Server 2004 SAC and template on vSphere
 build-node-ova-vsphere-windows-2022: ## Builds for Windows Server 2022 template on vSphere
@@ -639,6 +640,7 @@ build-node-ova-vsphere-clone-rhel-8: ## Builds RHEL 8 Node OVA and template on v
 build-node-ova-vsphere-clone-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
+build-node-ova-vsphere-clone-ubuntu-2204: ## Builds Ubuntu 22.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-all: $(NODE_OVA_VSPHERE_CLONE_BUILD_TARGETS) ## Builds all Node OVAs and templates on vSphere
 
 build-node-ova-vsphere-base-centos-7: ## Builds base CentOS 7 Node OVA and template on vSphere
@@ -649,6 +651,7 @@ build-node-ova-vsphere-base-rhel-8: ## Builds base RHEL 8 Node OVA and template 
 build-node-ova-vsphere-base-rockylinux-8: ## Builds base RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-1804: ## Builds base Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2004: ## Builds base Ubuntu 20.04 Node OVA and template on vSphere
+build-node-ova-vsphere-base-ubuntu-2204: ## Builds base Ubuntu 22.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-all: $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS) ## Builds all base Node OVAs and templates on vSphere
 
 build-node-ova-local-vmx-photon-3: ## Builds Photon 3 Node OVA from VMX file w local hypervisor
@@ -766,6 +769,7 @@ validate-node-ova-local-rhel-8: ## Validates RHEL 8 Node OVA Packer config w loc
 validate-node-ova-local-rockylinux-8: ## Validates RockyLinux 8 Node OVA Packer config w local hypervisor
 validate-node-ova-local-ubuntu-1804: ## Validates Ubuntu 18.04 Node OVA Packer config w local hypervisor
 validate-node-ova-local-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA Packer config w local hypervisor
+validate-node-ova-local-ubuntu-2204: ## Validates Ubuntu 22.04 Node OVA Packer config w local hypervisor
 validate-node-ova-local-windows-2019: ## Validates Windows Server 2019 Node OVA Packer config w local hypervisor
 validate-node-ova-local-windows-2004: ## Validates Windows Server 2004 SAC Node OVA Packer config w local hypervisor
 validate-node-ova-local-windows-2022: ## Validates Windows Server 2022 Node OVA Packer config w local hypervisor
@@ -779,6 +783,7 @@ validate-node-ova-local-vmx-rhel-8: ## Validates RHEL 8 Node OVA from VMX file w
 validate-node-ova-local-vmx-rockylinux-8: ## Validates RockyLinux 8 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-ubuntu-1804: ## Validates Ubuntu 18.04 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA from VMX file w local hypervisor
+validate-node-ova-local-vmx-ubuntu-2204: ## Validates Ubuntu 22.04 Node OVA from VMX file w local hypervisor
 
 validate-node-ova-local-base-photon-3: ## Validates Photon 3 Base Node OVA w local hypervisor
 validate-node-ova-local-base-photon-4: ## Validates Photon 4 Base Node OVA w local hypervisor
@@ -788,6 +793,7 @@ validate-node-ova-local-base-rhel-8: ## Validates RHEL 8 Base Node OVA w local h
 validate-node-ova-local-base-rockylinux-8: ## Validates RockyLinux 8 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-1804: ## Validates Ubuntu 18.04 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-2004: ## Validates Ubuntu 20.04 Base Node OVA w local hypervisor
+validate-node-ova-local-base-ubuntu-2204: ## Validates Ubuntu 22.04 Base Node OVA w local hypervisor
 
 validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
@@ -1,0 +1,88 @@
+#cloud-config
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# For more information on how autoinstall is configured, please refer to
+# https://ubuntu.com/server/docs/install/autoinstall-reference
+autoinstall:
+  version: 1
+  # Disable ssh server during installation, otherwise packer tries to connect and exceed max attempts
+  early-commands:
+    - systemctl stop ssh
+  # Configure the locale
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  # Create a single-partition with no swap space. Kubernetes
+  # really dislikes the idea of anyone else managing memory.
+  # For more information on how partitioning is configured,
+  # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
+  storage:
+    config:
+      - type: disk
+        id: disk-0
+        size: largest
+        grub_device: true
+        preserve: false
+        ptable: msdos
+        wipe: superblock
+      - type: partition
+        id: partition-0
+        device: disk-0
+        size: -1
+        number: 1
+        preserve: false
+        flag: boot
+      - type: format
+        id: format-0
+        volume: partition-0
+        fstype: ext4
+        preserve: false
+      - type: mount
+        id: mount-0
+        device: format-0
+        path: /
+  updates: 'all'
+  ssh:
+    install-server: true
+    allow-pw: true
+  # Customize the list of packages installed.
+  packages:
+    - open-vm-tools
+  # Create the default user.
+  # Ensures the "builder" user doesn't require a password to use sudo.
+  user-data:
+    users:
+      - name: builder
+        # openssl passwd -6 -stdin <<< builder
+        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
+        groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+        lock-passwd: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+
+  # This command runs after all other steps; it:
+  # 1. Disables swapfiles
+  # 2. Removes the existing swapfile
+  # 3. Removes the swapfile entry from /etc/fstab
+  # 4. Cleans up any packages that are no longer required
+  # 5. Removes the cached list of packages
+  late-commands:
+    - swapoff -a
+    - rm -f /swapfile
+    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - rm -f /etc/udev/rules.d/70-persistent-net.rules
+    - apt-get purge --auto-remove -y
+    - rm -rf /var/lib/apt/lists/*

--- a/images/capi/packer/ova/ubuntu-2204.json
+++ b/images/capi/packer/ova/ubuntu-2204.json
@@ -1,0 +1,17 @@
+{
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_disable_ipv6": "0",
+  "boot_media_path": "/media/HTTP",
+  "build_name": "ubuntu-2204",
+  "distro_arch": "amd64",
+  "distro_name": "ubuntu",
+  "distro_version": "22.04",
+  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now",
+  "vsphere_guest_os_type": "ubuntu64Guest"
+}

--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -22,7 +22,7 @@ CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
 export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
-TARGETS=("ubuntu-1804" "ubuntu-2004" "photon-3" "photon-4" "centos-7" "rockylinux-8" "flatcar")
+TARGETS=("ubuntu-1804" "ubuntu-2004" "ubuntu-2204" "photon-3" "photon-4" "centos-7" "rockylinux-8" "flatcar")
 
 on_exit() {
   # kill the VPN
@@ -112,6 +112,16 @@ EOF
 "build_version": "capv-ci-${target}-${TIMESTAMP}",
 "linked_clone": "true",
 "template": "base-rockylinux-8-20220623"
+}
+EOF
+    make build-node-ova-vsphere-clone-${target} > ${ARTIFACTS}/${target}.log 2>&1 &
+
+  elif [[ "${target}" == 'ubuntu-2204' ]]; then
+    cat << EOF > ci-${target}.json
+{
+"build_version": "capv-ci-${target}-${TIMESTAMP}",
+"linked_clone": "true",
+"template": "base-ubuntu-2204"
 }
 EOF
     make build-node-ova-vsphere-clone-${target} > ${ARTIFACTS}/${target}.log 2>&1 &


### PR DESCRIPTION
What this PR does / why we need it:
Adds Ubuntu 22.04 LTS build support to vSphere.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #960

**Additional context**
I have tested this our internal pipeline(builds successfully and creates the images), but havent yet used the created images to create a cluster and test

Please note that the portions of the PR w.r.t. autoinstall(preseed) have been taken from @Meecr0b in his PR# [997](https://github.com/kubernetes-sigs/image-builder/pull/997)(thank you for this). As he has mentioned in the PR, preseed has been replaced by autoinstall