### PR TITLE
Add pipeline test job for Azure VHDs

### DIFF
--- a/images/capi/packer/azure/.pipelines/build-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/build-vhd.yaml
@@ -22,8 +22,15 @@ jobs:
   - script: |
       set -o pipefail
       make deps-azure
-      os=$(echo "$OS" | tr '[:upper:]' '[:lower:]') 
-      version=$(echo "$OS_VERSION" | tr '[:upper:]' '[:lower:]' | tr -d .)
+      os=$(echo "${OS}" | tr '[:upper:]' '[:lower:]')
+      version=$(echo "${OS_VERSION}" | tr '[:upper:]' '[:lower:]' | tr -d .)
+      export RESOURCE_GROUP_NAME="cluster-api-images"
+
+      # timestamp is in RFC-3339 format to match kubetest
+      export TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+      export JOB_NAME="${JOB_NAME:-"image-builder-vhd"}"
+      export TAGS="creationTimestamp=${TIMESTAMP} jobName=${JOB_NAME}"
+      printf "${TAGS}" | tee packer/azure/tags.out
       make build-azure-vhd-$os-$version | tee packer/azure/packer.out
     displayName: Building VHD
     workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
@@ -39,5 +46,5 @@ jobs:
   - template: delete-storage-account.yaml
   - script: |
       chown -R $USER:$USER .
-    displayName: cleanup - chown all files in work directory 
+    displayName: cleanup - chown all files in work directory
     condition: always()

--- a/images/capi/packer/azure/.pipelines/generate-sas.yaml
+++ b/images/capi/packer/azure/.pipelines/generate-sas.yaml
@@ -4,7 +4,10 @@ steps:
       RESOURCE_GROUP_NAME=$(jq -r '.builds[-1].custom_data.resource_group_name' manifest.json | cut -d ":" -f2)
       STORAGE_ACCOUNT_NAME=$(jq -r '.builds[-1].custom_data.storage_account_name' manifest.json | cut -d ":" -f2)
       OS_DISK_URI=$(cat packer/azure/packer.out | grep "OSDiskUri:" -m 1 | cut -d " " -f 2)
+      printf "${STORAGE_ACCOUNT_NAME}" | tee packer/azure/storage-account-name.out
+      printf "${OS_DISK_URI}" | tee packer/azure/vhd-base-url.out
       printf "${OS_DISK_URI}?" | tee packer/azure/vhd-url.out
+      printf "${RESOURCE_GROUP_NAME}" | tee packer/azure/resource-group-name.out
       az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
       az account set -s ${AZURE_SUBSCRIPTION_ID}
       ACCOUNT_KEY=$(az storage account keys list -g ${RESOURCE_GROUP_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --account-name ${STORAGE_ACCOUNT_NAME} --query '[0].value')

--- a/images/capi/packer/azure/.pipelines/stages.yaml
+++ b/images/capi/packer/azure/.pipelines/stages.yaml
@@ -28,6 +28,16 @@ stages:
       AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET_VHD)
       AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID_VHD)
 
+  - stage: test
+    condition: and(succeeded(), eq(variables.CLEANUP, 'False'))
+    jobs:
+    - template: test-vhd.yaml
+    variables:
+      AZURE_TENANT_ID: $(AZURE_TENANT_ID_VHD)
+      AZURE_CLIENT_ID: $(AZURE_CLIENT_ID_VHD)
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET_VHD)
+      AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID_VHD)
+
   - stage: sku
     condition: and(succeeded(), eq(variables.CLEANUP, 'False'))
     jobs:

--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -1,0 +1,143 @@
+# Required pipeline variables:
+# - BUILD_POOL - Azure DevOps build pool to use
+# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer, and Ansible.
+# - AZ_CAPI_EXTENSION_URL - URL to the Azure CAPI extension build.
+# - AZURE_TENANT_ID - tenant ID
+# - AZURE_CLIENT_ID - Service principal ID
+# - AZURE_CLIENT_SECRET - Service principal secret
+# - AZURE_SUBSCRIPTION_ID - Subscription ID used by the pipeline
+# - KUBERNETES_VERSION - version of Kubernetes to build the image with, e.g. `1.16.2`
+# - OS - target of build e.g. `Ubuntu/Windows`
+# - OS_VERSION - target of build e.g. `18.04/2004/2019`
+
+jobs:
+- job: test_vhd
+  container: $[ variables['CONTAINER_IMAGE'] ]
+  timeoutInMinutes: 120
+  strategy:
+    maxParallel: 0
+  pool:
+    name: $(BUILD_POOL)
+  steps:
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: current
+      artifact: publishing-info
+      path: $(system.defaultWorkingDirectory)/images/capi/packer/azure/vhd/
+  - script: |
+      set -x
+      set -e -o pipefail
+
+      VHD_RESOURCE_ID=$(jq -r .vhd_base_url $(system.defaultWorkingDirectory)/images/capi/packer/azure/vhd/vhd-publishing-info.json)
+      STORAGE_ACCOUNT_NAME=$(jq -r .storage_account_name $(system.defaultWorkingDirectory)/images/capi/packer/azure/vhd/vhd-publishing-info.json)
+      TAGS=$(jq -r .tags $(system.defaultWorkingDirectory)/images/capi/packer/azure/vhd/vhd-publishing-info.json)
+    
+      echo "##vso[task.setvariable variable=VHD_RESOURCE_ID]$VHD_RESOURCE_ID"
+      echo "##vso[task.setvariable variable=STORAGE_ACCOUNT_NAME]$STORAGE_ACCOUNT_NAME"
+      echo "##vso[task.setvariable variable=TAGS;]$TAGS"
+    displayName: Import variables from build vhd job
+    env:
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+  - script: |
+      set -x
+      set -e -o pipefail
+
+      RANDOM=$(bash -c 'echo $RANDOM')
+      RESOURCE_GROUP="capi-testvmimage-${RANDOM}"
+      echo "${RESOURCE_GROUP}" is the group
+
+      # Azure CLI login
+      az login -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --service-principal --tenant $AZURE_TENANT_ID
+
+      # Find the VHD blob location from its storage account
+      AZURE_LOCATION=$(az storage account show --name "${STORAGE_ACCOUNT_NAME}" --query '[location]' -o tsv)
+
+      # Create the resource group
+      az group create --name "${RESOURCE_GROUP}" --location "${AZURE_LOCATION}" --tags "${TAGS}"
+
+      # Create a managed image from the VHD blob
+      OS_TYPE="Linux"
+      if [ "$OS" == "Windows" ]; then
+        OS_TYPE="Windows"
+      fi
+      az image create -n testvmimage -g "${RESOURCE_GROUP}" --os-type "${OS_TYPE}" --source "${VHD_RESOURCE_ID}"
+
+      # Pass the managed image resource ID on to the next step
+      IMAGE_ID=$(az image show -g "${RESOURCE_GROUP}" -n testvmimage --query '[id]' --output tsv)
+      echo "##vso[task.setvariable variable=RESOURCE_GROUP;]$RESOURCE_GROUP"
+      echo "##vso[task.setvariable variable=MANAGED_IMAGE_ID;]$IMAGE_ID"
+      echo "##vso[task.setvariable variable=AZURE_LOCATION;]$AZURE_LOCATION"
+    displayName: promote VHD blob to managed image
+    env:
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+  - template: k8s-config.yaml
+  - script: |
+      set -x
+      set -e -o pipefail
+
+      export PATH=${PATH}:.local/bin
+      ./packer/azure/scripts/ensure-kustomize.sh
+
+      # Generate cluster template with kustomize
+      if [ "$OS" == "Windows" ]; then
+        kustomize build --load-restrictor LoadRestrictionsNone $(system.defaultWorkingDirectory)/images/capi/packer/azure/scripts/test-templates/windows/ > $(system.defaultWorkingDirectory)/images/capi/packer/azure/scripts/test-templates/cluster-template.yaml
+      else
+        kustomize build --load-restrictor LoadRestrictionsNone $(system.defaultWorkingDirectory)/images/capi/packer/azure/scripts/test-templates/linux/ > $(system.defaultWorkingDirectory)/images/capi/packer/azure/scripts/test-templates/cluster-template.yaml
+      fi
+      TEST_TEMPLATE=$(system.defaultWorkingDirectory)/images/capi/packer/azure/scripts/test-templates/cluster-template.yaml
+      echo "##vso[task.setvariable variable=TEST_TEMPLATE;]$TEST_TEMPLATE"
+    displayName: generate cluster template
+    workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
+    env:
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+  - script: |
+      set -x
+      set -e -o pipefail
+
+      os=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
+
+      # Set up the Azure CLI Cluster API extension
+      # https://github.com/Azure/azure-capi-cli-extension/releases/download/az-capi-nightly/capi-0.0.vnext-py2.py3-none-any.whl
+      az extension add --yes --source "${AZ_CAPI_EXTENSION_URL}"
+
+      # Install required binaries
+      mkdir ~/test-binaries
+      export PATH=${PATH}:~/test-binaries
+      az capi install -a -ip ~/test-binaries
+
+      echo "##vso[task.setvariable variable=PATH;]$PATH"
+    displayName: Install and configure az capi extension
+    env:
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+  - script: |
+      params=()
+      if [ "$OS" == "Windows" ]; then
+        params+=(--windows)
+      fi
+      
+      # Create a cluster
+      az capi create \
+        --yes \
+        --debug \
+        --name testvm \
+        --kubernetes-version="${KUBERNETES_VERSION}" \
+        --location="${AZURE_LOCATION}" \
+        --resource-group="${RESOURCE_GROUP}" \
+        --management-cluster-resource-group-name="${RESOURCE_GROUP}" \
+        --control-plane-machine-count=1 \
+        --node-machine-count=1 \
+        --template="${TEST_TEMPLATE}" \
+        --tags="${TAGS}" \
+        --wait-for-nodes=2 \
+        "${params[@]}"
+    displayName: Create a cluster
+    env:
+      AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+  - script: |
+      set -x
+      set -e -o pipefail
+
+      # Clean up the test resource group
+      az group delete -n "${RESOURCE_GROUP}" --yes --no-wait
+    displayName: Clean up test resource group
+    condition: always()

--- a/images/capi/packer/azure/.pipelines/vhd-publishing-info.yaml
+++ b/images/capi/packer/azure/.pipelines/vhd-publishing-info.yaml
@@ -1,9 +1,17 @@
 steps:
 - script: |
+      VHD_BASE_URL="$(cat packer/azure/vhd-base-url.out)"
       VHD_URL="$(cat packer/azure/vhd-url.out)"
+      STORAGE_ACCOUNT_NAME="$(cat packer/azure/storage-account-name.out)"
+      RESOURCE_GROUP_NAME="$(cat packer/azure/resource-group-name.out)"
+      TAGS="$(cat packer/azure/tags.out)"
       cat <<EOF > packer/azure/vhd-publishing-info.json
       {
-          "vhd_url" : "$VHD_URL"
+          "vhd_base_url": "${VHD_BASE_URL}",
+          "vhd_url": "${VHD_URL}",
+          "storage_account_name": "${STORAGE_ACCOUNT_NAME}",
+          "resource_group_name": "${RESOURCE_GROUP_NAME}",
+          "tags": "${TAGS}"
       }
       EOF
   displayName: Generating publishing info for VHD

--- a/images/capi/packer/azure/scripts/ensure-kustomize.sh
+++ b/images/capi/packer/azure/scripts/ensure-kustomize.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/../../..
+cd "${CAPI_ROOT}" || exit 1
+
+source hack/utils.sh
+
+if command -v kustomize >/dev/null 2>&1; then exit 0; fi
+
+mkdir -p .local/bin && cd .local/bin
+
+KUSTOMIZE_VERSION=4.5.2
+_binfile="kustomize-v${KUSTOMIZE_VERSION}.tar.gz"
+
+echo "installing kustomize"
+curl -sLo "${_binfile}" "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_${HOSTOS}_${HOSTARCH}.tar.gz"
+tar -zvxf "${_binfile}" -C "./"
+chmod +x "./kustomize"
+rm "${_binfile}"
+echo "'kustomize' has been installed to $(pwd), make sure this directory is in your \$PATH"

--- a/images/capi/packer/azure/scripts/init-vhd.sh
+++ b/images/capi/packer/azure/scripts/init-vhd.sh
@@ -17,8 +17,13 @@ if ! az group show -n ${RESOURCE_GROUP_NAME} -o none 2>/dev/null; then
 fi
 CREATE_TIME="$(date +%s)"
 RANDOM_SUFFIX="$(head /dev/urandom | LC_ALL=C tr -dc a-z | head -c 4 ; echo '')"
+get_random_region() {
+  local REGIONS=("canadacentral" "eastus" "eastus2" "northeurope" "uksouth" "westeurope" "westus2" "westus3")
+  echo "${REGIONS[${RANDOM} % ${#REGIONS[@]}]}"
+}
+export AZURE_LOCATION="$(get_random_region)"
 export STORAGE_ACCOUNT_NAME="${STORAGE_ACCOUNT_NAME:-capi${CREATE_TIME}${RANDOM_SUFFIX}}"
 az storage account check-name --name ${STORAGE_ACCOUNT_NAME}
-az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} --allow-blob-public-access false
+az storage account create -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} -l ${AZURE_LOCATION} --allow-blob-public-access false
 
 echo "done"

--- a/images/capi/packer/azure/scripts/test-templates/linux/kustomization.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/linux/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.6.0/cluster-template.yaml
+patchesStrategicMerge:
+- ../patches/azuremachinetemplate-controlplane.yaml
+- ../patches/azuremachinetemplate-workload.yaml

--- a/images/capi/packer/azure/scripts/test-templates/patches/azuremachinetemplate-controlplane.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/patches/azuremachinetemplate-controlplane.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      image:
+        id: ${MANAGED_IMAGE_ID}
+---

--- a/images/capi/packer/azure/scripts/test-templates/patches/azuremachinetemplate-windows.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/patches/azuremachinetemplate-windows.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-win
+  namespace: default
+spec:
+  template:
+    spec:
+      image:
+        id: ${MANAGED_IMAGE_ID}
+---

--- a/images/capi/packer/azure/scripts/test-templates/patches/azuremachinetemplate-workload.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/patches/azuremachinetemplate-workload.yaml
@@ -1,0 +1,11 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: AzureMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      image:
+        id: ${MANAGED_IMAGE_ID}
+---

--- a/images/capi/packer/azure/scripts/test-templates/patches/kubeadmcontrolplane-windows.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/patches/kubeadmcontrolplane-windows.yaml
@@ -1,0 +1,8 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+  namespace: default
+spec:
+  version: ${KUBERNETES_BOOTSTRAP_VERSION}
+---

--- a/images/capi/packer/azure/scripts/test-templates/patches/machinedeployment-windows.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/patches/machinedeployment-windows.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+  namespace: default
+spec:
+  replicas: 0
+---

--- a/images/capi/packer/azure/scripts/test-templates/windows/kustomization.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/windows/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.6.0/cluster-template-windows.yaml
+patchesStrategicMerge:
+- ../patches/azuremachinetemplate-windows.yaml
+- ../patches/kubeadmcontrolplane-windows.yaml
+- ../patches/machinedeployment-windows.yaml


### PR DESCRIPTION
What this PR does / why we need it:
Currently, the Azure image publishing pipelines doesn't run any sort of validation to ensure the image is working. This PR adds a step in the image publishing pipeline after building the VHD that: 
- Applies the managed image to a cluster template.
- Builds a CAPZ cluster from the template using the [az capi cli extension](https://github.com/Azure/azure-capi-cli-extension).
- Ensures the nodes are running and ready. 

Which issue(s) this PR fixes: Fixes #992 

**Additional context**
cc @mboersma @CecileRobertMichon 