### PR TITLE
Add Ubuntu 22.04 LTS build support to CAPI OCI provider

### DIFF
--- a/docs/book/src/capi/providers/oci.md
+++ b/docs/book/src/capi/providers/oci.md
@@ -29,6 +29,8 @@ the different operating systems.
 | `oracle-linux-8.json` | The settings for the Oracle Linux 8 image |
 | `ubuntu-1804.json` | The settings for the Ubuntu 18.04 image |
 | `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
+| `ubuntu-2204.json` | The settings for the Ubuntu 22.04 image |
+
 
 #### Common options
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -304,7 +304,7 @@ AZURE_BUILD_VHD_NAMES	   ?= $(addprefix azure-vhd-,$(VHD_TARGETS))
 AZURE_BUILD_SIG_NAMES	   ?= $(addprefix azure-sig-,$(SIG_TARGETS))
 AZURE_BUILD_SIG_GEN2_NAMES ?= $(addsuffix -gen2,$(addprefix azure-sig-,$(SIG_GEN2_TARGETS)))
 
-OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-oracle-linux-8
+OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
@@ -655,6 +655,7 @@ build-raw-all: $(RAW_BUILD_TARGETS) ## Builds all RAW images
 
 build-oci-ubuntu-1804: ## Builds the OCI ubuntu-1804 image
 build-oci-ubuntu-2004: ## Builds the OCI ubuntu-2004 image
+build-oci-ubuntu-2204: ## Builds the OCI ubuntu-2204 image
 build-oci-oracle-linux-8: ## Builds the OCI Oracle Linux 8.x image
 build-oci-all: $(OCI_BUILD_TARGETS) ## Builds all OCI image
 
@@ -759,6 +760,7 @@ validate-raw-all: $(RAW_VALIDATE_TARGETS) ## Validates all RAW Packer config
 
 validate-oci-ubuntu-1804: ## Validates the OCI ubuntu-1804 image packer config
 validate-oci-ubuntu-2004: ## Validates the OCI ubuntu-2004 image packer config
+validate-oci-ubuntu-2204: ## Validates the OCI ubuntu-2204 image packer config
 validate-oci-oracle-linux-8: ## Validates the OCI Oracle Linux 8.x image packer config
 validate-oci-all: $(OCI_VALIDATE_TARGETS) ## Validates all OCI image packer config
 

--- a/images/capi/packer/oci/ubuntu-2204.json
+++ b/images/capi/packer/oci/ubuntu-2204.json
@@ -1,0 +1,7 @@
+{
+  "build_name": "ubuntu-2204",
+  "distribution": "ubuntu",
+  "operating_system": "Canonical Ubuntu",
+  "operating_system_version": "22.04",
+  "ssh_username": "ubuntu"
+}


### PR DESCRIPTION
What this PR does / why we need it:
Adds support for building Ubuntu 22.04 image using OCI

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fix: #960

**Additional context**
Add any other context for the reviewers
I've built and tested image build as well as using the built image with CAPI