### PR TITLE
Added qemu/kubevirt support for multiple Kubernetes versions

### DIFF
--- a/images/capi/packer/qemu/README.md
+++ b/images/capi/packer/qemu/README.md
@@ -1,0 +1,6 @@
+To build an image using a specific version of Kubernetes use the "PACKER_FLAGS" env var like in the example below:
+
+PACKER_FLAGS="--var 'kubernetes_rpm_version=1.25.3-0' --var 'kubernetes_semver=v1.25.3' --var 'kubernetes_series=v1.25'  --var 'kubernetes_deb_version=1.25.3-00'" make build-kubevirt-qemu-ubuntu-2004
+
+P.S: In order to change disk size(defaults to 20GB as of 31.10.22) you can update PACKER_FLAGS with:
+--var 'disk_size=<disk size in mb>'


### PR DESCRIPTION
Signed-off-by: Isaac Dorfman <idorfman@redhat.com>

This PR allow building qemu/kubevirt target with multiple Kubernetes versions by setting "PACKER_VAR_FILES" to one of the overwrite jsons added in this PR to the qemu folder.