### PR TITLE
Fix ansible SSH not connecting

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -332,7 +332,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa'"
       ],
       "except": [
         "vmware-iso-base",
@@ -363,7 +363,7 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa'"
       ],
       "except": [
         "vmware-iso-base",


### PR DESCRIPTION
What this PR does / why we need it:

Fix Ansible SSH not connecting because the image uses an ssh-rsa key which is disabled by default in recent OpenSSH.



Ansible SSH, since recent OpenSSH has disabled the usage of "old" ssh-rsa keys, cannot connect to the image; the Ubuntu 20.04 image still uses ssh-rsa.

`make build-node-ova-vsphere-ubuntu-2004`

 ```
   vsphere:
    vsphere: PLAY [all] *********************************************************************
==> vsphere: failed to handshake
    vsphere:
    vsphere: TASK [Gathering Facts] *********************************************************
    vsphere: fatal: [default]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Unable to negotiate with 127.0.0.1 port 43161: no matching host key type found. Their offer: ssh-rsa", "unreachable": true}
    vsphere:
    vsphere: PLAY RECAP *********************************************************************
    vsphere: default                    : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0
    vsphere:
```

This PR adds the correct options to ANSIBLE_SSH_ARGS to have Ansible connect.