### PR TITLE
Fix ova creation not finding correct vmdk

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -293,7 +293,7 @@
       ],
       "inline": [
         "cd {{user `output_dir`}}",
-        "../../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --ovf_template ../../hack/ovf_template.xml --vmdk_file {{user `build_version`}}-disk-0.vmdk"
+        "../../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --ovf_template ../../hack/ovf_template.xml"
       ],
       "name": "vsphere",
       "type": "shell-local"


### PR DESCRIPTION
What this PR does / why we need it:

Fix correct calling of image-build-ova.py from packer: an explicit vmdk file name was incorrectly set, revert to reading it from packer manifest.

As seen below, in vSphere the disk image is called "ubuntu-2004-kube-v1.23.10-0.vmdk", but the image-build-ova.py script is called explicitly setting the vmdk image as "ubuntu-2004-kube-v1.23.10-disk-0.vmdk".
With this PR we call the image-build-ova.py script without explicitly setting an image file, thus letting it read the name correctly from the packer manifest.

`make build-node-ova-vsphere-ubuntu-2004`

```
==> vsphere: Eject CD-ROM drives...
    vsphere: Starting export...
    vsphere: Downloading: ubuntu-2004-kube-v1.23.10-0.vmdk
    vsphere: Exporting file: ubuntu-2004-kube-v1.23.10-0.vmdk
    vsphere: Writing ovf...
==> vsphere: Clear boot order...
==> vsphere: Running post-processor: packer-manifest (type manifest)
==> vsphere: Running post-processor: vsphere (type shell-local)
==> vsphere (shell-local): Running local shell script: /tmp/packer-shell2326596846
    vsphere (shell-local): image-build-ova: cd .
    vsphere (shell-local): image-build-ova: loaded ubuntu-2004-kube-v1.23.10
==> vsphere (shell-local): Traceback (most recent call last):
==> vsphere (shell-local):   File "/home/agtogna/workdir/image-builder/images/capi/output/ubuntu-2004-kube-v1.23.10/../../hack/image-build-ova.py", line 272, in <module>
==> vsphere (shell-local):     main()
==> vsphere (shell-local):   File "/home/agtogna/workdir/image-builder/images/capi/output/ubuntu-2004-kube-v1.23.10/../../hack/image-build-ova.py", line 97, in main
==> vsphere (shell-local):     vmdk_files = [{"name": args.vmdk_file, "size": os.path.getsize(args.vmdk_file)}]
==> vsphere (shell-local):   File "/usr/lib/python3.10/genericpath.py", line 50, in getsize
==> vsphere (shell-local):     return os.stat(filename).st_size
==> vsphere (shell-local): FileNotFoundError: [Errno 2] No such file or directory: 'ubuntu-2004-kube-v1.23.10-disk-0.vmdk'
==> vsphere: Running post-processor: custom-post-processor (type shell-local)

```