### PR TITLE
feat(gcp): user overridable image_name and image_family for gce

### DIFF
--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -2,8 +2,8 @@
   "builders": [
     {
       "disable_default_service_account": "{{ user `disable_default_service_account` }}",
-      "image_family": "capi-{{user `build_name`}}-k8s-{{user `kubernetes_series` | clean_resource_name}}",
-      "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver` | clean_resource_name}}-{{user `build_timestamp`}}",
+      "image_family": "{{user `image_family` | clean_resource_name}}",
+      "image_name": "{{user `image_name` | clean_resource_name}}",
       "labels": {
         "build_timestamp": "{{user `build_timestamp`}}",
         "distribution": "ubuntu",
@@ -92,6 +92,8 @@
     "disable_default_service_account": "",
     "encrypted": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "image_family": "capi-{{user `build_name`}}-k8s-{{user `kubernetes_series`}}",
+    "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_http_source": null,
     "kubernetes_cni_rpm_version": null,


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds the capability to override `image_name` and `image_family` for GCE images.
We would like to be able to have our own naming convention when storing images to standardize the way they can be found whatever the provider.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

n.a

**Additional context**

I tried to keep the default naming behavior as much as possible but due to limitation of using functions within the `variables` block, I had to use `clean_resource_name` function on the entire variable instead of substrings:

https://github.com/kubernetes-sigs/image-builder/blob/03def50db05d589d409cbe9409912e1f6cdc51fe/images/capi/packer/gce/packer.json#L5-L6

What are you thoughts on this?