### PR TITLE
Add packer plugin install for oracle

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -117,6 +117,7 @@ deps-oci: ## Installs/checks dependencies for OCI builds
 deps-oci:
 	hack/ensure-ansible.sh
 	hack/ensure-packer.sh
+	packer plugins install github.com/hashicorp/oracle
 
 .PHONY: deps-vbox
 deps-vbox: ## Installs/checks dependencies for VirtualBox builds


### PR DESCRIPTION
What this PR does / why we need it:
As of [Packer 1.8.4 ](https://github.com/hashicorp/packer/blob/main/CHANGELOG.md#184-october-28-2022) the Oracle plugin is no longer vendored. This will make sure `oracle-oci` is installed.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1016

**Additional context**
Add any other context for the reviewers