### PR TITLE
Set FLATCAR_VERSION to latest available in Azure CI

### DIFF
--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -78,6 +78,13 @@ trap cleanup EXIT
 
 make deps-azure
 
+# Latest Flatcar version is often available on Azure with a delay, so resolve ourselves
+az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+get_flatcar_version() {
+    az vm image show --urn kinvolk:flatcar-container-linux-free:stable:latest --query 'name' -o tsv
+}
+export FLATCAR_VERSION="$(get_flatcar_version)"
+
 # Pre-pulling windows images takes 10-20 mins
 # Disable them for CI runs so don't run into timeouts
 export PACKER_VAR_FILES="packer/azure/scripts/disable-windows-prepull.json scripts/ci-disable-goss-inspect.json"


### PR DESCRIPTION
What this PR does / why we need it:
The default `FLATCAR_VERSION=current` resolves to something that is not always available on Azure. Override its value to the latest version actually available in Azure's marketplace, to ensure that CI does not fail because of this.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1002

**Additional context**
Add any other context for the reviewers:
I have no better idea than doing it this way, I investigated conditionally returning a different value from image-grok-latest-flatcar-version but found no way to access the "target" from global scope in the Makefile.
Setting `FLATCAR_VERSION=latest` in the Azure CI script would also make it work, but is more hacky.