### PR TITLE
Refresh OWNERs file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,11 @@ reviewers:
 
 emeritus_approvers:
   - akutz
+  - CecileRobertMichon
+  - codenrhoden
+  - detiber
   - figo
+  - justinsb
   - luxas
+  - moshloop
   - timothysc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,8 @@
 
 aliases:
   image-builder-maintainers:
-    - CecileRobertMichon
-    - codenrhoden
-    - detiber
     - jsturtevant
-    - justinsb
     - kkeshavamurthy
-    - moshloop
   image-builder-reviewers:
     - EleanorRigby
     - randomvariable

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,6 +4,7 @@ aliases:
   image-builder-maintainers:
     - jsturtevant
     - kkeshavamurthy
+    - mboersma
   image-builder-reviewers:
     - EleanorRigby
     - randomvariable


### PR DESCRIPTION
What this PR does / why we need it: 

Moves myself to emeritus as I no longer have the bandwidth to actively maintain this project.

Also used this as an opportunity to refresh the project OWNERS file and move all inactive (> 1 year) or known retired maintainers to emeritus (@codenrhoden @detiber @justinsb @moshloop - please speak up if any of you feels this was a mistake).

This leaves the maintainers list pretty lean. However, I believe it is better for the health of the project to be upfront about the need for new maintainers than having a bunch of maintainers that don't actually approve PRs. The project needs help, and there are several people that have expressed interest to get involved in Slack (cc @MarcusNoble @richardcase @MarcelMue @joekr) so I believe it's time to make space for more people to step up as reviewers and eventually maintainers. I recommend any one who would like to help and is already an active contributor (and member of k8s-sigs) opens a PR and adds themselves to the reviewers section of the OWNERs file. 

For now, I nominate @mboersma to become an additional as he has essentially been acting as a maintainer and reviewer for some time, along with @kkeshavamurthy and @jsturtevant. If folks prefer to make that change in a separate PR, I'm happy to do that.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers