### PR TITLE
Add AverageMarcus as reviewer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,6 +12,7 @@ aliases:
   image-builder-reviewers:
     - EleanorRigby
     - randomvariable
+    - AverageMarcus
   image-builder-azure-reviewers:
     - jsturtevant
   image-builder-openstack-reviewers:


### PR DESCRIPTION
What this PR does / why we need it:

Adds @AverageMarcus to project reviewers

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

Related: https://github.com/kubernetes-sigs/image-builder/pull/1024
