### PR TITLE
Migrate from osc to outscale and remove image centos7

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -309,7 +309,7 @@ OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-ubuntu-2204 oci-orac
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
-OSC_BUILD_NAMES 			?=	osc-centos-7 osc-ubuntu-2004
+OSC_BUILD_NAMES 			?=	osc-ubuntu-2004
 
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
@@ -661,7 +661,6 @@ build-oci-oracle-linux-8: ## Builds the OCI Oracle Linux 8.x image
 build-oci-all: $(OCI_BUILD_TARGETS) ## Builds all OCI image
 
 build-osc-ubuntu-2004: ## Builds Ubuntu 20.04 Outscale Snapshot
-build-osc-centos-7: ## Builds Centos 7 Outscale Snapshot
 build-osc-all: $(OSC_BUILD_TARGETS) ## Builds all Outscale Snapshot
 
 build-vbox-windows-2019: ## Builds for Windows Server 2019 Node VirtualBox w local hypervisor
@@ -766,7 +765,6 @@ validate-oci-oracle-linux-8: ## Validates the OCI Oracle Linux 8.x image packer 
 validate-oci-all: $(OCI_VALIDATE_TARGETS) ## Validates all OCI image packer config
 
 validate-osc-ubuntu-2004: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config
-validate-osc-centos-7: ## Validates Centos 7 Outscale Snapshot Packer config
 validate-osc-all: $(OSC_VALIDATE_TARGETS) ## Validates all Outscale Snapshot Packer config
 
 validate-vbox-windows-2019: ## Validates Windows Server 2019 Node VirtualBox Packer config w local hypervisor

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -19,7 +19,7 @@
   when: packer_builder_type.startswith('azure')
 
 - include_tasks: outscale.yml
-  when: packer_builder_type.startswith('osc')
+  when: packer_builder_type.startswith('outscale')
 
 - include_tasks: vmware.yml
   when: packer_builder_type is search('vmware') or

--- a/images/capi/ansible/roles/providers/tasks/outscale.yml
+++ b/images/capi/ansible/roles/providers/tasks/outscale.yml
@@ -10,6 +10,8 @@
 - name: Install cloud-init outscale package
   apt:
     deb: /tmp/cloud-init_22.2-outscale.deb
+    force: True
+    force_apt_get: True
   when: ansible_distribution == "Ubuntu"
 
 - name: Change cloud-init metadata outscale config in Ubuntu

--- a/images/capi/packer/outscale/centos-7.json
+++ b/images/capi/packer/outscale/centos-7.json
@@ -1,7 +1,0 @@
-{
-  "build_name": "centos-7",
-  "distribution": "centos",
-  "distribution_release": "centos-7",
-  "distribution_version": "7.7",
-  "image_name": "CentOS-7-2021.12.03-0"
-}


### PR DESCRIPTION
What this PR does / why we need it:
Outscale Packer plugin are now call outscale-bsu instead of osc-bsu since packer outscale v1.0.3. (https://github.com/outscale/packer-plugin-outscale/tree/main/docs)
Also we use only for the moment ubuntu image with our cloudinit change. 
Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers