### PR TITLE
Nutanix: Allow output image override if already exists

### DIFF
--- a/images/capi/packer/nutanix/nutanix.json
+++ b/images/capi/packer/nutanix/nutanix.json
@@ -7,5 +7,6 @@
   "nutanix_port": "9440",
   "nutanix_subnet_name": "",
   "nutanix_username": "pc_user",
-  "source_image_name": ""
+  "source_image_name": "",
+  "force_deregister": false
 }

--- a/images/capi/packer/nutanix/nutanix.json
+++ b/images/capi/packer/nutanix/nutanix.json
@@ -1,5 +1,5 @@
 {
-  "force_deregister": false,
+  "force_deregister": "false",
   "image_name": "",
   "nutanix_cluster_name": "",
   "nutanix_endpoint": "",

--- a/images/capi/packer/nutanix/nutanix.json
+++ b/images/capi/packer/nutanix/nutanix.json
@@ -1,4 +1,5 @@
 {
+  "force_deregister": false,
   "image_name": "",
   "nutanix_cluster_name": "",
   "nutanix_endpoint": "",
@@ -7,6 +8,5 @@
   "nutanix_port": "9440",
   "nutanix_subnet_name": "",
   "nutanix_username": "pc_user",
-  "source_image_name": "",
-  "force_deregister": false
+  "source_image_name": ""
 }

--- a/images/capi/packer/nutanix/packer.json
+++ b/images/capi/packer/nutanix/packer.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "cluster_name": "{{user `nutanix_cluster_name`}}",
+      "force_deregister": "{{user `force_deregister`}}",
       "image_name": "{{user `image_name`}}",
       "memory_mb": "{{user `memory`}}",
       "nutanix_endpoint": "{{user `nutanix_endpoint`}}",


### PR DESCRIPTION
Allow support for the `force_deregister` flag in the Nutanix Packer plugin (cf. https://developer.hashicorp.com/packer/plugins/builders/nutanix/nutanix#environment-configuration).

> [force_deregister](https://developer.hashicorp.com/packer/plugins/builders/nutanix/nutanix#force_deregister) (boolean) - Allow output image override if already exists.