### PR TITLE
add support for ansible_user_vars in nutanix

### DIFF
--- a/images/capi/packer/nutanix/packer.json
+++ b/images/capi/packer/nutanix/packer.json
@@ -50,7 +50,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
@@ -89,6 +91,7 @@
   "variables": {
     "ansible_common_vars": "",
     "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
+    "ansible_user_vars": "",
     "build_timestamp": "{{timestamp}}",
     "containerd_sha256": null,
     "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",


### PR DESCRIPTION
What this PR does / why we need it:
* Add support for `ansible_user_vars` when building images using Nutanix.