### PR TITLE
Update OWNERS_ALIASES for Azure

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,7 @@ aliases:
     - AverageMarcus
   image-builder-azure-reviewers:
     - jsturtevant
+    - mboersma
   image-builder-openstack-reviewers:
     - hidekazuna
   image-builder-cloudstack-reviewers:
@@ -35,7 +36,6 @@ aliases:
     - richardcase
     - sedefsavas
   cluster-api-azure-maintainers:
-    - alexeldeib
     - CecileRobertMichon
     - devigned
     - jackfrancis


### PR DESCRIPTION
What this PR does / why we need it:

Removes emeritus member @alexeldeib from the list of active CAPZ maintainers, and adds @mboersma to `image-builder-azure-reviewers`. See kubernetes-sigs/cluster-api-provider-azure#2939
