### PR TITLE
Adding a firewall rule to enable the 22 TCP port

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/ssh-archive.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/ssh-archive.yml
@@ -71,3 +71,13 @@
     Get-ChildItem -Path "{{ tempdir.stdout | trim }}\OpenSSH-Win64\*" -Recurse | Move-Item -Destination "{{ programfiles.stdout | trim }}\OpenSSH"
     Get-ChildItem -Path "{{ programfiles.stdout | trim }}\OpenSSH" | Unblock-File
     & 'C:\Program Files\OpenSSH\install-sshd.ps1'
+
+- name: Add OpenSSH firewall rule
+  win_firewall_rule:
+    name: sshd
+    localport: 22
+    action: allow
+    direction: in
+    protocol: tcp
+    state: present
+    enabled: yes

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -257,5 +257,11 @@ command:
     stdout:
     - True
     timeout: 30000
+  Check if SSH server port is open:
+    exec: powershell -command "(Get-NetFirewallRule -ErrorAction Stop -DisplayName 'sshd').Enabled"
+    exit-status: 0
+    stdout:
+        - True
+    timeout: 30000
 {{end}}
 {{end}} #end windows


### PR DESCRIPTION
What this PR does / why we need it:
The 22 port is not enabled by default and the service is not accessible when the node is created.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers