### PR TITLE
Update mdBook and fix darwin install

### DIFF
--- a/docs/book/build.sh
+++ b/docs/book/build.sh
@@ -24,7 +24,7 @@ cd "${KUBE_ROOT}" || exit 1
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 
-MDBOOK_VERSION="0.4.14"
+MDBOOK_VERSION="0.4.25"
 
 # translate arch to rust's conventions (if we can)
 if [[ ${arch} == "amd64" ]]; then
@@ -44,6 +44,8 @@ case ${os} in
         ;;
     darwin)
         target="apple-darwin"
+        # only x86_64 is published for darwin
+        arch="x86_64"
         ;;
     linux)
         # works for linux, too


### PR DESCRIPTION
What this PR does / why we need it:

Fixes `make build-book` on Apple Silicon and updates `mdBook` to the current patch release.

Which issue(s) this PR fixes:

N/A

**Additional context**:

Trying to run `make build-book` on my Mac leads to this error:

```shell
% make build-book
docs/book/build.sh
downloading mdBook-v0.4.14-arm64-apple-darwin.tar.gz
+ curl -sL -o /tmp/mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.14/mdBook-v0.4.14-arm64-apple-darwin.tar.gz
+ tar -C /tmp -xzvf /tmp/mdbook.tar.gz
tar: Error opening archive: Unrecognized archive format
make: *** [build-book] Error 1
```

This is because the URL above is a 404, since it's only [published for x86_64](https://github.com/rust-lang/mdBook/releases/tag/v0.4.25) architecture. That binary works fine on `arm64`.