### PR TITLE
feat: Add Oracle Linux 9 build support to CAPI OCI provider

### DIFF
--- a/docs/book/src/capi/providers/oci.md
+++ b/docs/book/src/capi/providers/oci.md
@@ -27,6 +27,7 @@ the different operating systems.
 | File | Description |
 |------|-------------|
 | `oracle-linux-8.json` | The settings for the Oracle Linux 8 image |
+| `oracle-linux-9.json` | The settings for the Oracle Linux 9 image |
 | `ubuntu-1804.json` | The settings for the Ubuntu 18.04 image |
 | `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
 | `ubuntu-2204.json` | The settings for the Ubuntu 22.04 image |

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -322,7 +322,7 @@ AZURE_BUILD_VHD_NAMES	   ?= $(addprefix azure-vhd-,$(VHD_TARGETS))
 AZURE_BUILD_SIG_NAMES	   ?= $(addprefix azure-sig-,$(SIG_TARGETS))
 AZURE_BUILD_SIG_GEN2_NAMES ?= $(addsuffix -gen2,$(addprefix azure-sig-,$(SIG_GEN2_TARGETS)))
 
-OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8
+OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-oracle-linux-9
 
 DO_BUILD_NAMES 			?=	do-centos-7 do-ubuntu-1804 do-ubuntu-2004
 
@@ -677,6 +677,7 @@ build-oci-ubuntu-1804: ## Builds the OCI ubuntu-1804 image
 build-oci-ubuntu-2004: ## Builds the OCI ubuntu-2004 image
 build-oci-ubuntu-2204: ## Builds the OCI ubuntu-2204 image
 build-oci-oracle-linux-8: ## Builds the OCI Oracle Linux 8.x image
+build-oci-oracle-linux-9: ## Builds the OCI Oracle Linux 9.x image
 build-oci-all: $(OCI_BUILD_TARGETS) ## Builds all OCI image
 
 build-osc-ubuntu-2004: ## Builds Ubuntu 20.04 Outscale Snapshot
@@ -783,6 +784,7 @@ validate-oci-ubuntu-1804: ## Validates the OCI ubuntu-1804 image packer config
 validate-oci-ubuntu-2004: ## Validates the OCI ubuntu-2004 image packer config
 validate-oci-ubuntu-2204: ## Validates the OCI ubuntu-2204 image packer config
 validate-oci-oracle-linux-8: ## Validates the OCI Oracle Linux 8.x image packer config
+validate-oci-oracle-linux-9: ## Validates the OCI Oracle Linux 9.x image packer config
 validate-oci-all: $(OCI_VALIDATE_TARGETS) ## Validates all OCI image packer config
 
 validate-osc-ubuntu-2004: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config

--- a/images/capi/packer/oci/oracle-linux-9.json
+++ b/images/capi/packer/oci/oracle-linux-9.json
@@ -1,0 +1,8 @@
+{
+  "build_name": "oracle-linux-9",
+  "distribution": "Oracle Linux",
+  "operating_system": "Oracle Linux",
+  "operating_system_version": "9",
+  "redhat_epel_rpm": "oracle-epel-release-el9",
+  "ssh_username": "opc"
+}


### PR DESCRIPTION
What this PR does / why we need it:
This adds the ability to build images based on the Oracle Linux 9 base images released by OCI (Oracle Cloud Infrastructure) https://docs.oracle.com/en-us/iaas/images/oracle-linux-9x/

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): No current open issues.

**Additional context**
Add any other context for the reviewers
An image as been built using the new OL9 config with image-builder and tested the image works using CAPI & CAPOCI.