### PR TITLE
nutanix improvement

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -71,6 +71,10 @@ aliases:
     - randomvariable
     - srm09
     - yastij
+  cluster-api-nutanix-maintainers:
+    - tuxtof
+  cluster-api-nutanix-reviewers:
+    - tuxtof
   kops-maintainers:
     - hakman
     - justinsb

--- a/docs/book/src/capi/providers/nutanix.md
+++ b/docs/book/src/capi/providers/nutanix.md
@@ -16,15 +16,15 @@ Complete the `packer/nutanix/nutanix.json` configuration file with credentials a
 This file must have the following format:
 ```
 {
-    "nutanix_cluster_name": "Name of PE Cluster",
-    "source_image_name": "Name of Source Image/ISO",
-    "image_name": "Name of Destination Image",
-    "nutanix_subnet_name": "Name of Subnet",
     "nutanix_endpoint": "Prism Central IP / FQDN",
-    "nutanix_insecure": "false",
     "nutanix_port": "9440",
+    "nutanix_insecure": "false",
     "nutanix_username": "PrismCentral_Username",
     "nutanix_password": "PrismCentral_Password",
+    "nutanix_cluster_name": "Name of PE Cluster",
+    "nutanix_subnet_name": "Name of Subnet",
+    "force_deregister": "true",
+    "image_name": "Name of Destination Image"
 }
 ```
 
@@ -36,11 +36,11 @@ For more details refer to packer-plugin-nutanix Documentation.
 
 If you prefer to use a different configuration file, you can create it with the same format and export `PACKER_VAR_FILES` environment variable containing the full path to it.
 ## Run the Make target to generate Nutanix images.
-From `images/capi` directory, run `make build-nutanix-ubuntu-<version>` command depending on which ubuntu version you want to build the image for.
+From `images/capi` directory, run `make build-nutanix-<os>-<version>` command depending on which os and version you want to build the image for.
 
-For instance, to build an image for `ubuntu 20-04`, run
+For example, to build an image for `Ubuntu 22.04`, run
 ```bash
-$ make build-nutanix-ubuntu-2004
+$ make build-nutanix-ubuntu-2204
 ```
 
 To build all Nutanix ubuntu images, run
@@ -51,8 +51,13 @@ make build-nutanix-all
 
 ## Configuration
 
-The `nutanix` sub-directory inside `images/capi/packer` stores JSON configuration files for Ubuntu OS including necessary cloud-init.
+The `nutanix` sub-directory inside `images/capi/packer` stores JSON configuration files for each OS including necessary config.
 
-| File | Description
-| -------- | --------
-| `ubuntu-2004.json`     | Settings for Ubuntu 20-04 image     |
+| File                | Description                                   |
+|---------------------|-----------------------------------------------|
+| `ubuntu-2004.json`  | Settings for Ubuntu 20.04 image               |
+| `ubuntu-2204.json`  | Settings for Ubuntu 22.04 image               |
+| `rockylinux-8.json` | Settings for Rocky Linux 8 image (UEFI)       |
+| `rockylinux-9.json` | Settings for Rocky Linux 9 image              |
+| `flatcar.json`      | Settings for Flatcar Linux image (beta)       |
+| `windows-2022.json` | Settings for Windows Server 2022 image (beta) |

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -319,7 +319,7 @@ VBOX_BUILD_NAMES			?=      vbox-windows-2019
 
 POWERVS_BUILD_NAMES         ?= powervs-centos-8
 
-NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2004
+NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2004 nutanix-ubuntu-2204 nutanix-rockylinux-8 nutanix-rockylinux-9 nutanix-flatcar nutanix-windows-2022
 
 ## --------------------------------------
 ## Dynamic build targets
@@ -501,12 +501,12 @@ $(POWERVS_VALIDATE_TARGETS): deps-powervs
 .PHONY: $(NUTANIX_BUILD_TARGETS)
 $(NUTANIX_BUILD_TARGETS): deps-nutanix
 	packer init packer/nutanix/config.pkr.hcl
-	packer build $(PACKER_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer.json
+	packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer$(if $(findstring windows,$@),-windows,).json
 
 .PHONY: $(NUTANIX_VALIDATE_TARGETS)
 $(NUTANIX_VALIDATE_TARGETS): deps-nutanix
 	packer init packer/nutanix/config.pkr.hcl
-	packer validate $(PACKER_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst validate-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer.json
+	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst validate-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer$(if $(findstring windows,$@),-windows,).json
 
 ## --------------------------------------
 ## Dynamic clean targets
@@ -669,6 +669,11 @@ build-vbox-windows-2019: ## Builds for Windows Server 2019 Node VirtualBox w loc
 build-vbox-all: $(VBOX_BUILD_TARGETS) ## Builds all Qemu images
 
 build-nutanix-ubuntu-2004: ## Builds the Nutanix ubuntu-2004 image
+build-nutanix-ubuntu-2204: ## Builds the Nutanix ubuntu-2204 image
+build-nutanix-rockylinux-8: ## Builds the Nutanix Rocky Linux 8 image
+build-nutanix-rockylinux-9: ## Builds the Nutanix Rocky Linux 9 image
+build-nutanix-flatcar: ## Builds the Nutanix Flatcar image
+build-nutanix-windows-2022: ## Builds the Nutanix Windows 2022 image
 build-nutanix-all: $(NUTANIX_BUILD_TARGETS) ## Builds all Nutanix image
 
 ## --------------------------------------
@@ -777,8 +782,13 @@ validate-vbox-all: $(VBOX_VALIDATE_TARGETS) ## Validates all RAW Packer config
 validate-powervs-centos-8: ## Validates the PowerVS CentOS image packer config
 validate-powervs-all: $(POWERVS_VALIDATE_TARGETS) ## Validates all PowerVS Packer config
 
-validate-nutanix-ubuntu-2004: ## Validates Ubuntu 20.04 Nutanix Snapshot Packer config
-validate-nutanix-all: $(NUTANIX_VALIDATE_TARGETS) ## Validates all Nutanix Snapshot Packer config
+validate-nutanix-ubuntu-2004: ## Validates Ubuntu 20.04 Nutanix Packer config
+validate-nutanix-ubuntu-2204: ## Validates Ubuntu 22.04 Nutanix Packer config
+validate-nutanix-rockylinux-8: ## Validates Rocky Linux 8 Nutanix Packer config
+validate-nutanix-rockylinux-9: ## Validates the Nutanix Rocky Linux 9 Nutanix Packer config
+validate-nutanix-flatcar: ## Validates the Nutanix Flatcar Nutanix Packer config
+validate-nutanix-windows-2022: ## Validates Windows Server 2022 Nutanix Packer config
+validate-nutanix-all: $(NUTANIX_VALIDATE_TARGETS) ## Validates all Nutanix Packer config
 
 validate-all: validate-ami-all \
 	validate-azure-all \

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -44,6 +44,9 @@
   when: packer_builder_type is search('qemu') and
     build_target is search('raw')
 
+- include_tasks: nutanix.yml
+  when: packer_builder_type is search('nutanix')
+
 # Create a boot order configuration
 # b/w containerd and cloud final, cloud config services
 

--- a/images/capi/ansible/roles/providers/tasks/nutanix.yml
+++ b/images/capi/ansible/roles/providers/tasks/nutanix.yml
@@ -1,0 +1,76 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Install cloud-init packages
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+  vars:
+    packages:
+      - cloud-init
+      - cloud-guest-utils
+      - cloud-initramfs-copymods
+      - cloud-initramfs-dyn-netconf
+  when: ansible_os_family == "Debian"
+
+- name: Install cloud-init packages
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - cloud-init
+      - cloud-utils-growpart
+  when: ansible_os_family == "RedHat"
+
+- name: Install CSI prerequisites on Ubuntu
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: yes
+  vars:
+    packages:
+      - nfs-common
+      - open-iscsi
+      - lvm2
+      - xfsprogs
+  when: ansible_os_family == "Debian"
+
+- name: Install CSI prerequisites on RedHat
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - iscsi-initiator-utils
+      - nfs-utils
+      - lvm2
+      - xfsprogs
+  when: ansible_os_family == "RedHat"
+
+- name: Enable iSCSI initiator daemon on Ubuntu or RedHat
+  systemd:
+    name: iscsid
+    state: started
+    enabled: true
+  when: ansible_os_family == "Debian" or
+    ansible_os_family == "RedHat"
+
+- name: Disable Hyper-V KVP protocol daemon on Ubuntu
+  systemd:
+    name: hv-kvp-daemon
+    state: stopped
+    enabled: false
+  when: ansible_os_family == "Debian"

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -62,7 +62,7 @@
 - name: Set hostname
   hostname:
     name: localhost.local
-  when: ansible_os_family != "VMware Photon OS" and ansible_os_family != "Flatcar"
+  when: ansible_os_family != "VMware Photon OS" and ansible_os_family != "Flatcar" and packer_build_name != "nutanix"
 
 - name: Reset hosts file
   copy:

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -161,6 +161,8 @@ flatcar:
     command:
   ova:
     command:
+  nutanix:
+    command:
 photon:
   common-service:
     apparmor:
@@ -222,6 +224,19 @@ rockylinux:
       cloud-utils:
       python3-netifaces:
       <<: *rh8_rpms
+  nutanix:
+    package:
+      cloud-init:
+      python3-netifaces:
+      iscsi-initiator-utils:
+      nfs-utils:
+      lvm2:
+      xfsprogs:
+      <<: *rh8_rpms
+    service:
+      iscsid:
+        enabled: true
+        running: true
 rhel:
   common-package: *common_rpms
   ova:
@@ -344,6 +359,21 @@ ubuntu:
       cloud-initramfs-dyn-netconf:
       linux-cloud-tools-generic:
       linux-tools-generic:
+  nutanix:
+    package:
+      linux-cloud-tools-virtual:
+      linux-tools-virtual:
+      cloud-guest-utils:
+      cloud-initramfs-copymods:
+      cloud-initramfs-dyn-netconf:
+      open-iscsi:
+      xfsprogs:
+      mdadm:
+      nfs-common:
+    service:
+      iscsid:
+        enabled: true
+        running: true
 
 oracle linux:
   common-kernel-param:
@@ -452,3 +482,27 @@ windows:
         - "cloudbaseinit.plugins.common.mtu.MTUPlugin"
         - "cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin"
         - "cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin"
+
+  nutanix:
+    windows-service:
+
+    files:
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+        exists: true
+        filetype: file
+        contains:
+        - "!/logging_serial_port=COM1,115200,N,8/"
+        - "cloudbaseinit.metadata.services.configdrive.ConfigDriveService"
+        - "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin"
+        - "cloudbaseinit.plugins.common.mtu.MTUPlugin"
+        - "cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin"
+        - "cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin"
+        - "cloudbaseinit.plugins.common.userdata.UserDataPlugin"
+        - "cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin"
+        - "cloudbaseinit.plugins.windows.createuser.CreateUserPlugin"
+        - "cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin"
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init-unattend.conf': 
+        exists: true
+        filetype: file
+        contains:
+        - "metadata_services=cloudbaseinit.metadata.services.base.EmptyMetadataService"

--- a/images/capi/packer/nutanix/OWNERS
+++ b/images/capi/packer/nutanix/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - cluster-api-nutanix-maintainers
+
+reviewers:
+  - cluster-api-nutanix-reviewers

--- a/images/capi/packer/nutanix/config.pkr.hcl
+++ b/images/capi/packer/nutanix/config.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.1.0"
+      version = ">= 0.3.1"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }

--- a/images/capi/packer/nutanix/flatcar.json
+++ b/images/capi/packer/nutanix/flatcar.json
@@ -1,0 +1,20 @@
+{
+  "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python3",
+  "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
+  "channel_name": "{{env `FLATCAR_CHANNEL`}}",
+  "crictl_source_type": "http",
+  "distribution": "flatcar",
+  "distribution_release": "Core",
+  "distribution_version": "{{env `FLATCAR_CHANNEL`}}",
+  "distro_name": "flatcar",
+  "guest_os_type": "Linux",
+  "image_url": "flatcar_production_openstack_image.img",
+  "kubernetes_cni_source_type": "http",
+  "kubernetes_source_type": "http",
+  "python_path": "/opt/bin/builder-env/site-packages",
+  "shutdown_command": "shutdown -P now",
+  "systemd_prefix": "/etc/systemd",
+  "sysusr_prefix": "/opt",
+  "sysusrlocal_prefix": "/opt",
+  "user_data": "ewogICAgImlnbml0aW9uIjogewogICAgICAgICJjb25maWciOiB7fSwKICAgICAgICAic2VjdXJpdHkiOiB7CiAgICAgICAgICAgICJ0bHMiOiB7fQogICAgICAgIH0sCiAgICAgICAgInRpbWVvdXRzIjoge30sCiAgICAgICAgInZlcnNpb24iOiAiMi4zLjAiCiAgICB9LAogICAgIm5ldHdvcmtkIjoge30sCiAgICAicGFzc3dkIjogewogICAgICAgICJ1c2VycyI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgImdyb3VwcyI6IFsKICAgICAgICAgICAgICAgICAgICAid2hlZWwiLAogICAgICAgICAgICAgICAgICAgICJzdWRvIiwKICAgICAgICAgICAgICAgICAgICAiZG9ja2VyIgogICAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICAgICJuYW1lIjogImJ1aWxkZXIiLAogICAgICAgICAgICAgICAgInBhc3N3b3JkSGFzaCI6ICIkNSQydU9Kc3M1ekpOalFZJHpYSVc3VFNxcUROTXZEbXFseUVybWQveE5UaGNDT1ZwRjZFUTZvR2JmaDUiCiAgICAgICAgICAgIH0KICAgICAgICBdCiAgICB9LAogICAgInN0b3JhZ2UiOiB7fSwKICAgICJzeXN0ZW1kIjogewogICAgICAgICJ1bml0cyI6IFsKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgIm5hbWUiOiAiZG9ja2VyLnNlcnZpY2UiCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJuYW1lIjogImZsYXRjYXItb3BlbnN0YWNrLWhvc3RuYW1lLnNlcnZpY2UiCiAgICAgICAgICAgIH0sCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJtYXNrIjogdHJ1ZSwKICAgICAgICAgICAgICAgICJuYW1lIjogInVwZGF0ZS1lbmdpbmUuc2VydmljZSIKICAgICAgICAgICAgfSwKICAgICAgICAgICAgewogICAgICAgICAgICAgICAgIm1hc2siOiB0cnVlLAogICAgICAgICAgICAgICAgIm5hbWUiOiAibG9ja3NtaXRoZC5zZXJ2aWNlIgogICAgICAgICAgICB9CiAgICAgICAgXQogICAgfQp9"
+}

--- a/images/capi/packer/nutanix/nutanix.json
+++ b/images/capi/packer/nutanix/nutanix.json
@@ -1,12 +1,11 @@
 {
-  "force_deregister": "false",
-  "image_name": "",
+  "force_deregister": "true",
   "nutanix_cluster_name": "",
   "nutanix_endpoint": "",
-  "nutanix_insecure": "",
+  "nutanix_insecure": "false",
   "nutanix_password": "",
   "nutanix_port": "9440",
   "nutanix_subnet_name": "",
-  "nutanix_username": "pc_user",
-  "source_image_name": ""
+  "nutanix_username": "admin",
+  "scp_extra_vars": ""
 }

--- a/images/capi/packer/nutanix/packer-windows.json
+++ b/images/capi/packer/nutanix/packer-windows.json
@@ -1,0 +1,149 @@
+{
+  "builders": [
+    {
+      "boot_type": "{{user `boot_type`}}",
+      "cd_files": [
+        "./packer/nutanix/windows/{{user `build_name`}}/autounattend.xml",
+        "./packer/nutanix/windows/disable-network-discovery.cmd",
+        "./packer/nutanix/windows/sysprep.ps1"
+      ],
+      "cd_label": "OEMDRV",
+      "cluster_name": "{{user `nutanix_cluster_name`}}",
+      "communicator": "winrm",
+      "force_deregister": "{{user `force_deregister`}}",
+      "image_description": "kube image-builder packer",
+      "image_name": "{{user `image_name`}}",
+      "memory_mb": "{{user `memory`}}",
+      "nutanix_endpoint": "{{user `nutanix_endpoint`}}",
+      "nutanix_insecure": "{{user `nutanix_insecure`}}",
+      "nutanix_password": "{{user `nutanix_password`}}",
+      "nutanix_port": "{{user `nutanix_port`}}",
+      "nutanix_username": "{{user `nutanix_username`}}",
+      "os_type": "{{user `guest_os_type`}}",
+      "shutdown_command": "powershell F:/sysprep.ps1",
+      "shutdown_timeout": "1h",
+      "type": "nutanix",
+      "vm_disks": [
+        {
+          "image_type": "ISO_IMAGE",
+          "source_image_name": "{{user `source_image_name`}}"
+        },
+        {
+          "image_type": "ISO_IMAGE",
+          "source_image_name": "{{user `virtio_image_name`}}"
+        },
+        {
+          "disk_size_gb": "{{user `disk_size_gb`}}",
+          "image_type": "DISK"
+        }
+      ],
+      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+      "vm_nics": {
+        "subnet_name": "{{user `nutanix_subnet_name`}}"
+      },
+      "winrm_insecure": true,
+      "winrm_password": "S3cr3t0!",
+      "winrm_port": 5986,
+      "winrm_timeout": "4h",
+      "winrm_use_ssl": true,
+      "winrm_username": "Administrator"
+    }
+  ],
+  "provisioners": [
+    {
+      "extra_arguments": [
+        "-e",
+        "ansible_winrm_server_cert_validation=ignore",
+        "--extra-vars",
+        "{{user `ansible_common_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
+      ],
+      "playbook_file": "ansible/windows/node_windows.yml",
+      "type": "ansible",
+      "use_proxy": false,
+      "user": "Administrator"
+    },
+    {
+      "restart_timeout": "10m",
+      "type": "windows-restart"
+    },
+    {
+      "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
+      "format": "{{user `goss_format`}}",
+      "format_options": "{{user `goss_format_options`}}",
+      "goss_file": "{{user `goss_entry_file`}}",
+      "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
+      "target_os": "Windows",
+      "tests": [
+        "{{user `goss_tests_dir`}}"
+      ],
+      "type": "goss",
+      "url": "{{user `goss_url`}}",
+      "use_sudo": false,
+      "vars_env": {
+        "GOSS_MAX_CONCURRENT": "1",
+        "GOSS_USE_ALPHA": "1"
+      },
+      "vars_file": "{{user `goss_vars_file`}}",
+      "vars_inline": {
+        "OS": "{{user `distro_name` | lower}}",
+        "PROVIDER": "nutanix",
+        "containerd_version": "{{user `containerd_version`}}",
+        "distribution_version": "{{user `distro_version`}}",
+        "docker_ee_version": "{{user `docker_ee_version`}}",
+        "kubernetes_version": "{{user `kubernetes_semver`}}",
+        "pause_image": "{{user `pause_image`}}",
+        "runtime": "{{user `runtime`}}",
+        "ssh_source_url": "{{user `ssh_source_url`}}"
+      },
+      "version": "{{user `goss_version`}}"
+    },
+    {
+      "inline": [
+        "rm -Force -Recurse C:\\var\\log\\kubelet\\*"
+      ],
+      "type": "powershell"
+    }
+  ],
+  "variables": {
+    "ansible_common_vars": "",
+    "ansible_extra_vars": "",
+    "ansible_user_vars": "",
+    "build_timestamp": "{{timestamp}}",
+    "cloudbase_init_url": "https://github.com/cloudbase/cloudbase-init/releases/download/{{user `cloudbase_init_version`}}/CloudbaseInitSetup_{{user `cloudbase_init_version` | replace_all `.` `_` }}_x64.msi",
+    "cloudbase_metadata_services": "cloudbaseinit.metadata.services.configdrive.ConfigDriveService",
+    "cloudbase_metadata_services_unattend": "cloudbaseinit.metadata.services.base.EmptyMetadataService",
+    "cloudbase_plugins": "cloudbaseinit.plugins.common.ephemeraldisk.EphemeralDiskPlugin, cloudbaseinit.plugins.common.mtu.MTUPlugin, cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin, cloudbaseinit.plugins.common.sshpublickeys.SetUserSSHPublicKeysPlugin, cloudbaseinit.plugins.common.userdata.UserDataPlugin, cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin, cloudbaseinit.plugins.windows.createuser.CreateUserPlugin, cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin",
+    "cloudbase_plugins_unattend": "cloudbaseinit.plugins.common.mtu.MTUPlugin",
+    "containerd_sha256": null,
+    "containerd_url": "",
+    "containerd_version": null,
+    "cpus": "2",
+    "crictl_url": "",
+    "crictl_version": null,
+    "disk_size_gb": "40",
+    "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "image_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+    "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/binaries/node/windows/{{user `kubernetes_goarch`}}",
+    "kubernetes_container_registry": null,
+    "kubernetes_http_package_url": "",
+    "kubernetes_http_source": null,
+    "kubernetes_install_path": "c:\\k",
+    "kubernetes_load_additional_imgs": null,
+    "kubernetes_semver": null,
+    "kubernetes_series": null,
+    "kubernetes_source_type": null,
+    "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}",
+    "machine_id_mode": "444",
+    "memory": "4096",
+    "scp_extra_vars": "",
+    "wins_url": null
+  }
+}

--- a/images/capi/packer/nutanix/packer.json
+++ b/images/capi/packer/nutanix/packer.json
@@ -1,8 +1,11 @@
 {
   "builders": [
     {
+      "boot_type": "{{user `boot_type`}}",
       "cluster_name": "{{user `nutanix_cluster_name`}}",
+      "cpu": "{{user `cpus`}}",
       "force_deregister": "{{user `force_deregister`}}",
+      "image_description": "kube image-builder packer",
       "image_name": "{{user `image_name`}}",
       "memory_mb": "{{user `memory`}}",
       "nutanix_endpoint": "{{user `nutanix_endpoint`}}",
@@ -21,7 +24,7 @@
       "vm_disks": {
         "disk_size_gb": "{{user `disk_size_gb`}}",
         "image_type": "DISK_IMAGE",
-        "source_image_name": "{{user `source_image_name`}}"
+        "source_image_uri": "{{user `image_url`}}"
       },
       "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
       "vm_nics": {
@@ -44,6 +47,14 @@
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "BUILD_NAME={{user `build_name`}}"
+      ],
+      "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
+      "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",
+      "type": "shell"
+    },
+    {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} -o IdentitiesOnly=yes'"
       ],
@@ -53,7 +64,8 @@
         "--extra-vars",
         "{{user `ansible_extra_vars`}}",
         "--extra-vars",
-        "{{user `ansible_user_vars`}}"
+        "{{user `ansible_user_vars`}}",
+        "--scp-extra-args={{user `scp_extra_vars`}}"
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
@@ -75,7 +87,7 @@
       "vars_inline": {
         "ARCH": "amd64",
         "OS": "{{user `distro_name` | lower}}",
-        "PROVIDER": "qemu",
+        "PROVIDER": "nutanix",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",
         "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",
@@ -91,7 +103,7 @@
   ],
   "variables": {
     "ansible_common_vars": "",
-    "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
+    "ansible_extra_vars": "",
     "ansible_user_vars": "",
     "build_timestamp": "{{timestamp}}",
     "containerd_sha256": null,
@@ -100,8 +112,9 @@
     "cpus": "1",
     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
     "crictl_version": null,
-    "disk_size_gb": "40",
+    "disk_size_gb": "10",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "image_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_http_source": null,
     "kubernetes_cni_semver": null,
@@ -122,6 +135,7 @@
     "machine_id_mode": "444",
     "memory": "2048",
     "python_path": "",
+    "scp_extra_vars": "",
     "ssh_password": "builder",
     "ssh_username": "builder"
   }

--- a/images/capi/packer/nutanix/rockylinux-8.json
+++ b/images/capi/packer/nutanix/rockylinux-8.json
@@ -1,0 +1,15 @@
+{
+  "boot_type": "uefi",
+  "build_name": "rockylinux-8",
+  "distribution": "rockylinux",
+  "distribution_release": "Core",
+  "distribution_version": "8",
+  "distro_name": "rockylinux",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
+  "extra_rpms": "python3",
+  "guest_os_type": "Linux",
+  "image_url": "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base-8.7-20221130.0.x86_64.qcow2",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+  "shutdown_command": "shutdown -P now",
+  "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
+}

--- a/images/capi/packer/nutanix/rockylinux-9.json
+++ b/images/capi/packer/nutanix/rockylinux-9.json
@@ -1,0 +1,14 @@
+{
+  "boot_type": "uefi",
+  "build_name": "rockylinux-9",
+  "distribution": "rockylinux",
+  "distribution_release": "Core",
+  "distribution_version": "9",
+  "distro_name": "rockylinux",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "guest_os_type": "Linux",
+  "image_url": "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.1-20221130.0.x86_64.qcow2",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "shutdown -P now",
+  "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
+}

--- a/images/capi/packer/nutanix/ubuntu-2204.json
+++ b/images/capi/packer/nutanix/ubuntu-2204.json
@@ -1,8 +1,8 @@
 {
-  "build_name": "ubuntu-2004",
+  "build_name": "ubuntu-2204",
   "distro_name": "ubuntu",
   "guest_os_type": "Linux",
-  "image_url": "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img",
+  "image_url": "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img",
   "shutdown_command": "shutdown -P now",
   "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCiAgICBzaGVsbDogL2Jpbi9iYXNoCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQo="
 }

--- a/images/capi/packer/nutanix/windows-2022.json
+++ b/images/capi/packer/nutanix/windows-2022.json
@@ -1,0 +1,11 @@
+{
+  "build_name": "windows-2022",
+  "distro_name": "windows",
+  "distro_version": "2022",
+  "guest_os_type": "Windows",
+  "runtime": "containerd",
+  "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+  "source_image_name": "en-us_windows_server_2022_x64_dvd_620d7eac",
+  "virtio_image_name": "Nutanix-VirtIO-1.2.1",
+  "wins_url": ""
+}

--- a/images/capi/packer/nutanix/windows/disable-network-discovery.cmd
+++ b/images/capi/packer/nutanix/windows/disable-network-discovery.cmd
@@ -1,0 +1,2 @@
+reg ADD HKLM\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff /f
+netsh advfirewall firewall set rule group="Network Discovery" new enable=No

--- a/images/capi/packer/nutanix/windows/sysprep.ps1
+++ b/images/capi/packer/nutanix/windows/sysprep.ps1
@@ -1,0 +1,31 @@
+# Copyright 2020 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Write-Output '>>> Sysprepping VM ...'
+
+Write-Output 'Removing default unattend.xml file...'
+if( Test-Path $Env:SystemRoot\system32\Sysprep\unattend.xml ) {
+  Remove-Item $Env:SystemRoot\system32\Sysprep\unattend.xml -Force
+}
+
+$unattendedXml = "$ENV:ProgramFiles\Cloudbase Solutions\Cloudbase-Init\conf\Unattend.xml"
+$FileExists = Test-Path $unattendedXml
+
+If ($FileExists -eq $True) {
+  # Use the Cloudbase-init provided unattend file during install
+  Write-Output "Using cloudbase-init unattend file for sysprep: $unattendedXml"
+  & $Env:SystemRoot\System32\Sysprep\Sysprep.exe /oobe /generalize /mode:vm /shutdown /quiet /unattend:$unattendedXml
+}else {
+  & $Env:SystemRoot\System32\Sysprep\Sysprep.exe /oobe /generalize /mode:vm /shutdown /quiet
+}

--- a/images/capi/packer/nutanix/windows/windows-2022/autounattend.xml
+++ b/images/capi/packer/nutanix/windows/windows-2022/autounattend.xml
@@ -1,0 +1,265 @@
+<!--*************************************************
+Windows Server 2019 Answer File Generator
+Created using Windows AFG found at:
+;http://www.windowsafg.com
+
+Installation Notes:
+- This file need to be adapted based on your needs
+**************************************************-->
+
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1">
+                    <Path>e:\Windows Server 2022\x64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <CreatePartitions>
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Size>350</Size>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Extend>true</Extend>
+                            <Type>Primary</Type>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <ModifyPartition wcm:action="add">
+                            <Format>NTFS</Format>
+                            <Label>System</Label>
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <TypeID>0x27</TypeID>
+                        </ModifyPartition>
+                        <ModifyPartition wcm:action="add">
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                            <Letter>C</Letter>
+                            <Label>OS</Label>
+                            <Format>NTFS</Format>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                </Disk>
+            </DiskConfiguration>
+            <ImageInstall>
+                <OSImage>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>2</PartitionID>
+                    </InstallTo>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Server 2022 SERVERSTANDARDCORE</Value>
+                        </MetaData>
+                    </InstallFrom>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Administrator</FullName>
+                <Organization>Organization</Organization>
+                <ProductKey>
+                    <Key>VDYBN-27WPP-V4HQT-9VMD4-VMK7H</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+            </UserData>
+            <EnableFirewall>true</EnableFirewall>
+        </component>
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>0409:00000409</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <EnableLUA>false</EnableLUA>
+        </component>
+    </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-Security-SPP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipRearm>1</SkipRearm>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>0409:00000409</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+        <component name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <CEIPEnabled>0</CEIPEnabled>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <ComputerName></ComputerName>
+            <ProductKey>VDYBN-27WPP-V4HQT-9VMD4-VMK7H</ProductKey>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <AutoLogon>
+                <Password>
+                    <Value>S3cr3t0!</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Enabled>true</Enabled>
+                <Username>Administrator</Username>
+            </AutoLogon>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Description>Set Execution Policy 64 Bit</Description>
+                    <CommandLine>cmd.exe /c powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Description>Set Execution Policy 32 Bit</Description>
+                    <CommandLine>%SystemDrive%\Windows\SysWOW64\cmd.exe /c powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v HideFileExt /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>3</Order>
+                    <Description>Show file extensions in Explorer</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\Console /v QuickEdit /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>4</Order>
+                    <Description>Enable QuickEdit mode</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v Start_ShowRun /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>5</Order>
+                    <Description>Show Run command in Start Menu</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v StartMenuAdminTools /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>6</Order>
+                    <Description>Show Administrative Tools in Start Menu</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateFileSizePercent /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>7</Order>
+                    <Description>Zero Hibernation File</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateEnabled /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>8</Order>
+                    <Description>Disable Hibernation Mode</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE</CommandLine>
+                    <Order>9</Order>
+                    <Description>Disable password expiration for Administrator user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command New-SelfSignedCertificate -CertstoreLocation Cert:\LocalMachine\My -DnsName "WinRMCertificate"</CommandLine>
+                    <Description>Certificate for WinRM</Description>
+                    <Order>10</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command Enable-PSRemoting -SkipNetworkProfileCheck -Force</CommandLine>
+                    <Description>Enable WinRM</Description>
+                    <Order>11</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command ($cert = gci Cert:\LocalMachine\My\) -and (New-Item -Path WSMan:\LocalHost\Listener -Transport HTTPS -Address * -CertificateThumbPrint $cert.Thumbprint –Force)</CommandLine>
+                    <Description>Add HTTPS WinRM listener with previously generated certificate</Description>
+                    <Order>12</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command New-NetFirewallRule -DisplayName 'Windows Remote Management (HTTPS-In)' -Name 'Windows Remote Management (HTTPS-In)' -Profile Any -LocalPort 5986 -Protocol TCP</CommandLine>
+                    <Description>Add firewall exception to TCP port 5986 for WinRM over HTTPS</Description>
+                    <Order>13</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe -Command Set-Item WSMan:\localhost\Service\Auth\Basic -Value $true</CommandLine>
+                    <Description>Enable Basic authentication</Description>
+                    <Order>14</Order>
+                    <RequiresUserInput>true</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c f:\disable-network-discovery.cmd</CommandLine>
+                    <Description>Disable Network Discovery</Description>
+                    <Order>15</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+            </OOBE>
+            <RegisteredOrganization>Organization</RegisteredOrganization>
+            <RegisteredOwner>Owner</RegisteredOwner>
+            <DisableAutoDaylightTimeSet>false</DisableAutoDaylightTimeSet>
+            <TimeZone>Pacific Standard Time</TimeZone>
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>S3cr3t0!</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Description>Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+        </component>
+    </settings>
+</unattend>


### PR DESCRIPTION
What this PR does / why we need it:

This PR significantly improves the support of the Nutanix Cloud Platform inside the image-builder:

- based on Nutanix Packer plugin v0.3.1
- directly download OS images if available
- implement dedicated goss preset
- add support of the following OS: Ubuntu-2204, Rocker-8, Rocker-9, Flatcar, Windows 2022
- create a dedicated Nutanix task for ansible provider Role
- add Nutanix CSI dependency inside Linux images
- various fixes
- updated documentation
- add Nutanix OWNERS/OWNERS_ALIASES

Tested with a matrix build for each OS /  k8s supported version

![image](https://user-images.githubusercontent.com/180613/210639300-2fd4e4c7-ad67-4e83-849b-6b97f2200068.png)
