### PR TITLE
Update book Makefile

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+MDBOOK = /tmp/mdbook
 .PHONY: serve
 serve:
-	mdbook serve
+	$(MDBOOK) serve


### PR DESCRIPTION
What this PR does / why we need it:
`docs/book/build.sh` downloads `mdbook` to `/tmp/mdbook` serve should probably try to use the same location. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): No open issue

**Additional context**
After the change `make serve-book` works from root dir
```
~/Projects/image-builder » make serve-book                     
/Library/Developer/CommandLineTools/usr/bin/make -C docs/book serve
/tmp/mdbook serve
2023-01-11 15:04:27 [INFO] (mdbook::book): Book building has started
2023-01-11 15:04:27 [INFO] (mdbook::book): Running the html backend
2023-01-11 15:04:28 [INFO] (mdbook::cmd::serve): Serving on: http://localhost:3000
2023-01-11 15:04:28 [INFO] (warp::server): Server::run; addr=127.0.0.1:3000
2023-01-11 15:04:28 [INFO] (warp::server): listening on http://127.0.0.1:3000
2023-01-11 15:04:28 [INFO] (mdbook::cmd::watch): Listening for changes...
```