### PR TITLE
capi/packer/qemu: Pass oem_id value to ansible

### DIFF
--- a/images/capi/packer/qemu/qemu-flatcar.json
+++ b/images/capi/packer/qemu/qemu-flatcar.json
@@ -1,5 +1,5 @@
 {
-  "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
+  "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python oem_id={{user `oem_id`}}",
   "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter>curl -sLo /tmp/ignition.json ",
   "boot_command_suffix": "/bootstrap.json<enter>sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json<enter>sudo flatcar-install -d /dev/sda -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json<enter>sudo reboot<enter>",
   "boot_wait": "120s",


### PR DESCRIPTION
What this PR does / why we need it:
Fixes an issue with PR #966 - the oem_id variable in packer is set to the value of env OEM_ID but this is not forwarded to ansible. Make sure this is done so that the ansible step is executed correctly.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #966 

**Additional context**
Add any other context for the reviewers