### PR TITLE
Update kubernetes-cni .deb to v1.2.0

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/debian.yml
@@ -33,4 +33,4 @@
       - "kubelet={{ kubernetes_deb_version }}"
       - "kubeadm={{ kubernetes_deb_version }}"
       - "kubectl={{ kubernetes_deb_version }}"
-      - "kubernetes-cni={{kubernetes_cni_deb_version }}"
+      - "kubernetes-cni={{ kubernetes_cni_deb_version }}"

--- a/images/capi/packer/config/cni.json
+++ b/images/capi/packer/config/cni.json
@@ -1,9 +1,9 @@
 {
-  "kubernetes_cni_deb_version": "1.1.1-00",
-  "kubernetes_cni_http_checksum": "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v1.1.1/cni-plugins-linux-{{user `kubernetes_cni_http_checksum_arch`}}-v1.1.1.tgz.sha256",
+  "kubernetes_cni_deb_version": "1.2.0-00",
+  "kubernetes_cni_http_checksum": "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-{{user `kubernetes_cni_http_checksum_arch`}}-v1.2.0.tgz.sha256",
   "kubernetes_cni_http_checksum_arch": "amd64",
   "kubernetes_cni_http_source": "https://github.com/containernetworking/plugins/releases/download",
-  "kubernetes_cni_rpm_version": "1.1.1-0",
-  "kubernetes_cni_semver": "v1.1.1",
+  "kubernetes_cni_rpm_version": "1.2.0-0",
+  "kubernetes_cni_semver": "v1.2.0",
   "kubernetes_cni_source_type": "pkg"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Updates the Debian package for `kubernetes-cni` to v1.2.0. The previous version v1.1.1 started failing builds on our pipeline for the new k8s patches:

>  "The following packages have unmet dependencies:", " kubeadm : Depends: kubernetes-cni (>= 1.2.0)", " kubelet : Depends: kubernetes-cni (>= 1.2.0)"

Which issue(s) this PR fixes:

None, but see #976 for the last time we had to do this.

**Additional context**

I used this branch in our pipeline to build the matrix of (Ubuntu 18.04, 20.04, 22.04) by (Kubernetes v1.23.16, v1.24.10, v1.25.6, v1.26.1) and it fixed the errors and all images brought up a CAPZ cluster successfully.