### PR TITLE
Add outscale global permission image

### DIFF
--- a/docs/book/src/capi/providers/3dsoutscale.md
+++ b/docs/book/src/capi/providers/3dsoutscale.md
@@ -27,3 +27,13 @@ the different operating systems.
 | File | Description |
 |------|-------------|
 | `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
+
+You must have your [Access Keys](https://docs.outscale.com/en/userguide/About-Access-Keys.html).
+You must have your [Account Id](https://docs.outscale.com/en/userguide/Getting-Information-About-Your-Account-and-Quotas.html).
+Please set the following enviroement variables before building image:
+```
+OSC_SECRET_KEY: Outscale Secret Key
+OSC_REGION: Outscale Region
+OSC_ACCESS_KEY: Outscale Access Key Id
+OSC_ACCOUNT_ID: Outscale Account Id 
+```

--- a/images/capi/packer/outscale/packer.json
+++ b/images/capi/packer/outscale/packer.json
@@ -2,6 +2,10 @@
   "builders": [
     {
       "access_key": "{{ user `access_key` }}",
+      "global_permission": true,
+      "omi_account_ids": [
+        "{{ user `account_id` }}"
+      ],
       "omi_name": "{{user `build_name`}}-{{user `distribution_version`}}-kubernetes-{{user `kubernetes_semver`}}-{{isotime `2006-01-02`}}",
       "region": "{{ user `region` }}",
       "secret_key": "{{ user `secret_key` }}",
@@ -89,6 +93,7 @@
   ],
   "variables": {
     "access_key": "{{env `OSC_ACCESS_KEY`}}",
+    "account_id": "{{env `OSC_ACCOUNT_ID`}}",
     "ansible_common_vars": "",
     "ansible_extra_vars": "",
     "build_timestamp": "{{timestamp}}",


### PR DESCRIPTION
What this PR does / why we need it:
We have to set global_permission and omi_account_ids to have the omi public instead of private.
https://docs.outscale.com/api#updateimage
https://developer.hashicorp.com/packer/plugins/builders/outscale/bsu

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers