### PR TITLE
Add Cloudstack provider support for Flatcar

### DIFF
--- a/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/cloudstack-coreos-cloudinit
+++ b/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/cloudstack-coreos-cloudinit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. /usr/share/oem/bin/cloudstack-dhcp
+
+DHCP_SERVER=$(get_dhcp_ip)
+USERDATA_URL="http://${DHCP_SERVER}/latest/user-data"
+
+block-until-url "${USERDATA_URL}"
+coreos-cloudinit --from-url="${USERDATA_URL}"

--- a/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/cloudstack-dhcp
+++ b/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/cloudstack-dhcp
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+get_dhcp_ip() {
+    local leases_dir="/run/systemd/netif/leases"
+    local found=0
+    while true; do
+        for leasefile in $(find "${leases_dir}" -type f -size +1c); do
+            dhcp_server_ip=$(cat $leasefile | awk -F= '/SERVER_ADDRESS/ { print $2 }')
+            if [[ -n "${dhcp_server_ip}" ]]; then
+                metadata_url="http://${dhcp_server_ip}/latest/meta-data/"
+                if curl --fail -s "${metadata_url}" >/dev/null; then
+                    echo $dhcp_server_ip
+                    found=1
+                    break
+                fi
+            fi
+        done
+        [[ $found -eq 0 ]] || break
+        sleep .5
+    done
+}

--- a/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/cloudstack-ssh-key
+++ b/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/cloudstack-ssh-key
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. /usr/share/oem/bin/cloudstack-dhcp
+
+DHCP_SERVER=$(get_dhcp_ip)
+KEY_URL="http://${DHCP_SERVER}/latest/meta-data/public-keys"
+
+block-until-url "${KEY_URL}"
+curl --fail -s "${KEY_URL}" | update-ssh-keys -a cloudstack

--- a/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/flatcar-setup-environment
+++ b/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/bin/flatcar-setup-environment
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+ENV=$1
+
+if [[ -z "$ENV" ]]; then
+    echo "usage: $0 /etc/environment" >&2
+    exit 1
+fi
+
+# Make sure that the file is writable
+touch $ENV
+if [[ $? -ne 0 ]]; then
+    echo "$0: unable to modify ${ENV}" >&2
+    exit 1
+fi
+
+sed -i -e '/^COREOS_PUBLIC_IPV4=/d' \
+    -e '/^COREOS_PRIVATE_IPV4=/d' \
+    "${ENV}"
+
+. /usr/share/oem/bin/cloudstack-dhcp
+
+DHCP_SERVER=$(get_dhcp_ip)
+METADATA_URL="http://${DHCP_SERVER}/latest/meta-data/"
+
+block-until-url "${METADATA_URL}"
+
+PUBLIC_IP=$(curl --fail -s "${METADATA_URL}public-ipv4")
+echo COREOS_PUBLIC_IPV4=${PUBLIC_IP} >> $ENV
+
+PRIVATE_IP=$(curl --fail -s "${METADATA_URL}local-ipv4")
+echo COREOS_PRIVATE_IPV4=${PRIVATE_IP} >> $ENV

--- a/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/cloud-config.yml
+++ b/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/cloud-config.yml
@@ -1,0 +1,34 @@
+#cloud-config
+
+coreos:
+    units:
+      - name: cloudstack-ssh-key.service
+        command: restart
+        runtime: yes
+        content: |
+          [Unit]
+          Description=Sets SSH key from metadata
+
+          [Service]
+          Type=oneshot
+          StandardOutput=journal+console
+          ExecStart=/usr/share/oem/bin/cloudstack-ssh-key
+      - name: cloudstack-cloudinit.service
+        command: restart
+        runtime: yes
+        content: |
+          [Unit]
+          Description=Cloudinit from CloudStack-style metadata
+          Requires=flatcar-setup-environment.service
+          After=flatcar-setup-environment.service
+
+          [Service]
+          Type=oneshot
+          EnvironmentFile=/etc/environment
+          ExecStart=/usr/share/oem/bin/cloudstack-coreos-cloudinit
+    oem:
+      id: cloudstack
+      name: CloudStack
+      version-id: 0.0.4
+      home-url: http://cloudstack.apache.org/
+      bug-report-url: https://github.com/coreos/coreos-overlay

--- a/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/grub.cfg
+++ b/images/capi/ansible/roles/providers/files/flatcar-oem-cloudstack/grub.cfg
@@ -1,0 +1,3 @@
+# Flatcar GRUB settings
+
+set oem_id="cloudstack"

--- a/images/capi/ansible/roles/providers/tasks/cloudstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/cloudstack.yml
@@ -24,6 +24,15 @@
     owner: root
     group: root
     mode: 0644
+  when: ansible_os_family != "Flatcar"
+
+# For Flatcar, copy the cloudstack support files into the oem partition
+- name: Copy Cloudstack support files into the oem partition
+  copy:
+    src: files/flatcar-oem-cloudstack/
+    dest: /usr/share/oem/
+    mode: preserve
+  when: ansible_os_family == "Flatcar"
 
 - name: Run dracut cmd to regenerate initramfs with all drivers - needed when converting to different hypervisor templates
   shell: dracut --force --no-hostonly


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds Cloudstack provider support for Flatcar Linux. Flatcar requires some support scripts to be present in the oem partition (/usr/share/oem) to support the Cloudstack metadata service. These files were taken from [Flatcar's own Cloudstack image](https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_cloudstack_image.bin.bz2)

**Additional context**
Add any other context for the reviewers