### PR TITLE
Feature/Azure: Support build_resource_group_name to use custom build rg

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -7,7 +7,7 @@ These images are designed for use with [Cluster API Provider Azure](https://capz
 - An Azure account
 - The Azure CLI installed and configured
 - Set environment variables for `AZURE_SUBSCRIPTION_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`
-- Set optional environment variables `RESOURCE_GROUP_NAME`, `STORAGE_ACCOUNT_NAME`, `AZURE_LOCATION` & `GALLERY_NAME` to override the default values
+- Set optional environment variables `RESOURCE_GROUP_NAME`, `BUILD_RESOURCE_GROUP_NAME`, `STORAGE_ACCOUNT_NAME`, `AZURE_LOCATION` & `GALLERY_NAME` to override the default values
 
 ## Building Images
 

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -214,6 +214,7 @@
     "ansible_user_vars": "",
     "azure_location": null,
     "build_name": null,
+    "build_resource_group_name": "{{ env `BUILD_RESOURCE_GROUP_NAME` }}",
     "build_timestamp": "{{timestamp}}",
     "client_id": null,
     "client_secret": null,


### PR DESCRIPTION
# What this PR does / why we need it:
We would like to increase security by scoping a `service principal` to specific resource groups instead of giving full access to a subscription.

Packer doesn't allow optional parameters, this is why the packer template is simply updated when the variable `BUILD_RESOURCE_GROUP_NAME` is passed.

There is maybe a more elegant solution to do it, suggestions are welcome.

# How to test it
## Create a SP that have acccess only to the build RG and the image destination RG
```
az ad sp create-for-rbac \
--name capi-image-builder --role "Contributor" --scopes \
/subscriptions/REDACTED/resourceGroups/cluster-api-images \ 
/subscriptions/REDACTED/resourceGroups/cluster-api-images-build \
--years 10
```
## Export the needed variables
```
export AZURE_SUBSCRIPTION_ID=REDACTED
export AZURE_CLIENT_ID=REDACTED
export AZURE_CLIENT_SECRET=REDACTED
```
## Export the RG that will be used to build the image
```
export BUILD_RESOURCE_GROUP_NAME=cluster-api-images-build
```
## Run the make command
```
make build-azure-sig-ubuntu-2204
```
