### PR TITLE
Update to latest pause image from registry.k8s.io

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -66,7 +66,7 @@ Several variables can be used to customize the image build.
 | `no_proxy` | This can be set to a comma-delimited list of domains that should be exluded from proxying during the Ansible stage of building | `""` |
 | `reenable_public_repos` | If set to `"false"`, the package repositories disabled by setting `disable_public_repos` will remain disabled at the end of the build. | `"true"` |
 | `remove_extra_repos` | If set to `"true"`, the package repositories added to the OS through the use of `extra_repos` will be removed at the end of the build. | `"false"` |
-| `pause_image` | This can be used to override the default pause image used to hold the network namespace and IP for the pod. | `"k8s.gcr.io/pause:3.6"` |
+| `pause_image` | This can be used to override the default pause image used to hold the network namespace and IP for the pod. | `"registry.k8s.io/pause:3.9"` |
 | `pip_conf_file` | The path to a file to be copied into the image at `/etc/pip.conf` for use as a global config file. This file will be removed at the end of the build if `remove_extra_repos` is `true`. | `""` |
 | `containerd_additional_settings` | This is a string, base64 encoded, that contains additional configuration for containerd. It must be version 2 and not contain the pause image configuration block. See `image-builder/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml` for the template. | `null` |
 | `load_additional_components` | If set to `"true"`, the `load_additional_components` role will be executed. This needs to be set to `"true"` if any of `additional_url_images`, `additional_registry_images` or `additional_executables` are set to `"true"` | `"false"` |

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -110,7 +110,7 @@ common_raw_photon_rpms: []
 #as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.
 sysctl_conf_file: "{{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family == 'VMware Photon OS' else '/etc/sysctl.conf' }}"
 
-pause_image: "k8s.gcr.io/pause:3.6"
+pause_image: "registry.k8s.io/pause:3.9"
 containerd_additional_settings: null
 leak_local_mdns_to_dns: false
 build_target: "virt"

--- a/images/capi/ansible/windows/example.vars.yml
+++ b/images/capi/ansible/windows/example.vars.yml
@@ -22,7 +22,7 @@ runtime: docker-ee
 docker_ee_version: "19.03.12"
 kubernetes_install_path: 'c:\k'
 windows_service_manager: 'nssm'
-pause_image: "k8s.gcr.io/pause:3.6"
+pause_image: "registry.k8s.io/pause:3.9"
 load_additional_components: true
 additional_registry_images: true
 additional_registry_images_list: "docker.io/sigwindowstools/flannel:0.12.0, docker.io/sigwindowstools/kube-proxy:v1.19.2"

--- a/images/capi/ansible/windows/roles/runtimes/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/runtimes/defaults/main.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-pause_image: mcr.microsoft.com/oss/kubernetes/pause:1.4.0
+pause_image: mcr.microsoft.com/oss/kubernetes/pause:3.9
 containerd_additional_settings: ""
 containerd_config_file: "config.toml"
 

--- a/images/capi/packer/config/common.json
+++ b/images/capi/packer/config/common.json
@@ -11,7 +11,7 @@
   "no_proxy": "",
   "node_custom_roles_post": "",
   "node_custom_roles_pre": "",
-  "pause_image": "k8s.gcr.io/pause:3.6",
+  "pause_image": "registry.k8s.io/pause:3.9",
   "pip_conf_file": "",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
   "reenable_public_repos": "true",


### PR DESCRIPTION
What this PR does / why we need it:

This PR updates to the latest pause image and moves the registry from k8s.gcr.io to registry.k8s.io. This prevents additional pulling of images on cluster spin-up.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers