### PR TITLE
Goss: Remove conditional for auditd on flatcar

### DIFF
--- a/images/capi/ansible/roles/node/files/etc/audit/rules.d/containerd.rules-flatcar
+++ b/images/capi/ansible/roles/node/files/etc/audit/rules.d/containerd.rules-flatcar
@@ -1,0 +1,10 @@
+-w /var/lib/containerd/ -p rwxa -k containerd
+-w /etc/containerd/ -p rwxa -k containerd
+-w /etc/systemd/system/containerd.service -p rwxa -k containerd
+-w /etc/systemd/system/containerd.service.d/ -p rwxa -k containerd
+-w /run/containerd/ -p rwxa -k containerd
+-w /opt/bin/containerd-shim -p rwxa -k containerd
+-w /opt/bin/containerd-shim-runc-v1 -p rwxa -k containerd
+-w /opt/bin/containerd-shim-runc-v2 -p rwxa -k containerd
+-w /opt/bin/runc -p rwxa -k containerd
+-w /opt/bin/containerd -p rwxa -k containerd

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -84,7 +84,6 @@
     name: auditd
     state: started
     enabled: yes
-  when: ansible_os_family != "Flatcar"
 
 - name: configure auditd rules for containerd
   copy:
@@ -94,6 +93,15 @@
     group: root
     mode: 0644
   when: ansible_os_family != "Flatcar"
+
+- name: configure auditd rules for containerd (Flatcar)
+  copy:
+    src: etc/audit/rules.d/containerd.rules-flatcar
+    dest: /etc/audit/rules.d/containerd.rules
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_os_family == "Flatcar"
 
 - name: Ensure reverse packet filtering is set as strict
   sysctl:

--- a/images/capi/packer/goss/goss-service.yaml
+++ b/images/capi/packer/goss/goss-service.yaml
@@ -12,15 +12,10 @@ service:
   conntrackd:
     enabled: false
     running: false
-  {{if ne .Vars.OS "flatcar"}}
-  # TODO: auditd was added to Flatcar in 
-  # https://github.com/flatcar/coreos-overlay/commit/b3194ee538bf7ddb8f699d37a8be81ab106079c3
-  # but isn't available in the various channels yet.
-  # Remove the conditional when auditd is available in Flatcar stable (supposed to happen
-  # once the major release number of the stable channel is larger than 3140).
   auditd:
     enabled: true
     running: true
+  {{if ne .Vars.OS "flatcar"}}
   # Flatcar uses systemd-timesyncd instead of chronyd.
   chronyd:
     enabled: true


### PR DESCRIPTION
What this PR does / why we need it:

As auditd is now part of flatcar stable channel, the check for auditd can be enabled as mentioned in the TODO comment.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers