### PR TITLE
Strip arch suffix from k8s images before installing to prevent additional pull by kubeadm

### DIFF
--- a/images/capi/ansible/roles/kubernetes/files/tmp/modify-k8s-img.sh
+++ b/images/capi/ansible/roles/kubernetes/files/tmp/modify-k8s-img.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "$#" -eq 0 ];then
+  echo "Usage: $0 <name of tar file>"
+else
+  FILE=$1
+  DIR="/tmp/${FILE%%.*}"
+  mkdir -p ${DIR}
+  tar xf /tmp/${FILE} -C ${DIR}
+  sed -i "s/${FILE%%.*}\-amd64\:/${FILE%%.*}\:/" "${DIR}/manifest.json"
+  sed -i "s/${FILE%%.*}\-amd64/${FILE%%.*}/" "${DIR}/repositories"
+  tar cf "${DIR}.tar" -C ${DIR} .
+  rm -rf ${DIR}
+fi

--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -64,6 +64,24 @@
     mode: 0600
   loop: "{{ kubernetes_imgs }}"
 
+- name: Copy Kubernetes image modification script
+  copy:
+    src: files/tmp/modify-k8s-img.sh
+    dest: /tmp/modify-k8s-img.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Modify Kubernetes images
+  # Strip the arch from the name of the image to prevent image from being pulled again by kubeadm
+  shell: '/tmp/modify-k8s-img.sh {{ item }}'
+  loop: "{{ kubernetes_imgs }}"
+
+- name: Remove Kubernetes image modification script
+  file:
+    state: absent
+    path: /tmp/modify-k8s-img.sh
+
 - name: Load Kubernetes images
   shell: 'CONTAINERD_NAMESPACE="k8s.io" {{ sysusr_prefix }}/bin/ctr --address={{ containerd_cri_socket }} images import /tmp/{{ item }}'
   loop: "{{ kubernetes_imgs }}"


### PR DESCRIPTION
What this PR does / why we need it:

Since kubeadm 1.12 [the arch suffix has been dropped from the Kubernetes artifacts being pulled by kubeadm](https://github.com/kubernetes/kubernetes/pull/66960) during bootstrap.

The tarballs of the Kubernetes components still contain this arch suffix, and when they are imported in containerd by image-builder, you end up with the following: f.e.:

```
registry.k8s.io/kube-apiserver-amd64            v1.24.10            30becdfde3b15       34.1MB
registry.k8s.io/kube-controller-manager-amd64   v1.24.10            ff3988818e26e       31.3MB
registry.k8s.io/kube-proxy-amd64                v1.24.10            00c0d381ecef0       39.6MB
registry.k8s.io/kube-scheduler-amd64            v1.24.10            43a202d733b24       15.7MB
```

Because kubeadm now pulls the artifacts without arch suffix, on cluster bootstrap, kubeadm will do another round of pulls for these artifacts because it doesn't find them.

This PR modifies the manifests of the downloaded components to strip the arch from them before importing in containerd, preventing the additional pull by kubeadm (and speeding up cluster startup)

We have this running in our env and i can confirm `crictl images` no longer shows duplicate pulled images.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers