### PR TITLE
Fix typo in artifact_name variable

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -46,7 +46,7 @@
     {
       "environment_vars": [
         "OUTPUT_DIR={{user `output_directory`}}",
-        "ARTIFACT_NAME={{user `artificat_name`}}",
+        "ARTIFACT_NAME={{user `artifact_name`}}",
         "KUBEVIRT={{user `kubevirt`}}"
       ],
       "inline": [
@@ -147,7 +147,7 @@
     "ansible_common_vars": "",
     "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
     "ansible_user_vars": "",
-    "artificat_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+    "artifact_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
     "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",


### PR DESCRIPTION
# What this PR does / why we need it:

This corrects a typo in the `artifact_name` user variable, so that it aligns with the name of `ARTIFACT_NAME` environment variable in the `build_kubevirt_image.sh` script.

This is in line with the principle of least astonishment in that users would rightfully expect to be able to configure the `ARTIFACT_NAME` environment variable by setting `artifact_name` rather than `artificat_name` 😺.