### PR TITLE
Allow users to configure the QEMU VM name

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -28,7 +28,7 @@
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",
       "type": "qemu",
-      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
@@ -189,6 +189,7 @@
     "python_path": "",
     "qemu_binary": "qemu-system-x86_64",
     "ssh_password": "builder",
-    "ssh_username": "builder"
+    "ssh_username": "builder",
+    "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
   }
 }

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -28,7 +28,7 @@
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",
       "type": "qemu",
-      "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
+      "vm_name": "{{user `vm_name`}}"
     }
   ],
   "post-processors": [
@@ -174,6 +174,7 @@
     "python_path": "",
     "qemu_binary": "qemu-system-x86_64",
     "ssh_password": "builder",
-    "ssh_username": "builder"
+    "ssh_username": "builder",
+    "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
   }
 }


### PR DESCRIPTION
What this PR does / why we need it:

This allows users to configure the name of the VM used by packer explicitly, which also determines the name of the generated output file.

Making this configurable is also important in the context of other settings that have already been exposed to users. The QEMU builds allow users to configure `artifact_name` which has to be set to the same value as `vm_name` as it ultimately refers to the aforementioned output file.

Arguably, it might make sense to only expose `vm_name` to users and remove `artifact_name`, but that would constitute a non-backwards compatible change in the user interface that could break user builds.

See:
- https://developer.hashicorp.com/packer/plugins/builders/qemu#vm_name