### PR TITLE
Update containerd to 1.6.18, packer to 1.8.6

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.8.5"
+_version="1.8.6"
 
 # Change directories to the parent directory of the one in which this
 # script is located.

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,7 +1,7 @@
 {
   "containerd_additional_settings": null,
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
-  "containerd_sha256": "152c8479fc0054db63ff0175fea014da227279b8d3dcab5f2f4b4876317ffe26",
-  "containerd_sha256_windows": "5b723eb58f7678a63928ec6eadc4a837d52a727e264f365a888d1ee97046bc7f",
-  "containerd_version": "1.6.15"
+  "containerd_sha256": "974fdbd78875910a809b21aed0fa3356482fc4d438916a3c7f12bd6fe66c03f0",
+  "containerd_sha256_windows": "99977deb97bc0a013e453c705530e663e8556bff7fb1721e9b047540e45922fc",
+  "containerd_version": "1.6.18"
 }


### PR DESCRIPTION
What this PR does / why we need it:

#### Update containerd to 1.6.18

The eighteenth patch release for containerd 1.6 includes fixes for [CVE-2023-25153](https://github.com/advisories/GHSA-259w-8hf6-59c2) and [CVE-2023-25173](https://github.com/advisories/GHSA-hmfx-3pcx-653p)
along with a security update for Go.

See https://github.com/containerd/containerd/releases/tag/v1.6.18

#### Update packer to 1.8.6

See https://github.com/hashicorp/packer/releases/tag/v1.8.6



Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers