### PR TITLE
Allow Customizing values for Azure SIG Image Definition

### DIFF
--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -38,10 +38,10 @@ create_image_definition() {
   az sig image-definition create \
     --resource-group ${RESOURCE_GROUP_NAME} \
     --gallery-name ${GALLERY_NAME} \
-    --gallery-image-definition capi-${1} \
-    --publisher capz \
-    --offer capz-demo \
-    --sku ${2} \
+    --gallery-image-definition capi-${SIG_SKU:-$1} \
+    --publisher ${SIG_PUBLISHER:-capz} \
+    --offer ${SIG_OFFER:-capz-demo} \
+    --sku ${SIG_SKU:-$2} \
     --hyper-v-generation ${3} \
     --os-type ${4}
 }


### PR DESCRIPTION
What this PR does / why we need it:

At the moment the `init-sig.sh` script has many hardcoded values and does not allow customizing values. 

This PR allows customizing values using Environment Variables while defaulting to the current behaviour

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**

When creating FLATCAR image definition i want to be able to create

* image definition `capi-flatcar-stable-$(KUBERNETES_VERSION)-gen2`
* have one image for each `flatcar` version in the image definition which is organized by k8s version

with this PR i just need to export the right Environment variables to achieve this