### PR TITLE
fix: Update Ubuntu 22.04 ISO for vsphere and qemu

### DIFF
--- a/images/capi/packer/ova/ubuntu-2204.json
+++ b/images/capi/packer/ova/ubuntu-2204.json
@@ -10,7 +10,7 @@
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso",
+  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.1-live-server-amd64.iso",
   "os_display_name": "Ubuntu 22.04",
   "shutdown_command": "shutdown -P now",
   "vsphere_guest_os_type": "ubuntu64Guest"

--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
@@ -5,7 +5,7 @@
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.1-live-server-amd64.iso",
+  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.1-live-server-amd64.iso",
   "os_display_name": "Ubuntu 22.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"


### PR DESCRIPTION
Update Ubuntu 22.04.1 ISO location to old-releases. This keeps the ISO url stable for longer and the packer process will do a distro upgrade in any case.

closes: https://github.com/kubernetes-sigs/image-builder/issues/1083

What this PR does / why we need it:
Currently vsphere and qemu builds fail because the Ubuntu 22.04.1 ISO was moved to old-releases. This PR simply points to that ISO url, without having to change the SHA256 values.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1083

**Additional context**
I have tested both the vsphere and qemu builds in my environment.