### PR TITLE
Add jq to CAPI Dockerfile to fix Makefile error

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -17,7 +17,7 @@
 ARG BASE_IMAGE=docker.io/library/ubuntu:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates python3-pip curl wget git rsync vim unzip build-essential \
+RUN apt-get update && apt-get install -y apt-transport-https build-essential ca-certificates curl git jq python3-pip rsync unzip vim wget \
     && useradd -ms /bin/bash imagebuilder \
     && apt-get purge --auto-remove -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
What this PR does / why we need it:

Adds `apt-get install jq` to the Dockerfile for the `cluster-node-image-builder` container image.

This fixes an error running `make -C images/capi docker-build` since [line 294](https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/Makefile#L290-L295) of the Makefile calls a script that uses `jq`.

Which issue(s) this PR fixes:

N/A

**Additional context**
