### PR TITLE
fix: update OCI to work on ubuntu and ensure windows tool

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -117,6 +117,7 @@ deps-oci: ## Installs/checks dependencies for OCI builds
 deps-oci:
 	hack/ensure-ansible.sh
 	hack/ensure-packer.sh
+	hack/ensure-ansible-windows.sh
 	packer plugins install github.com/hashicorp/oracle
 
 .PHONY: deps-vbox

--- a/images/capi/packer/oci/scripts/set_bootstrap.sh
+++ b/images/capi/packer/oci/scripts/set_bootstrap.sh
@@ -22,6 +22,4 @@ set -o pipefail
 
 echo "Changing Password in winrm_bootstrap.txt"
 
-cp packer/oci/scripts/winrm_bootstrap_template.txt packer/oci/scripts/winrm_bootstrap.txt
-
-sed "s/(\[adsi\].*/([adsi](\"WinNT:\/\/\"+\$opcUser.caption).replace(\"\\\\\",\"\/\")).SetPassword(\"$OPC_USER_PASSWORD\")/g" packer/oci/scripts/winrm_bootstrap.txt | tee packer/oci/scripts/winrm_bootstrap.txt >/dev/null
+sed "s/(\[adsi\].*/([adsi](\"WinNT:\/\/\"+\$opcUser.caption).replace(\"\\\\\",\"\/\")).SetPassword(\"$OPC_USER_PASSWORD\")/g" packer/oci/scripts/winrm_bootstrap_template.txt | tee packer/oci/scripts/winrm_bootstrap.txt >/dev/null


### PR DESCRIPTION
What this PR does / why we need it:
The `tee` command worked on osx, but created a blank file on ubuntu. Removing the `cp` command and just letting `sed` and `tee` handle it.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): No open issues
**Additional context**

Add any other context for the reviewers

Linux output after successfully building the image
```
    oracle-oci: instance2023030 restarted.
==> oracle-oci: Machine successfully restarted, moving on
==> oracle-oci: Uploading ./packer/oci/scripts/sysprep.ps1 => C:\Users\opc\
    oracle-oci: sysprep.ps1 1.51 KiB / 1.51 KiB [===================================================================================================================================================] 100.00% 1s
==> oracle-oci: Uploading ./packer/oci/scripts/attach_secondary_vnic.ps1 => C:\Users\opc\
    oracle-oci: attach_secondary_vnic.ps1 1.31 KiB / 1.31 KiB [=====================================================================================================================================] 100.00% 1s
==> oracle-oci: Uploading ./packer/oci/scripts/enable_second_nic.ps1 => C:\Windows\Setup\Scripts\
    oracle-oci: enable_second_nic.ps1 1.07 KiB / 1.07 KiB [=========================================================================================================================================] 100.00% 2s
==> oracle-oci: Provisioning with Powershell...
==> oracle-oci: Provisioning with powershell script: /tmp/powershell-provisioner2845083841
==> oracle-oci: Provisioning with Powershell...
==> oracle-oci: Provisioning with powershell script: /tmp/powershell-provisioner2950415624
    oracle-oci: Using cloudbase-init unattend file for sysprep: C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf\Unattend.xml
    oracle-oci: IMAGE_STATE_COMPLETE
    oracle-oci: IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE
    oracle-oci: >>> Sysprep complete ...
==> oracle-oci: Creating image from instance...
==> oracle-oci: Updating image schema...
==> oracle-oci: Created image (<image-id>).
==> oracle-oci: Terminating instance (<instance-id>)...
==> oracle-oci: Terminated instance.
==> oracle-oci: Running post-processor: manifest
Build 'oracle-oci' finished after 32 minutes 44 seconds.

==> Wait completed after 32 minutes 44 seconds

==> Builds finished. The artifacts of successful builds are:
--> oracle-oci: An image was created: 'cluster-api-windows-v1.24.9-1677780905' (OCID: <image-id>) in region 'us-ashburn-1'
--> oracle-oci: An image was created: 'cluster-api-windows-v1.24.9-1677780905' (OCID: <image-id>) in region 'us-ashburn-1'
./packer/oci/scripts/unset_bootstrap.sh
resetting Password in winrm_bootstrap.txt
```

OSX output after successfully building the image
```
    oracle-oci: instance2023030 restarted.
==> oracle-oci: Machine successfully restarted, moving on
==> oracle-oci: Uploading ./packer/oci/scripts/sysprep.ps1 => C:\Users\opc\
    oracle-oci: sysprep.ps1 1.51 KiB / 1.51 KiB [=================================] 100.00% 1s
==> oracle-oci: Uploading ./packer/oci/scripts/attach_secondary_vnic.ps1 => C:\Users\opc\
    oracle-oci: attach_secondary_vnic.ps1 1.31 KiB / 1.31 KiB [===================] 100.00% 1s
==> oracle-oci: Uploading ./packer/oci/scripts/enable_second_nic.ps1 => C:\Windows\Setup\Scripts\
    oracle-oci: enable_second_nic.ps1 1.07 KiB / 1.07 KiB [=======================] 100.00% 1s
==> oracle-oci: Provisioning with Powershell...
==> oracle-oci: Provisioning with powershell script: /var/folders/yp/cx82s01j4m1d34krx_q97xs80000gn/T/powershell-provisioner2712643053
==> oracle-oci: Provisioning with Powershell...
==> oracle-oci: Provisioning with powershell script: /var/folders/yp/cx82s01j4m1d34krx_q97xs80000gn/T/powershell-provisioner2236797998
    oracle-oci: Using cloudbase-init unattend file for sysprep: C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf\Unattend.xml
    oracle-oci: IMAGE_STATE_COMPLETE
    oracle-oci: IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE
    oracle-oci: >>> Sysprep complete ...
==> oracle-oci: Creating image from instance...
==> oracle-oci: Updating image schema...
==> oracle-oci: Created image (<image-id>).
==> oracle-oci: Terminating instance (<instance-id>)...
==> oracle-oci: Terminated instance.
==> oracle-oci: Running post-processor: manifest
Build 'oracle-oci' finished after 32 minutes 34 seconds.

==> Wait completed after 32 minutes 34 seconds

==> Builds finished. The artifacts of successful builds are:
--> oracle-oci: An image was created: 'cluster-api-windows-v1.24.9-1677782994' (OCID: <image-id>) in region 'us-ashburn-1'
--> oracle-oci: An image was created: 'cluster-api-windows-v1.24.9-1677782994' (OCID: <image-id>) in region 'us-ashburn-1'
./packer/oci/scripts/unset_bootstrap.sh
resetting Password in winrm_bootstrap.txt
```