### PR TITLE
add /etc/cloud/cloud.cfg.d/15_azure-vnet.cfg to all Azure VMs

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/15_azure-vnet.cfg
+++ b/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/15_azure-vnet.cfg
@@ -1,0 +1,16 @@
+## We need the below configuration on Azure flavor VMs to enable DHCP on eth0
+## instead of Azure's IMDS endpoint. This configuration supports CNIs that
+## use extra available IPs on the host to assign them to the scheduled pods.
+## CNIs operating in overlay mode do not get affected by this configuration update.
+## We apply this configuration to the VM before its first boot, and not via
+## cloud-init's VM user data(customData), because network will get setup before reading
+## customData. Please refer for more context:
+## - https://github.com/kubernetes-sigs/image-builder/pull/1090#issuecomment-1468552870
+## - https://github.com/kubernetes-sigs/image-builder/pull/1090#issuecomment-1462944511
+##
+## Also refer to the PR adding this configuration for complete history and conversation.
+## - https://github.com/kubernetes-sigs/image-builder/pull/1090
+##
+datasource:
+  Azure:
+    apply_network_config: false

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -65,3 +65,14 @@
     - netbase
     - nfs-common
   when: ansible_os_family == "Debian"
+
+## refer to ../files/etc/cloud/cloud.cfg.d/15_azure-vnet.cfg
+## for more context on below file addition
+- name: Create azure-vnet config file
+  copy:
+    src: files/etc/cloud/cloud.cfg.d/15_azure-vnet.cfg
+    dest: /etc/cloud/cloud.cfg.d/15_azure-vnet.cfg
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_os_family == "Debian"

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -324,6 +324,12 @@ ubuntu:
       iptables -C FORWARD -d 168.63.129.16/32 -p tcp -m tcp --dport 80 -m comment --comment "block traffic to 168.63.129.16 for cve-2021-27075" -j DROP:
         exit-status: 0
         timeout: 0
+      grep -z -q -E '^datasource:\n\s\sAzure:\n\s\s\s\sgiapply_network_config:\sfalse$' /etc/cloud/cloud.cfg.d/15_azure-vnet.cfg || echo $?:
+        exit-status: 0
+        stdout: []
+        stderr: []
+        timeout: 0
+        title: "Check exact for the contents in /etc/cloud/cloud.cfg.d/15_azure-vnet.cfg"
     package:
       open-vm-tools:
       linux-cloud-tools-virtual:


### PR DESCRIPTION
What this PR does / why we need it:
- this applies the below struct to enable Azure CNI on CAPZ workloads created on Azure
```
datasource:
  Azure:
    apply_network_config: false
```


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
- This PR is a part of the PR https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3204 solving https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/467

**Additional context**
Add any other context for the reviewers