### PR TITLE
Updating cloudbase-init version to v1.1.4

### DIFF
--- a/images/capi/packer/config/windows/cloudbase-init.json
+++ b/images/capi/packer/config/windows/cloudbase-init.json
@@ -1,3 +1,3 @@
 {
-  "cloudbase_init_version": "1.1.2"
+  "cloudbase_init_version": "1.1.4"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Cloudbase-init v1.1.4 contains a fix for https://github.com/cloudbase/cloudbase-init/issues/94 which impacts node provisioning on Azure / with CAPZ

**Additional context**
Add any other context for the reviewers