### PR TITLE
docker: support qemu target builds

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -17,7 +17,20 @@
 ARG BASE_IMAGE=docker.io/library/ubuntu:latest
 FROM $BASE_IMAGE
 
-RUN apt-get update && apt-get install -y apt-transport-https build-essential ca-certificates curl git jq python3-pip rsync unzip vim wget \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	apt-transport-https \
+	build-essential \
+	ca-certificates \
+	curl \
+	git \
+	jq \
+	python3-pip \
+	rsync \
+	unzip \
+	vim \
+	wget \
+	qemu-system-x86 \
+	qemu-kvm \
     && useradd -ms /bin/bash imagebuilder \
     && apt-get purge --auto-remove -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
this commit adds qemu amd64 binaries to build qemu images from the Docker image.

example:
```
docker run -it --net host --rm -e OEM_ID=openstack cluster-node-image-builder-amd64 build-qemu-flatcar
```

_Note_: For now it can only run builds without acceleration because it still uses the `imagebuilder` user but as `imagebuilder` needs to be in the KVM group and we don't know in advance the group ID of `kvm` group on the host: we would need to build and run the image with `root` user to allow KVM acceleration, this can be done in a follow-up PR.

**Additional context**

We could preserve the `imagebuilder` user by creating it with the uid/gid 0 but in the end it's creating another "root" user... 