### PR TITLE
feat: Ubuntu 22.04 EFI Support for vSphere

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -285,7 +285,7 @@ FLATCAR_VERSIONS		:=	flatcar
 PHOTON_VERSIONS			:=	photon-3 photon-4
 RHEL_VERSIONS			:=	rhel-7 rhel-8
 ROCKYLINUX_VERSIONS     :=  rockylinux-8
-UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi ubuntu-2204
+UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi ubuntu-2204 ubuntu-2204-efi
 WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
 
 # Set Flatcar Container Linux channel and version if not supplied
@@ -626,11 +626,12 @@ build-node-ova-vsphere-rhel-8: ## Builds RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
+build-node-ova-vsphere-ubuntu-2004-efi: ## Builds Ubuntu 20.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-ubuntu-2204: ## Builds Ubuntu 22.04 Node OVA and template on vSphere
+build-node-ova-vsphere-ubuntu-2204-efi: ## Builds Ubuntu 22.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-windows-2019: ## Builds for Windows Server 2019 and template on vSphere
 build-node-ova-vsphere-windows-2004: ## Builds for Windows Server 2004 SAC and template on vSphere
 build-node-ova-vsphere-windows-2022: ## Builds for Windows Server 2022 template on vSphere
-build-node-ova-vsphere-ubuntu-2004-efi: ## Builds Ubuntu 20.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-all: $(NODE_OVA_VSPHERE_BUILD_TARGETS) ## Builds all Node OVAs and templates on vSphere
 
 build-node-ova-vsphere-clone-centos-7: ## Builds CentOS 7 Node OVA and template on vSphere
@@ -642,6 +643,7 @@ build-node-ova-vsphere-clone-rockylinux-8: ## Builds RockyLinux 8 Node OVA and t
 build-node-ova-vsphere-clone-ubuntu-1804: ## Builds Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2204: ## Builds Ubuntu 22.04 Node OVA and template on vSphere
+build-node-ova-vsphere-clone-ubuntu-2204-efi: ## ## Builds Ubuntu 22.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-clone-all: $(NODE_OVA_VSPHERE_CLONE_BUILD_TARGETS) ## Builds all Node OVAs and templates on vSphere
 
 build-node-ova-vsphere-base-centos-7: ## Builds base CentOS 7 Node OVA and template on vSphere
@@ -653,6 +655,7 @@ build-node-ova-vsphere-base-rockylinux-8: ## Builds base RockyLinux 8 Node OVA a
 build-node-ova-vsphere-base-ubuntu-1804: ## Builds base Ubuntu 18.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2004: ## Builds base Ubuntu 20.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2204: ## Builds base Ubuntu 22.04 Node OVA and template on vSphere
+build-node-ova-vsphere-base-ubuntu-2204-efi: ## Builds Ubuntu 22.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-base-all: $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS) ## Builds all base Node OVAs and templates on vSphere
 
 build-node-ova-local-vmx-photon-3: ## Builds Photon 3 Node OVA from VMX file w local hypervisor

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04.efi/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04.efi/user-data
@@ -1,0 +1,108 @@
+#cloud-config
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For more information on how autoinstall is configured, please refer to
+# https://ubuntu.com/server/docs/install/autoinstall-reference
+autoinstall:
+  version: 1
+  # Disable ssh server during installation, otherwise packer tries to connect and exceed max attempts
+  early-commands:
+    - systemctl stop ssh
+  # Configure the locale
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  grub:
+    reorder_uefi: false
+  # For more information on how partitioning is configured,
+  # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
+  storage:
+    config:
+    - ptable: gpt
+      path: /dev/sda
+      wipe: superblock-recursive
+      preserve: false
+      name: ''
+      grub_device: false
+      type: disk
+      id: disk-sda
+    - device: disk-sda
+      # Create EFI partition of 512MB same as in Ubuntu 20.04
+      size: 536870912
+      wipe: superblock
+      flag: boot
+      number: 1
+      preserve: false
+      grub_device: true
+      type: partition
+      id: partition-0
+    - fstype: fat32
+      volume: partition-0
+      preserve: false
+      type: format
+      id: format-0
+    - device: disk-sda
+      size: -1
+      wipe: superblock
+      flag: ''
+      number: 2
+      preserve: false
+      grub_device: false
+      type: partition
+      id: partition-1
+    - fstype: ext4
+      volume: partition-1
+      preserve: false
+      type: format
+      id: format-1
+    - path: /
+      device: format-1
+      type: mount
+      id: mount-1
+    - path: /boot/efi
+      device: format-0
+      type: mount
+      id: mount-0
+  updates: "all"
+  ssh:
+    install-server: true
+    allow-pw: true
+  # Customize the list of packages installed.
+  packages:
+    - open-vm-tools
+  # Create the default user.
+  # Ensures the "builder" user doesn't require a password to use sudo.
+  user-data:
+    users:
+      - name: builder
+        # openssl passwd -6 -stdin <<< builder
+        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
+        groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+        lock-passwd: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+
+  # This command runs after all other steps; it:
+  # 1. Disables swapfiles
+  # 2. Removes the existing swapfile
+  # 3. Removes the swapfile entry from /etc/fstab
+  # 4. Cleans up any packages that are no longer required
+  # 5. Removes the cached list of packages
+  late-commands:
+    - swapoff -a
+    - rm -f /swapfile
+    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - apt-get purge --auto-remove -y
+    - rm -rf /var/lib/apt/lists/*

--- a/images/capi/packer/ova/ubuntu-2204-efi.json
+++ b/images/capi/packer/ova/ubuntu-2204-efi.json
@@ -1,0 +1,17 @@
+{
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_media_path": "/media/HTTP",
+  "build_name": "ubuntu-2204-efi",
+  "distro_arch": "amd64",
+  "distro_name": "ubuntu",
+  "distro_version": "22.04",
+  "firmware": "efi",
+  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.1-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now",
+  "vsphere_guest_os_type": "ubuntu64Guest"
+}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds support for building vSphere Ubuntu 22.04 OVA's boot using EFI. This is needed for GPU support.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1096 

**Additional context**
- This is how I got the partition information, deployed a VM on vSphere environment from Ubuntu 22.04 ISO using EFI boot, and adjusted the auto-install user data available at `/var/log/installer`.
- Create OVA successfully
```
    vsphere (shell-local): image-build-ova: loaded ubuntu-2204-efi-kube-v1.23.15+vmware.1
    vsphere (shell-local): image-build-ova: create ovf ubuntu-2204-efi-v1.23.15---vmware.1.ovf
    vsphere (shell-local): image-build-ova: creating OVA from ubuntu-2204-efi-v1.23.15---vmware.1.ovf using ovftool
    vsphere (shell-local): image-build-ova: create ova checksum ubuntu-2204-efi-v1.23.15---vmware.1.ova.sha256
==> vsphere: Running post-processor: custom-post-processor (type shell-local)
==> vsphere (shell-local): Running local shell script: /tmp/packer-shell278616142
Build 'vsphere' finished after 36 minutes 28 seconds.

==> Wait completed after 36 minutes 28 seconds

==> Builds finished. The artifacts of successful builds are:
--> vsphere: ubuntu-2204-efi-kube-v1.23.15
--> vsphere: ubuntu-2204-efi-kube-v1.23.15
--> vsphere: ubuntu-2204-efi-kube-v1.23.15
--> vsphere: ubuntu-2204-efi-kube-v1.23.15
```
- Verified by creating a Kubernetes cluster.