### PR TITLE
Update pywinrm to v0.4.3

### DIFF
--- a/images/capi/hack/ensure-ansible-windows.sh
+++ b/images/capi/hack/ensure-ansible-windows.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="0.4.2"
+_version="0.4.3"
 
 if [[ ${HOSTOS} == "darwin" ]]; then
     echo "IMPORTANT: Winrm connection plugin for Ansible on MacOS causes connection issues."


### PR DESCRIPTION
What this PR does / why we need it:

Updates the [`pywinrm`](https://pypi.org/project/pywinrm/#history) package to v0.4.3, in hopes that this improves Windows build reliability.

See https://docs.ansible.com/ansible/latest/os_guide/windows_winrm.html#what-is-winrm for some context.

Which issue(s) this PR fixes: 

Refs #1097

**Additional context**

I tried this change in our Azure DevOps pipeline and it passed, but this bug isn't deterministic.