### PR TITLE
fix: update working with second nic for OCI image

### DIFF
--- a/docs/book/src/capi/providers/oci.md
+++ b/docs/book/src/capi/providers/oci.md
@@ -89,11 +89,10 @@ is defined in images/capi/packer/config/containerd.json.
 
 ### Building a Windows image
 
-> NOTE: In order to use Windows with CAPI a Baremetal instance is required. This means a Baremetal instance is required for building the image as well. The OCIDs for the 2019
-and 2022 Datacenter edition of Windows can be found in their respective documentation:
+> NOTE: In order to use Windows with CAPI a Baremetal instance is required. This means a Baremetal instance is required for
+> building the image as well. The OCIDs for the 2019 Datacenter edition of Windows can be found in their documentation:
 >
-> - [Windows server 2019](https://docs.oracle.com/en-us/iaas/images/windows-server-2019-bm/)
-> - [Windows server 2022](https://docs.oracle.com/en-us/iaas/images/windows-server-2022-bm/)
+> - [Windows server 2019](https://docs.oracle.com/en-us/iaas/images/image/ffa1ec8d-694e-4df7-b5ec-3e8061a7ecdf/)
 
 > NOTE: It is important to make sure the shape used at image build time is used when launching an instance.
 >
@@ -117,7 +116,7 @@ password failed to be updated.
 
 #### Build a Windows based image
 
-The following example JSON would use the [Windows Server 2019 Datacenter Edition BM E4 image in the us-ashburn-1 region](https://docs.oracle.com/en-us/iaas/images/image/4d56c93a-2165-49b0-9c6e-f9e9a9b05011/).
+The following example JSON would use the [Windows Server 2019 Datacenter Edition BM E4 image in the us-ashburn-1 region](https://docs.oracle.com/en-us/iaas/images/image/ffa1ec8d-694e-4df7-b5ec-3e8061a7ecdf/).
 
 ```json
 {

--- a/images/capi/packer/oci/scripts/enable_second_nic.ps1
+++ b/images/capi/packer/oci/scripts/enable_second_nic.ps1
@@ -8,7 +8,18 @@ if ($netAdapters.Length -le 1) {
     Exit 1
 }
 
-$secondNic = $netAdapters[1]
+# Make sure we use the second NIC, not the primary
+$primaryNic = Get-NetAdapter -Physical -Name "Ethernet"
+ForEach ($adapter in $netAdapters){
+    if ($adapter.Name -ne $primaryNic.Name) {
+        $secondNic = $adapter
+    }
+}
+
+if ($secondNic -eq $null) {
+    Write-Output "Could not find second Network Adapter from ${netAdapters}"
+    Exit 1
+}
 
 # make sure the network adapter is known
 if ($secondNic.Name -ne "") {


### PR DESCRIPTION
What this PR does / why we need it:
Hard coding to always use the second adapter doesn't work on all images. This should address the issue where the script is trying to modify the primary nic.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers

Output from building an image
```
==> oracle-oci: Restarting Machine
==> oracle-oci: Waiting for machine to restart...
==> oracle-oci: A system shutdown is in progress.(1115)
    oracle-oci: instance2023030 restarted.
==> oracle-oci: Machine successfully restarted, moving on
==> oracle-oci: Uploading ./packer/oci/scripts/sysprep.ps1 => C:\Users\opc\
    oracle-oci: sysprep.ps1 1.51 KiB / 1.51 KiB [======================================] 100.00% 1s
==> oracle-oci: Uploading ./packer/oci/scripts/attach_secondary_vnic.ps1 => C:\Users\opc\
    oracle-oci: attach_secondary_vnic.ps1 1.31 KiB / 1.31 KiB [========================] 100.00% 1s
==> oracle-oci: Uploading ./packer/oci/scripts/enable_second_nic.ps1 => C:\Windows\Setup\Scripts\
    oracle-oci: enable_second_nic.ps1 1.30 KiB / 1.30 KiB [============================] 100.00% 1s
==> oracle-oci: Provisioning with Powershell...
==> oracle-oci: Provisioning with powershell script: /var/folders/yp/cx82s01j4m1d34krx_q97xs80000gn/T/powershell-provisioner2617075006
==> oracle-oci: Provisioning with Powershell...
==> oracle-oci: Provisioning with powershell script: /var/folders/yp/cx82s01j4m1d34krx_q97xs80000gn/T/powershell-provisioner1713601553
    oracle-oci: Using cloudbase-init unattend file for sysprep: C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf\Unattend.xml
    oracle-oci: IMAGE_STATE_COMPLETE
    oracle-oci: IMAGE_STATE_UNDEPLOYABLE
    oracle-oci: IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE
    oracle-oci: >>> Sysprep complete ...
==> oracle-oci: Creating image from instance...
==> oracle-oci: Updating image schema...
==> oracle-oci: Created image (<image-ocid>).
==> oracle-oci: Terminating instance (<instance-ocid>)...
==> oracle-oci: Terminated instance.
==> oracle-oci: Running post-processor: manifest
Build 'oracle-oci' finished after 32 minutes 8 seconds.

==> Wait completed after 32 minutes 8 seconds

==> Builds finished. The artifacts of successful builds are:
--> oracle-oci: An image was created: 'cluster-api-windows-v1.24.9-1678298675' (OCID: <image-ocid>) in region 'us-ashburn-1'
--> oracle-oci: An image was created: 'cluster-api-windows-v1.24.9-1678298675' (OCID: <image-ocid>) in region 'us-ashburn-1'
./packer/oci/scripts/unset_bootstrap.sh
resetting Password in winrm_bootstrap.txt
```