### PR TITLE
Modify ova/rockylinux OS type

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -108,14 +108,15 @@ def main():
     vmdk = vmdk_files[0]
 
     OS_id_map = {"vmware-photon-64": {"id": "36", "version": "", "type": "vmwarePhoton64Guest"},
-                 "centos7-64": {"id": "107", "version": "7", "type": "centos7-64"},
-                 "centos8-64": {"id": "107", "version": "8", "type": "centos8-64"},
-                 "rhel7-64": {"id": "80", "version": "7", "type": "rhel7_64guest"},
-                 "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64guest"},
+                 "centos7-64": {"id": "107", "version": "7", "type": "centos7_64Guest"},
+                 "centos8-64": {"id": "107", "version": "8", "type": "centos8_64Guest"},
+                 "rhel7-64": {"id": "80", "version": "7", "type": "rhel7_64Guest"},
+                 "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64Guest"},
+                 "rockylinux-64": {"id": "80", "version": "", "type": "rockylinux_64Guest"},
                  "ubuntu-64": {"id": "94", "version": "", "type": "ubuntu64Guest"},
-                 "flatcar-64": {"id": "100", "version": "", "type": "linux-64"},
-                 "Windows2019Server-64": {"id": "112", "version": "", "type": "windows9srv-64"},
-                 "Windows2004Server-64": {"id": "112", "version": "", "type": "windows9srv-64"}}
+                 "flatcar-64": {"id": "100", "version": "", "type": "otherLinux64Guest"},
+                 "Windows2019Server-64": {"id": "112", "version": "", "type": "windows2019srv_64Guest"},
+                 "Windows2004Server-64": {"id": "112", "version": "", "type": "windows2019srv_64Guest"}}
 
     # Create the OVF file.
     data = {

--- a/images/capi/packer/ova/rockylinux-8.json
+++ b/images/capi/packer/ova/rockylinux-8.json
@@ -7,12 +7,12 @@
   "distro_name": "rockylinux",
   "distro_version": "8",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
-  "guest_os_type": "centos8-64",
+  "guest_os_type": "rockylinux-64",
   "iso_checksum": "13c3e7fca1fd32df61695584baafc14fa28d62816d0813116d23744f5394624b",
   "iso_checksum_type": "sha256",
   "iso_url": "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 8",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p",
-  "vsphere_guest_os_type": "other4xLinux64Guest"
+  "vsphere_guest_os_type": "rockylinux_64Guest"
 }


### PR DESCRIPTION
What this PR does / why we need it:

According to newly updated [GuestOsIdentifier](https://vdc-download.vmware.com/vmwb-repository/dcr-public/c476b64b-c93c-4b21-9d76-be14da0148f9/04ca12ad-59b9-4e1c-8232-fd3d4276e52c/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html), `rockylinux_64Guest` is added on Jan/12/2022.
- Modify `images/capi/packer/ova/rockylinux-8.json` to utilize `rockylinux_64Guest` instead of using `other4xLinux64Guest `. 
- Modify `images/capi/hack/image-build-ova.py` OS_id_map to pass GuestOSIdentifier from above link into OVF file as `OS_TYPE`. After this change, ovf will shows correct osType:
` <OperatingSystemSection ovf:id="80" ovf:version="" vmw:osType="rockylinux_64Guest">`