### PR TITLE
Adding vmware datasource configuration when building ubuntu 22.04 OVA

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
@@ -43,3 +43,11 @@
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
+
+- name: Create cloud-init datasource config file
+  copy:
+    dest: /etc/cloud/ds-identify.cfg
+    force: true
+    content: |
+      datasource: VMware
+  when: ansible_distribution_version is version('22.04', '>=')

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -93,3 +93,15 @@
   file:
     state: absent
     path: /etc/udev/rules.d/70-persistent-net.rules
+
+- name: Remvoing subiquity disable disable cloud-init networking config
+  file:
+    path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+    state: absent
+  when: ansible_distribution_version is version('22.04', '>=')
+
+- name: Removing 99-installer.cfg which sets the cloud-init datasource to None
+  file:
+    path: /etc/cloud/cloud.cfg.d/99-installer.cfg
+    state: absent
+  when: ansible_distribution_version is version('22.04', '>=')

--- a/images/capi/packer/ova/ubuntu-2204-efi.json
+++ b/images/capi/packer/ova/ubuntu-2204-efi.json
@@ -1,5 +1,6 @@
 {
-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_disable_ipv6": "0",
   "boot_media_path": "/media/HTTP",
   "build_name": "ubuntu-2204-efi",
   "distro_arch": "amd64",

--- a/images/capi/packer/ova/ubuntu-2204.json
+++ b/images/capi/packer/ova/ubuntu-2204.json
@@ -1,5 +1,5 @@
 {
-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
   "boot_disable_ipv6": "0",
   "boot_media_path": "/media/HTTP",
   "build_name": "ubuntu-2204",


### PR DESCRIPTION
What this PR does / why we need it:
- This PR adds the `ds-identify.cfg` with the datasource as VMware when building Ubuntu 22.04 OVA this is required to address the issue mentioned in #1104 
- Removes the cloud-init config files as per [KB](https://kb.vmware.com/s/article/80934)
- Adds the ability to disable ipv6 during the installation similar to #648 where it disabled ipv6 during boot for Ubuntu 20.04

### Testing
- Created Ubuntu 20.04 and Ubuntu 22.04 OVA
- Verified the OVA by creating Kubernetes clusters.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1104 

**Additional context**
While I removed some files related to the cloud-init configurations as per [KB](https://kb.vmware.com/s/article/80934), this is also affecting other clouds as per #1080.