### PR TITLE
Check for kube-proxy before building Azure Windows image

### DIFF
--- a/images/capi/packer/azure/.pipelines/build-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/build-vhd.yaml
@@ -20,6 +20,19 @@ jobs:
   steps:
   - template: k8s-config.yaml
   - script: |
+      set -euo pipefail
+      kube_proxy_url="sigwindowstools/kube-proxy:v${KUBERNETES_VERSION/+/_}-calico-hostprocess"
+      echo "Checking for Windows kube-proxy image $kube_proxy_url"
+      if ! stderr="$(docker pull $kube_proxy_url 2>&1 > /dev/null)"; then
+        # It's a Windows image, so expect an error after pulling it on Linux
+        if [[ $stderr != *"cannot be used on this platform"* ]]; then
+          echo "Failed to pull kube-proxy image: $stderr"
+          exit 1
+        fi
+      fi
+    displayName: Checking for Windows kube-proxy image
+    condition: and(eq(variables['PREFLIGHT_CHECKS'], 'true'), eq(variables['OS'], 'Windows'))
+  - script: |
       set -o pipefail
       make deps-azure
       os=$(echo "${OS}" | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
What this PR does / why we need it:

Adds a pre-flight check for the existence of the Windows kube-proxy image, before building and publishing the correlated Windows Kubernetes reference image.

Which issue(s) this PR fixes: 

Fixes #1106

**Additional context**
