### PR TITLE
Adding the possibility to have flatcar updated after deployment.

### DIFF
--- a/images/capi/ansible/roles/sysprep/defaults/main.yml
+++ b/images/capi/ansible/roles/sysprep/defaults/main.yml
@@ -15,3 +15,5 @@
 extra_repos: ""
 pip_conf_file: ""
 remove_extra_repos: false
+update_flatcar: false
+update_url: "https://public.update.flatcar-linux.net/v1/update/"

--- a/images/capi/ansible/roles/sysprep/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/flatcar.yml
@@ -22,12 +22,30 @@
     path: /etc/machine-id
     state: absent
 
+- name: Reactivate update-engine to enable updates from Nebraska
+  systemd:
+    name: update-engine
+    state: stopped
+    enabled: yes
+    masked: no
+  when: update_flatcar
+
+- name: Point to nebraska update server for OS and application updates
+  copy:
+    dest: /etc/flatcar/update.conf
+    content: |
+      GROUP={{update_group}}
+      SERVER={{update_url}}
+    mode: 0644
+  when: update_flatcar and (update_group is defined)
+
 - name: Stop and mask update-engine to freeze the image version
   systemd:
     name: update-engine
     state: stopped
     enabled: no
     masked: yes
+  when: not update_flatcar
 
 - name: Stop and mask the locksmith reboot manager since it depends on update-engine
   systemd:


### PR DESCRIPTION
**What this PR does / why we need it:**

Adding the possibility to have flatcar updated after deployment.


**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #**

**Additional context**

New ansible variables for `extra-vars.json` to have update-engine reenable and pointing to a Nebraska instance
- *update_flatcar* this is to enable the update capability of Flatcar.
- *update_group* is to assign a node to a update group in nebraska (ex: stable, beta, custom one)
- *update_url* is to point to a Nebraska update server (ex: https://public.update.flatcar-linux.net/v1/update/)