### PR TITLE
Fix netword-dispatcher url for Photon builds

### DIFF
--- a/images/capi/ansible/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/roles/providers/defaults/main.yml
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-networkd_dispatcher_download_url: "https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.bz2"
+networkd_dispatcher_download_url: "https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.gz"
 packer_builder_type: ""
 build_target: "virt"


### PR DESCRIPTION
What this PR does / why we need it:
`Install networkd-dispatcher service (Download from source)]` that downloads the source file is incorrectly unarchiving the `.bz2` file. Hence the next ansible task fails since it can't find the files -
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_image-builder/1120/pull-ova-all/1641194226899226624/artifacts/photon-3.log

Changing the download source to `.gz` fixes this issue.

/assign @kkeshavamurthy 