### PR TITLE
Adding support for qemu-ubuntu-2204-efi.

### DIFF
--- a/docs/book/src/capi/providers/raw.md
+++ b/docs/book/src/capi/providers/raw.md
@@ -31,7 +31,8 @@ $ sudo chown root:kvm /dev/kvm
 
 Then exit and log back in to make the change take place.
 
-## Building Images
+## Raw Images
+### Raw Dependencies
 
 The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
 building raw images are managed by running:
@@ -40,8 +41,7 @@ building raw images are managed by running:
 cd image-builder/images/capi
 make deps-raw
 ```
-
-### Building QCOW2 Image
+### Build the Raw Image
 
 From the `images/capi` directory, run `make build-raw-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `1804` or `2004` depending on the version you want to build the image for.
 
@@ -50,5 +50,28 @@ For building a ubuntu-2004 based CAPI image, run the following commands -
 ```bash
 $ git clone https://github.com/kubernetes-sigs/image-builder.git
 $ cd image-builder/images/capi/
-$ make build-qemu-ubuntu-2004
+$ make build-raw-ubuntu-2004
+```
+
+## QCOW2 Images
+### Raw Dependencies
+
+The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for
+building raw images are managed by running:
+
+```bash
+cd image-builder/images/capi
+make deps-qemu
+```
+
+### Building QCOW2 Image
+
+From the `images/capi` directory, run `make build-qemu-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `1804`,`2004` or `2204` depending on the version you want to build the image for.
+
+For building a ubuntu-2204 based CAPI image, run the following commands -
+
+```bash
+$ git clone https://github.com/kubernetes-sigs/image-builder.git
+$ cd image-builder/images/capi/
+$ make build-qemu-ubuntu-2204
 ```

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -367,7 +367,8 @@ OPENSTACK_BUILD_NAMES	?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-f
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2204-efi qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES				?=      raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar raw-rhel-8
@@ -743,6 +744,7 @@ build-qemu-flatcar: ## Builds Flatcar QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-ubuntu-2004-efi: ## Builds Ubuntu 20.04 QEMU image that EFI boots
 build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
+build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
@@ -872,6 +874,7 @@ validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-ubuntu-2004-efi: ## Validates Ubuntu 20.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
+validate-qemu-ubuntu-2204-efi: ## Validates Ubuntu 22.04 QEMU EFI image packer config
 validate-qemu-centos-7: ## Validates CentOS 7 QEMU image packer config
 validate-qemu-rhel-8: ## Validates RHEL 8 QEMU image
 validate-qemu-rockylinux-8: ## Validates Rocky Linux 8 QEMU image packer config

--- a/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi.qemu/user-data
+++ b/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi.qemu/user-data
@@ -1,0 +1,108 @@
+#cloud-config
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For more information on how autoinstall is configured, please refer to
+# https://ubuntu.com/server/docs/install/autoinstall-reference
+autoinstall:
+  version: 1
+  # Disable ssh server during installation, otherwise packer tries to connect and exceeds the max attempts allowed
+  early-commands:
+    - systemctl stop ssh
+  # Configure the locale
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  # Create a single-partition with no swap space. Kubernetes
+  # really dislikes the idea of anyone else managing memory.
+  # For more information on how partitioning is configured,
+  # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
+  storage:
+    config:
+      - ptable: gpt
+        path: /dev/sda
+        wipe: superblock-recursive
+        preserve: false
+        grub_device: false
+        type: disk
+        id: disk-sda
+      - device: disk-sda
+        size: 564133888
+        wipe: superblock
+        flag: boot
+        number: 1
+        preserve: false
+        grub_device: true
+        type: partition
+        id: partition-0
+      - fstype: fat32
+        volume: partition-0
+        preserve: false
+        type: format
+        id: format-0
+      - device: disk-sda
+        size: 8023703552
+        wipe: superblock
+        number: 2
+        preserve: false
+        grub_device: false
+        type: partition
+        id: partition-1
+      - fstype: ext4
+        volume: partition-1
+        preserve: false
+        type: format
+        id: format-1
+      - path: /
+        device: format-1
+        type: mount
+        id: mount-1
+      - path: /boot/efi
+        device: format-0
+        type: mount
+        id: mount-O
+  ssh:
+    install-server: true
+    allow-pw: true
+  # Customize the list of packages installed.
+  packages:
+    - open-vm-tools
+  # Create the default user.
+  # Ensures the "builder" user doesn't require a password to use sudo.
+  user-data:
+    users:
+      - name: builder
+        # openssl passwd -6 -stdin <<< builder
+        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
+        groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+        lock-passwd: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+
+  # This command runs after all other steps; it:
+  # 1. Installs efibootmgr tool
+  # 2. Sets disk device as first boot device instead of cd-rom
+  # 3. Disables swapfiles
+  # 4. Removes the existing swapfile
+  # 5. Removes the swapfile entry from /etc/fstab
+  # 6. Cleans up any packages that are no longer required
+  # 7. Removes the cached list of packages
+  late-commands:
+    - apt install -y efibootmgr
+    - efibootmgr -o 0006,0001,0000,0002,0003,0004,0005
+    - swapoff -a
+    - rm -f /swapfile
+    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - apt-get purge --auto-remove -y
+    - rm -rf /var/lib/apt/lists/*

--- a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
@@ -7,7 +7,7 @@
   "http_directory": "./packer/qemu/linux/ubuntu/http/22.04.efi.qemu",
   "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://ftpmirror.infania.net/mirror/ubuntu-releases/22.04.3/ubuntu-22.04.3-live-server-amd64.iso",
+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso",
   "os_display_name": "Ubuntu 22.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"

--- a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
@@ -1,0 +1,14 @@
+{
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/' --- <enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "build_name": "ubuntu-2204-efi",
+  "distro_name": "ubuntu",
+  "firmware": "OVMF.fd",
+  "guest_os_type": "ubuntu-64",
+  "http_directory": "./packer/qemu/linux/ubuntu/http/22.04.efi.qemu",
+  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://ftpmirror.infania.net/mirror/ubuntu-releases/22.04.3/ubuntu-22.04.3-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now",
+  "unmount_iso": "true"
+}


### PR DESCRIPTION
This PR provides a qemu-ubuntu-2204-efi target.

The qemu build does not work with the current user-data file used with the ova build (images/capi/packer/ova/linux/ubuntu/http/22.04.efi). 
Therefor I have provided a user-data file in the location image/capi/packer/qemu/files/22.04-efi/