### PR TITLE
Switch to e2 machine type

### DIFF
--- a/images/kube-deploy/container-image/cloudbuild.yaml
+++ b/images/kube-deploy/container-image/cloudbuild.yaml
@@ -1,7 +1,7 @@
 timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_8'
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'pull', 'debian:buster' ]


### PR DESCRIPTION
What this PR does / why we need it:
N1 one machines are outdated and going to be more expensive

Reference https://github.com/kubernetes/k8s.io/issues/5059

