### PR TITLE
Fix owners aliases for tide

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,7 +14,7 @@ aliases:
     - mboersma
   image-builder-openstack-reviewers:
     - hidekazuna
-  image-builder-openstack-maintainers
+  image-builder-openstack-maintainers:
     - drew-viles
     - yankcrime
   image-builder-cloudstack-reviewers:


### PR DESCRIPTION
Looks like there is a format error in the owners aliases file that is preventing automated merges.