### PR TITLE
Update kubeadm config file to supported API version

### DIFF
--- a/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
+++ b/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
@@ -1,11 +1,11 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 imageRepository: {{ kubernetes_container_registry }}
 kubernetesVersion: {{ kubernetes_semver }}
 dns:
   imageRepository: {{ kubernetes_container_registry }}/coredns
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 nodeRegistration:
   criSocket: {{ containerd_cri_socket }}


### PR DESCRIPTION
What this PR does / why we need it:

Updates the `kubeadm.yml` config file to the current `v1beta3` API. Support for the `v1beta2` API was dropped in Kubernetes v1.27.0, thus image-builder can't build current versions of k8s without this change.

Which issue(s) this PR fixes: 
Fixes #1130

**Additional context**
I tested this locally and was able to reproduce the error reported by @invidian using Kubernetes v1.27.1. I did a bit of research, found kubernetes/kubernetes#114540, then migrated the config file to the new API version and tested that it works.