### PR TITLE
Update some URL links in docs

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -48,7 +48,7 @@ Generation 2 images may only be used with Shared Image Gallery, not VHD.
 This table lists several common options that a user may want to set via
 `PACKER_VAR_FILES` to customize their build behavior.  This is not an exhaustive
 list, and greater explanation can be found in the
-[Packer documentation for the Azure ARM builder](https://www.packer.io/docs/builders/azure/arm).
+[Packer documentation for the Azure ARM builder](https://developer.hashicorp.com/packer/plugins/builders/azure/arm).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -65,7 +65,7 @@ If you are adding features to image builder than it is sometimes useful to work 
 
 ### Provision a VM directly from a VHD
 
-After creating a VHD, create a managed image using the url output from `make build-azure-vhd-<image>` and use it to [create the VM](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/build-image-with-packer#create-a-vm-from-the-packer-image): 
+After creating a VHD, create a managed image using the url output from `make build-azure-vhd-<image>` and use it to [create the VM](https://learn.microsoft.com/azure/virtual-machines/windows/build-image-with-packer#create-a-vm-from-the-packer-image):
 
 ```bash
 az image create -n testvmimage -g cluster-api-images --os-type <Windows/Linux> --source <storage url for vhd file>
@@ -73,4 +73,4 @@ az vm create -n testvm --image testvmimage -g cluster-api-images
 ```
 
 ### Debugging Packer scripts
-There are several ways to debug Packer scripts: https://www.packer.io/docs/other/debugging.html
+There are several ways to debug Packer scripts: https://developer.hashicorp.com/packer/docs/debugging

--- a/docs/book/src/capi/providers/oci.md
+++ b/docs/book/src/capi/providers/oci.md
@@ -69,8 +69,8 @@ PACKER_VAR_FILES=oci.json make build-oci-oracle-linux-8
 
 #### Build an Arm based image
 
-Building an Arm based image requires some overrides to use the correct installation files . An example for an 
-`oci.json` file  for Arm is shown below. The parameters for containerd, crictl and Kubernetes 
+Building an Arm based image requires some overrides to use the correct installation files . An example for an
+`oci.json` file  for Arm is shown below. The parameters for containerd, crictl and Kubernetes
 has to point to the corresponding URL for Arm. The containerd SHA can be changed appropriately, the containerd version
 is defined in images/capi/packer/config/containerd.json.
 
@@ -92,7 +92,7 @@ is defined in images/capi/packer/config/containerd.json.
 > NOTE: In order to use Windows with CAPI a Baremetal instance is required. This means a Baremetal instance is required for
 > building the image as well. The OCIDs for the 2019 Datacenter edition of Windows can be found in their documentation:
 >
-> - [Windows server 2019](https://docs.oracle.com/en-us/iaas/images/image/ffa1ec8d-694e-4df7-b5ec-3e8061a7ecdf/)
+> - [Windows server 2019](https://docs.oracle.com/iaas/images/image/ffa1ec8d-694e-4df7-b5ec-3e8061a7ecdf/)
 
 > NOTE: It is important to make sure the shape used at image build time is used when launching an instance.
 >
@@ -106,7 +106,7 @@ is defined in images/capi/packer/config/containerd.json.
 | `OPC_USER_PASSWORD` | The password to set the OPC user to when creating the image. This will be used for accessing instances using this image. |  | Yes |
 
 > NOTE: Your new password must be at least 12 characters long and must comply with
-[Microsoft's password policy](https://technet.microsoft.com/library/hh994562(v=ws.11).aspx?f=255&MSPPError=-2147217396).
+[Microsoft's password policy](https://learn.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/hh994562(v=ws.11)).
 If the password doesn't comply WinRM will fail to connect to the instance since the
 password failed to be updated.
 
@@ -116,7 +116,7 @@ password failed to be updated.
 
 #### Build a Windows based image
 
-The following example JSON would use the [Windows Server 2019 Datacenter Edition BM E4 image in the us-ashburn-1 region](https://docs.oracle.com/en-us/iaas/images/image/ffa1ec8d-694e-4df7-b5ec-3e8061a7ecdf/).
+The following example JSON would use the [Windows Server 2019 Datacenter Edition BM E4 image in the us-ashburn-1 region](https://docs.oracle.com/iaas/images/image/ffa1ec8d-694e-4df7-b5ec-3e8061a7ecdf/).
 
 ```json
 {

--- a/docs/book/src/capi/providers/virtualbox.md
+++ b/docs/book/src/capi/providers/virtualbox.md
@@ -32,7 +32,7 @@ make build-node-vbox-local-windows-2019
 
 #### Windows ISO download
 
-This field should point to a Windows evaluation ISO, it can be found at [Microsoft Evaluation Center](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019) page. Make sure you have the correct Windows Server version.
+This field should point to a Windows evaluation ISO, it can be found at [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter/evaluate-windows-server-2019) page. Make sure you have the correct Windows Server version.
 
 ```json
 {

--- a/docs/book/src/capi/windows/windows.md
+++ b/docs/book/src/capi/windows/windows.md
@@ -14,13 +14,13 @@ The `images/capi/packer/config/windows` directory includes several JSON files th
 
 ## Service Manager
 
-Image-builder provides you two ways to configure Windows services. The default is setup using [nssm](https://nssm.cc/) which configures a Windows service for kubelet by running `{{ kubernetes_install_path }}\StartKubelet.ps1` allowing easy editing of command arguments in the startup file.  The alternate is to use the Windows native [sc.exe](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/sc-config) which uses the kubelet argument `--windows-service` to install kubelet as a native Windows service with the command line arguments configured on the service. Nssm handles service restarts, if you are using sc.exe you may wish to configure the service restart options on kubelet. To avoid starting kubelet to early, image-builder sets the kubelet service to *manual* which you should consider changing once the node has joined a cluster.
+Image-builder provides you two ways to configure Windows services. The default is setup using [nssm](https://nssm.cc/) which configures a Windows service for kubelet by running `{{ kubernetes_install_path }}\StartKubelet.ps1` allowing easy editing of command arguments in the startup file.  The alternate is to use the Windows native [sc.exe](https://learn.microsoft.com/windows-server/administration/windows-commands/sc-config) which uses the kubelet argument `--windows-service` to install kubelet as a native Windows service with the command line arguments configured on the service. Nssm handles service restarts, if you are using sc.exe you may wish to configure the service restart options on kubelet. To avoid starting kubelet to early, image-builder sets the kubelet service to *manual* which you should consider changing once the node has joined a cluster.
 
 **Important: sc.exe does not support kubeadm KUBELET_KUBEADM_ARGS which is used by Cluster API to pass extra user args**
 
 ## Wins (by rancher)
 
-As a workaround for the lack of privileged containers on Windows nodes, SIG Windows utilise [Wins](https://github.com/rancher/wins/) to allow pods to run processes on hosts, an example is when you are using kube-proxy or a cni provider in a pod. This means that by default we install wins using image-builder. This may be undesirable, if you do not need pod to have the ability to run processes on the host. Additionally, Alpha support for Windows [Host Processes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support), which is the Windows equivalent for privileged containers, will be introduced in 1.22 which negates the need for wins entirely. To skip installing wins on the host you can add `"wins_url": ""` to your variables.  
+As a workaround for the lack of privileged containers on Windows nodes, SIG Windows utilise [Wins](https://github.com/rancher/wins/) to allow pods to run processes on hosts, an example is when you are using kube-proxy or a cni provider in a pod. This means that by default we install wins using image-builder. This may be undesirable, if you do not need pod to have the ability to run processes on the host. Additionally, Alpha support for Windows [Host Processes](https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/1981-windows-privileged-container-support), which is the Windows equivalent for privileged containers, will be introduced in 1.22 which negates the need for wins entirely. To skip installing wins on the host you can add `"wins_url": ""` to your variables.
 
 When using containerd, due to lack of host networking, there is currently no way to run cni inside a pod.   To work around this, containerd needs to be installed with an additional custom Ansible module or after the image has been created.  With CAPI, the additional configuration can be done with pre/postKubeadm scripts when the node is created.
 
@@ -31,15 +31,15 @@ When building Windows images it is necessary to install OS and Security updates.
 To specify the update categories to check, provide a value for `windows_updates_categories` in `packer/config/windows/common.json`.
 
 Example:
-Install all available updates from *all categories*.    
-`"windows_updates_categories": "CriticalUpdates SecurityUpdates UpdateRollups"` 
+Install all available updates from *all categories*.
+`"windows_updates_categories": "CriticalUpdates SecurityUpdates UpdateRollups"`
 
 Published Cloud Provider images such as Azure or AWS are regularly updated so it may be preferable to specify individual patches to install.  This can be achieved by specifying the KB numbers of required updates.
 
-To choose individual updates, provide a value for `windows_updates_kbs` in `packer/config/windows/common.json`. 
+To choose individual updates, provide a value for `windows_updates_kbs` in `packer/config/windows/common.json`.
 
-Example: 
-`"windows_updates_kbs": "KB4580390 KB4471332"`.  
+Example:
+`"windows_updates_kbs": "KB4580390 KB4471332"`.
 
 ## OpenSSH Server
 
@@ -58,7 +58,7 @@ Follow the documentation for configuring WinRM on the Windows machine: https://d
 After WinRM is installed you can edit or `/etc/ansible/hosts` file with the following:
 
 ```
-[winhost]    
+[winhost]
 <windows ip>
 
 [winhost:vars]


### PR DESCRIPTION
What this PR does / why we need it:

I noticed a broken link to a Hashicorp doc on debugging, then found some other URL updates to make while I was fixing that.

Which issue(s) this PR fixes:

N/A

**Additional context**

Removing `/en-us` from URLs is a best practice, because otherwise correctly localized documentation may not be accessed.