### PR TITLE
mark the test_vhd step as failed if az capi command fails

### DIFF
--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -110,6 +110,9 @@ jobs:
     env:
       AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
   - script: |
+      set -x
+      set -e -o pipefail
+
       params=()
       if [ "$OS" == "Windows" ]; then
         params+=(--windows)
@@ -130,9 +133,6 @@ jobs:
         --tags="${TAGS}" \
         --wait-for-nodes=2 \
         "${params[@]}"
-
-        set -x
-        set -e -o pipefail
 
         # test if the vm's provisionState is "Succeeded" otherwise fail
         # even though the node is reporting Ready, it still takes a moment for the Azure VM to go to Succeeded


### PR DESCRIPTION
What this PR does / why we need it:
- We have been a weird behavior in the Azure pipeline where the Azure pipeline goes green even when the `test_vhd` step had failed. (Reference https://dev.azure.com/AzureContainerUpstream/capz/_build/results?buildId=88485&view=logs&j=c8c55126-21c3-5ad0-4841-9cb30089399f&t=14905e62-d139-5cb8-a824-fcdc1dd3fb3f&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e)
- This PR will mark the _test_vhd_ step as failed if `az capi` command fails.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers