### PR TITLE
Add OS_VERSION to goss for qemu

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -128,6 +128,7 @@
       "vars_inline": {
         "ARCH": "amd64",
         "OS": "{{user `distro_name` | lower}}",
+        "OS_VERSION": "{{user `distribution_version` | lower}}",
         "PROVIDER": "qemu",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",

--- a/images/capi/packer/qemu/qemu-centos-7.json
+++ b/images/capi/packer/qemu/qemu-centos-7.json
@@ -3,6 +3,7 @@
   "boot_command_prefix": "<tab> text ks=",
   "boot_command_suffix": "/7/ks.cfg<enter><wait>",
   "build_name": "centos-7",
+  "distribution_version": "7",
   "distro_arch": "amd64",
   "distro_name": "centos",
   "distro_version": "7",

--- a/images/capi/packer/qemu/qemu-flatcar.json
+++ b/images/capi/packer/qemu/qemu-flatcar.json
@@ -6,6 +6,7 @@
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",
   "crictl_source_type": "http",
+  "distribution_version": "{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "distro_name": "flatcar",
   "guest_os_type": "linux-64",
   "http_directory": "./packer/files/flatcar/ignition/",

--- a/images/capi/packer/qemu/qemu-rhel-8.json
+++ b/images/capi/packer/qemu/qemu-rhel-8.json
@@ -2,6 +2,7 @@
   "boot_command_prefix": "<tab> text inst.ks=",
   "boot_command_suffix": "/8/ks.cfg<enter><wait>",
   "build_name": "rhel-8",
+  "distribution_version": "8",
   "distro_name": "rhel",
   "distro_version": "8",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",

--- a/images/capi/packer/qemu/qemu-rockylinux-8.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-8.json
@@ -2,6 +2,7 @@
   "boot_command_prefix": "<up><tab> text inst.ks=",
   "boot_command_suffix": "/8/ks.cfg<enter><wait><enter>",
   "build_name": "rockylinux-8",
+  "distribution_version": "8",
   "distro_arch": "amd64",
   "distro_name": "rockylinux",
   "distro_version": "8",

--- a/images/capi/packer/qemu/qemu-ubuntu-1804.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-1804.json
@@ -2,6 +2,7 @@
   "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
   "boot_command_suffix": "/18.04/preseed.cfg -- <enter>",
   "build_name": "ubuntu-1804",
+  "distribution_version": "1804",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",

--- a/images/capi/packer/qemu/qemu-ubuntu-2004-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2004-efi.json
@@ -2,6 +2,7 @@
   "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>linux /install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost preseed/url=",
   "boot_command_suffix": "/20.04/preseed-efi.cfg -- <wait><enter>initrd /install/initrd.gz<enter>boot<enter><wait>",
   "build_name": "ubuntu-2004",
+  "distribution_version": "2004",
   "distro_name": "ubuntu",
   "firmware": "OVMF.fd",
   "guest_os_type": "ubuntu-64",

--- a/images/capi/packer/qemu/qemu-ubuntu-2004.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2004.json
@@ -2,6 +2,7 @@
   "boot_command_prefix": "<esc><wait><esc><wait><enter><wait>/install/vmlinuz auto console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US netcfg/get_domain=local netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda preseed/url=",
   "boot_command_suffix": "/20.04/preseed.cfg -- <wait><enter><wait>",
   "build_name": "ubuntu-2004",
+  "distribution_version": "2004",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",

--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
@@ -1,6 +1,7 @@
 {
   "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
   "build_name": "ubuntu-2204",
+  "distribution_version": "2204",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
   "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",


### PR DESCRIPTION
What this PR does / why we need it:


currently a local `qemu-flatcar` build fails with

```
==> qemu: Goss validate failed
==> qemu: Inspect mode on : proceeding without failing Packer
==> qemu: Running GOSS render command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"flatcar","PROVIDER":"qemu","containerd_version":"1.6.18","kubernetes_cni_deb_version":"1.2.0-00","kubernetes_cni_rpm_version":"1.2.0","kubernetes_cni_source_type":"http","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.23.15-00","kubernetes_rpm_version":"1.23.15","kubernetes_source_type":"http","kubernetes_version":"1.23.15"}' render > /tmp/goss-spec.yaml
==> qemu: could not read json data in goss/goss-package.yaml: template: test:60:26: executing "test" at <.Vars.OS_VERSION>: map has no entry for key "OS_VERSION"
==> qemu: Goss render failed
==> qemu: Inspect mode on : proceeding without failing Packer
==> qemu: Running GOSS render debug command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"flatcar","PROVIDER":"qemu","containerd_version":"1.6.18","kubernetes_cni_deb_version":"1.2.0-00","kubernetes_cni_rpm_version":"1.2.0","kubernetes_cni_source_type":"http","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.23.15-00","kubernetes_rpm_version":"1.23.15","kubernetes_source_type":"http","kubernetes_version":"1.23.15"}' render -d > /tmp/debug-goss-spec.yaml
==> qemu: could not read json data in goss/goss-package.yaml: template: test:60:26: executing "test" at <.Vars.OS_VERSION>: map has no entry for key "OS_VERSION"
```

Setting the same value that is set on the `azure/packer.json` for `OS_VERSION`

**Additional context**
Add any other context for the reviewers