### PR TITLE
AARCH64 / ARM64 CAPI image build for Ubuntu 22.04

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -338,7 +338,7 @@ OPENSTACK_BUILD_NAMES	?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-f
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-1804 qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar qemu-ubuntu-2204-arm64
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES                        ?=      raw-ubuntu-1804 raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar raw-rhel-8
@@ -700,6 +700,7 @@ build-openstack-ubuntu-2204: ## Builds Ubuntu 22.04 OpenStack image
 build-openstack-flatcar: ## Builds Flatcar OpenStack image
 build-openstack-all: $(OPENSTACK_BUILD_TARGETS)
 
+build-qemu-ubuntu-2204-arm64: ## Builds Ubuntu 22.04 QEMU ARM64 image
 build-qemu-flatcar: ## Builds Flatcar QEMU image
 build-qemu-ubuntu-1804: ## Builds Ubuntu 18.04 QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
@@ -830,11 +831,11 @@ validate-node-ova-local-base-ubuntu-1804: ## Validates Ubuntu 18.04 Base Node OV
 validate-node-ova-local-base-ubuntu-2004: ## Validates Ubuntu 20.04 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-2204: ## Validates Ubuntu 22.04 Base Node OVA w local hypervisor
 
-validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-1804: ## Validates Ubuntu 18.04 QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-ubuntu-2004-efi: ## Validates Ubuntu 20.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
+validate-qemu-ubuntu-2204-arm64: ## Validates Ubuntu 22.04 QEMU ARM64 image packer config
 validate-qemu-centos-7: ## Validates CentOS 7 QEMU image packer config
 validate-qemu-rhel-8: ## Validates RHEL 8 QEMU image
 validate-qemu-rockylinux-8: ## Validates Rocky Linux 8 QEMU image packer config

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -91,7 +91,6 @@ common_virt_rpms:
 - open-vm-tools
 
 common_virt_debs:
-- linux-cloud-tools-virtual
 - linux-tools-virtual
 - open-vm-tools
 

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -46,4 +46,4 @@
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and ansible_architecture != "aarch64"

--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -19,7 +19,16 @@
     mode: 0644
   # OCI Base images have the required apt sources list embedded inside the image, adding the sources list
   # from this repo leads to build failures(especially in Arm), hence ignoring the step.
-  when: packer_builder_type != "oracle-oci"
+  when: packer_builder_type != "oracle-oci" and ansible_architecture != "aarch64"
+
+- name: Put templated sources.list in place for ARM64
+  template:
+    src: etc/apt/arm64.sources.list.j2
+    dest: /etc/apt/sources.list
+    mode: 0644
+  # OCI Base images have the required apt sources list embedded inside the image, adding the sources list
+  # from this repo leads to build failures(especially in Arm), hence ignoring the step.
+  when: packer_builder_type != "oracle-oci" and ansible_architecture == "aarch64"
 
 - name: Put templated apt.conf.d/90proxy in place when defined
   template:

--- a/images/capi/ansible/roles/setup/templates/etc/apt/arm64.sources.list.j2
+++ b/images/capi/ansible/roles/setup/templates/etc/apt/arm64.sources.list.j2
@@ -1,0 +1,4 @@
+deb http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }} main restricted universe
+deb http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }}-updates main restricted universe
+deb http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }}-backports main restricted universe
+deb http://ports.ubuntu.com/ubuntu-ports {{ ansible_distribution_release }}-security main restricted universe

--- a/images/capi/arm64.json
+++ b/images/capi/arm64.json
@@ -1,0 +1,8 @@
+{
+  "containerd_sha256": "5b7811998b02cf06ec2449c571d5d68a6796cfbba6b402cee0a355a6e431e204",
+  "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-arm64.tar.gz",
+  "cpus": "32",
+  "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-arm64.tar.gz",
+  "memory": "16384",
+  "qemu_binary": "qemu-system-aarch64"
+}

--- a/images/capi/hack/ensure-goss.sh
+++ b/images/capi/hack/ensure-goss.sh
@@ -25,7 +25,8 @@ source hack/utils.sh
 # SHA are for amd64 arch.
 _version="3.1.4"
 darwin_sha256="ddb663a3e4208639d90b89ebdb69dc240ec16d6b01877ccbf968f76a58a89f99"
-linux_sha256="9084877c2eea7e41fae60aaa6cdf7a7dde4e5de5e3d1f693ec8e812419ac54e9"
+linux_amd64_sha256="9084877c2eea7e41fae60aaa6cdf7a7dde4e5de5e3d1f693ec8e812419ac54e9"
+linux_arm64_sha256="5c3f43800b22cc9a1084f3f700243ea1a2392e12c0ae55987bec91d07b5547ed"
 _bin_url="https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${_version}/packer-provisioner-goss-v${_version}-${HOSTOS}-${HOSTARCH}.tar.gz"
 _tarfile="${HOME}/.packer.d/plugins/packer-provisioner-goss.tar.gz"
 _binfile="${HOME}/.packer.d/plugins/packer-provisioner-goss"
@@ -33,7 +34,18 @@ _binfile="${HOME}/.packer.d/plugins/packer-provisioner-goss"
 # Get a shasum for right OS's binary
 case "${HOSTOS}" in
 linux)
-  _sha256="${linux_sha256}"
+  case "${HOSTARCH}" in
+    amd64)
+      _sha256="${linux_amd64_sha256}"
+      ;;
+    arm64)
+      _sha256="${linux_arm64_sha256}"
+      ;;
+    *)
+      echo "unsupported HOSTARCH=${HOSTARCH}" 1>&2
+      return 1
+      ;;
+  esac
   ;;
 darwin)
   _sha256="${darwin_sha256}"

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -29,7 +29,10 @@ esac
 
 _hostarch=$(uname -m)
 case "${_hostarch}" in
-*64*)
+*aarch64*)
+  HOSTARCH=arm64
+  ;;
+*x86_64*)
   HOSTARCH=amd64
   ;;
 *386*)

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -390,7 +390,6 @@ ubuntu:
       cloud-initramfs-dyn-netconf:
   qemu:
     package:
-      linux-cloud-tools-virtual:
       linux-tools-virtual:
       open-vm-tools:
       cloud-guest-utils:
@@ -552,3 +551,4 @@ windows:
         filetype: file
         contains:
         - "metadata_services=cloudbaseinit.metadata.services.base.EmptyMetadataService"
+

--- a/images/capi/packer/qemu/files/22.04-arm64/user-data
+++ b/images/capi/packer/qemu/files/22.04-arm64/user-data
@@ -1,0 +1,112 @@
+#cloud-config
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# For more information on how autoinstall is configured, please refer to
+# https://ubuntu.com/server/docs/install/autoinstall-reference
+autoinstall:
+  version: 1
+  # Disable ssh server during installation, otherwise packer tries to connect and exceed max attempts
+  early-commands:
+    - systemctl stop ssh
+  # Configure the locale
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  # Create a single-partition with no swap space. Kubernetes
+  # really dislikes the idea of anyone else managing memory.
+  # For more information on how partitioning is configured,
+  # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
+  storage:
+    config:
+    - ptable: gpt
+      path: /dev/vda
+      wipe: superblock-recursive
+      preserve: false
+      grub_device: false
+      type: disk
+      id: disk-vda
+    - device: disk-vda
+      size: 564133888
+      wipe: superblock
+      flag: boot
+      number: 1
+      preserve: false
+      grub_device: true
+      type: partition
+      id: partition-0
+    - fstype: fat32
+      volume: partition-0
+      preserve: false
+      type: format
+      id: format-0
+    - device: disk-vda
+      size: 8023703552
+      wipe: superblock
+      number: 2
+      preserve: false
+      grub_device: false
+      type: partition
+      id: partition-1
+    - fstype: ext4
+      volume: partition-1
+      preserve: false
+      type: format
+      id: format-1
+    - path: /
+      device: format-1
+      type: mount
+      id: mount-1
+    - path: /boot/efi
+      device: format-0
+      type: mount
+      id: mount-O
+  # This is redundant, done in ansible also
+  # updates: 'all'
+  ssh:
+    install-server: true
+    allow-pw: true
+  # Customize the list of packages installed.
+  packages:
+    - open-vm-tools
+  # Create the default user.
+  # Ensures the "builder" user doesn't require a password to use sudo.
+  user-data:
+    users:
+      - name: builder
+        # openssl passwd -6 -stdin <<< builder
+        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
+        groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+        lock-passwd: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+
+  # This command runs after all other steps; it:
+  # 1. Install efibootmgr tool
+  # 2. Set disk device as first dootdevice instead of cd-rom
+  # 3. Disables swapfiles
+  # 4. Removes the existing swapfile
+  # 5. Removes the swapfile entry from /etc/fstab
+  # 6. Cleans up any packages that are no longer required
+  # 7. Removes the cached list of packages
+  late-commands:
+    - apt install -y efibootmgr
+    - efibootmgr -o 0001,0000,0002,0003,0004,0005
+    - swapoff -a
+    - rm -f /swapfile
+    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - apt-get purge --auto-remove -y
+    - rm -rf /var/lib/apt/lists/*
+

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -23,12 +23,74 @@
       "net_device": "virtio-net",
       "output_directory": "{{user `output_directory`}}",
       "qemu_binary": "{{user `qemu_binary`}}",
+      "qemuargs": [
+        [
+          "-machine",
+          "virt,accel=kvm,gic-version=host"
+        ],
+        [
+          "-cpu",
+          "host"
+        ],
+        [
+          "-k",
+          "en-us"
+        ],
+        [
+          "-boot",
+          "strict=off"
+        ],
+        [
+          "-device",
+          "usb-ehci"
+        ],
+        [
+          "-device",
+          "usb-kbd"
+        ],
+        [
+          "-device",
+          "usb-mouse"
+        ],
+        [
+          "-drive",
+          "file=./output/{{user `vm_name`}}/{{user `vm_name`}},if=none,id=drive0,cache=writeback"
+        ],
+        [
+          "-device",
+          "virtio-blk,drive=drive0,bootindex=0"
+        ],
+        [
+          "-drive",
+          "file=/root/.cache/packer/1bb131b162f10e50ac7d8671a71f4a0e13e36197.iso,if=none,id=drive1,cache=writeback"
+        ],
+        [
+          "-device",
+          "virtio-blk,drive=drive1,bootindex=1"
+        ],
+        [
+          "-drive",
+          "file=/var/lib/libvirt/images/capi.fd,format=raw,if=pflash"
+        ],
+        [
+          "-drive",
+          "file=/var/lib/libvirt/images/capi-nvmram.fd,format=raw,if=pflash"
+        ],
+        "-usb",
+        [
+          "-device",
+          "virtio-gpu-pci"
+        ]
+      ],
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",
       "type": "qemu",
-      "vm_name": "{{user `vm_name`}}"
+      "vm_name": "{{user `vm_name`}}",
+      "vnc_bind_address": "0.0.0.0",
+      "vnc_port_max": 5903,
+      "vnc_port_min": 5903
     }
   ],
   "post-processors": [

--- a/images/capi/packer/qemu/qemu-ubuntu-2204-arm64.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204-arm64.json
@@ -1,0 +1,15 @@
+{
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz console=ttyAMA0 autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/' --- <enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_type": "uefi",
+  "build_name": "ubuntu-2204-arm64",
+  "distro_name": "ubuntu",
+  "guest_os_type": "ubuntu-64",
+  "http_directory": "./packer/qemu/files/22.04-arm64",
+  "iso_checksum": "12eed04214d8492d22686b72610711882ddf6222b4dc029c24515a85c4874e95",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://cdimage.ubuntu.com/releases/jammy/release/ubuntu-22.04.2-live-server-arm64.iso",
+  "os_display_name": "Ubuntu 22.04",
+  "root_device_name": "/dev/vda",
+  "shutdown_command": "shutdown -P now",
+  "unmount_iso": "true"
+}


### PR DESCRIPTION
What this PR does / why we need it:

Added example on how to build an ARM64 CAPI image using QEMU.
How to run:

```bash

# under root

apt-get install qemu-system-arm qemu-efi qemu-kvm libvirt-daemon-system -y

# create disk images
pushd /var/lib/libvirt/images/
dd if=/dev/zero of=capi.fd bs=1M count=64
dd if=/dev/zero of=capi-nvmram.fd bs=1M count=64
dd if=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd of=capi.fd conv=notrunc
popd

PACKER_VAR_FILES=arm64.json ARCH=arm64 PACKER_LOG=1 make build-qemu-ubuntu-2204-arm64

# vnc listener is set conveniently to 0.0.0.0:5903 for quicker debug, can be removed later on

# Image should be present at
# ./output/ubuntu-2204-arm64-kube-v1.24.11/ubuntu-2204-arm64-kube-v1.24.11
```

Several parts need to be refactored, any help would be great.

To do's:

1. linux-cloud-tools-virtual debian package does not exist on ARM64 (an exception needs to be added)
2. Replace qemuargs with Packer keywords. I did check on Packer support for ARM64 + QEMU-KVM, but could not see any way to replace the specific qemuargs with Packer equivalent.
3. Cleanup the code after the above have been implemented

Ubuntu 22.04 ARM64 CAPI image with K8s version 1.24 was created and was tested using Tinkerbell Cluster API Provider.