### PR TITLE
Avoid errors when RHEL subscription user and pass are not provided

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -18,7 +18,10 @@
     username: "{{ lookup('env', 'RHSM_USER') }}"
     password: "{{ lookup('env', 'RHSM_PASS') }}"
     auto_attach: true
-  when: ansible_distribution == "RedHat"
+  when: 
+    - ansible_distribution == "RedHat"
+    - lookup('env', 'RHSM_USER') | length > 0
+    - lookup('env', 'RHSM_PASS') | length > 0
 
 - name: import epel gpg key
   rpm_key:

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -60,7 +60,10 @@
         state: absent
     - name: clean local subscription data
       command: subscription-manager clean
-  when: ansible_distribution == "RedHat"
+  when: 
+    - ansible_distribution == "RedHat"
+    - lookup('env', 'RHSM_USER') | length > 0
+    - lookup('env', 'RHSM_PASS') | length > 0
 
 - name: Remove yum package caches
   yum:


### PR DESCRIPTION
What this PR does / why we need it:

Avoid errors when RHEL subscription username and password are not provided

Tasks: RHEL subscription & Remove subscriptions
