### PR TITLE
Remove subiquity autoinstall leftovers

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -105,3 +105,15 @@
     path: /etc/cloud/cloud.cfg.d/99-installer.cfg
     state: absent
   when: ansible_distribution_version is version('22.04', '>=')
+
+- name: Removing subiquity curtin preserve sources config
+  file:
+    path: /etc/cloud/cloud.cfg.d/curtin-preserve-sources.cfg
+    state: absent
+  when: ansible_distribution_version is version('22.04', '>=')
+
+- name: Removing cloud-init ds identify config
+  file:
+    path: /etc/cloud/ds-identify.cfg
+    state: absent
+  when: ansible_distribution_version is version('22.04', '>=')

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04.efi/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04.efi/user-data
@@ -24,11 +24,12 @@ autoinstall:
   locale: en_US.UTF-8
   keyboard:
     layout: us
-  grub:
-    reorder_uefi: false
   # For more information on how partitioning is configured,
   # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
   storage:
+    grub:
+      reorder_uefi: false
+      replace_linux_default: false
     config:
     - ptable: gpt
       path: /dev/sda

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
@@ -30,6 +30,8 @@ autoinstall:
   # For more information on how partitioning is configured,
   # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
   storage:
+    grub:
+      replace_linux_default: false
     config:
       - type: disk
         id: disk-0


### PR DESCRIPTION
Remove subiquity autoinstall leftovers

Also, GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub is not altered with 'autoinstall ds='nocloud-net...'' so another cloud-init datasource can be detected

What this PR does / why we need it:

The bootstrap process of Capi Ubuntu 22.04 image built with Qemu now should work. I tested it on OpenStack.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1137 

**Additional context**

> ubuntu 22.04 images created with qemu are quite big.... 10-15G each

I experienced the same problem as mentioned in #1137 but it is not solved.