### PR TITLE
Add support for Confidential VM images

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -42,6 +42,18 @@ make build-azure-sig-ubuntu-1804-gen2
 
 Generation 2 images may only be used with Shared Image Gallery, not VHD.
 
+### Confidential VM Images
+
+Confidential VMs require specific generation 2 OS images. The naming pattern of those images includes the suffix `-cvm`. For example:
+
+```bash
+# Ubuntu 20.04 LTS for Confidential VMs
+make build-azure-sig-ubuntu-2004-cvm
+
+# Windows 2019 with containerd for Confindential VMs
+make build-azure-sig-windows-2019-containerd-cvm
+```
+
 ### Configuration
 #### Common Azure options
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -333,9 +333,11 @@ GCE_BUILD_NAMES			   ?= gce-ubuntu-1804 gce-ubuntu-2004 gce-ubuntu-2204
 VHD_TARGETS := $(shell grep VHD_TARGETS azure_targets.sh | sed 's/VHD_TARGETS=//' | tr -d \")
 SIG_TARGETS := $(shell grep SIG_TARGETS azure_targets.sh | sed 's/SIG_TARGETS=//' | tr -d \")
 SIG_GEN2_TARGETS := $(shell grep SIG_GEN2_TARGETS azure_targets.sh | sed 's/SIG_GEN2_TARGETS=//' | tr -d \")
+SIG_CVM_TARGETS := $(shell grep SIG_CVM_TARGETS azure_targets.sh | sed 's/SIG_CVM_TARGETS=//' | tr -d \")
 AZURE_BUILD_VHD_NAMES	   ?= $(addprefix azure-vhd-,$(VHD_TARGETS))
 AZURE_BUILD_SIG_NAMES	   ?= $(addprefix azure-sig-,$(SIG_TARGETS))
 AZURE_BUILD_SIG_GEN2_NAMES ?= $(addsuffix -gen2,$(addprefix azure-sig-,$(SIG_GEN2_TARGETS)))
+AZURE_BUILD_SIG_CVM_NAMES ?= $(addsuffix -cvm,$(addprefix azure-sig-,$(SIG_CVM_TARGETS)))
 
 OCI_BUILD_NAMES			   ?= oci-ubuntu-1804 oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-oracle-linux-9 oci-windows-2019 oci-windows-2022
 
@@ -373,8 +375,10 @@ AZURE_BUILD_VHD_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_VHD_NAMES))
 AZURE_VALIDATE_VHD_TARGETS	:= $(addprefix validate-,$(AZURE_BUILD_VHD_NAMES))
 AZURE_BUILD_SIG_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_SIG_NAMES))
 AZURE_BUILD_SIG_GEN2_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_SIG_GEN2_NAMES))
+AZURE_BUILD_SIG_CVM_TARGETS	:= $(addprefix build-,$(AZURE_BUILD_SIG_CVM_NAMES))
 AZURE_VALIDATE_SIG_TARGETS	:= $(addprefix validate-,$(AZURE_BUILD_SIG_NAMES))
 AZURE_VALIDATE_SIG_GEN2_TARGETS	:= $(addprefix validate-,$(AZURE_BUILD_SIG_GEN2_NAMES))
+AZURE_VALIDATE_SIG_CVM_TARGETS	:= $(addprefix validate-,$(AZURE_BUILD_SIG_CVM_NAMES))
 DO_BUILD_TARGETS 	:= $(addprefix build-,$(DO_BUILD_NAMES))
 DO_VALIDATE_TARGETS 	:= $(addprefix validate-,$(DO_BUILD_NAMES))
 OPENSTACK_BUILD_TARGETS	:= $(addprefix build-,$(OPENSTACK_BUILD_NAMES))
@@ -462,6 +466,10 @@ $(AZURE_BUILD_SIG_TARGETS): deps-azure
 $(AZURE_BUILD_SIG_GEN2_TARGETS): deps-azure
 	. $(abspath packer/azure/scripts/init-sig.sh) $(subst build-azure-sig-,,$@) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-gen2.json)" -var-file="$(abspath packer/azure/$(subst build-azure-sig-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
 
+.PHONY: $(AZURE_BUILD_SIG_CVM_TARGETS)
+$(AZURE_BUILD_SIG_CVM_TARGETS): deps-azure
+	. $(abspath packer/azure/scripts/init-sig.sh) $(subst build-azure-sig-,,$@) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-cvm.json)" -var-file="$(abspath packer/azure/$(subst build-azure-sig-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+
 .PHONY: $(AZURE_VALIDATE_SIG_TARGETS)
 $(AZURE_VALIDATE_SIG_TARGETS): deps-azure
 	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
@@ -469,6 +477,10 @@ $(AZURE_VALIDATE_SIG_TARGETS): deps-azure
 .PHONY: $(AZURE_VALIDATE_SIG_GEN2_TARGETS)
 $(AZURE_VALIDATE_SIG_GEN2_TARGETS): deps-azure
 	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-gen2.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring windows,$@).json
+
+.PHONY: $(AZURE_VALIDATE_SIG_CVM_TARGETS)
+$(AZURE_VALIDATE_SIG_CVM_TARGETS): deps-azure
+	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-cvm.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
 
 .PHONY: $(DO_BUILD_TARGETS)
 $(DO_BUILD_TARGETS): deps-do
@@ -601,6 +613,8 @@ build-azure-sig-rhel-8: ## Builds RHEL 8 Azure managed image in Shared Image Gal
 build-azure-sig-windows-2019: ## Builds Windows Server 2019 Azure managed image in Shared Image Gallery
 build-azure-sig-windows-2019-containerd: ## Builds Windows Server 2019 with containerd Azure managed image in Shared Image Gallery
 build-azure-sig-windows-2022-containerd: ## Builds Windows Server 2022 with containerd Azure managed image in Shared Image Gallery
+build-azure-sig-windows-2019-containerd-cvm: ## Builds Windows Server 2019 with containerd CVM Azure managed image in Shared Image Gallery
+build-azure-sig-windows-2022-containerd-cvm: ## Builds Windows Server 2022 with containerd CVM Azure managed image in Shared Image Gallery
 build-azure-sig-windows-2004: ## Builds Windows Server 2004 SAC Azure managed image in Shared Image Gallery
 build-azure-vhd-ubuntu-1804: ## Builds Ubuntu 18.04 VHD image for Azure
 build-azure-vhd-ubuntu-2004: ## Builds Ubuntu 20.04 VHD image for Azure
@@ -617,8 +631,10 @@ build-azure-sig-flatcar-gen2: ## Builds Flatcar Azure Gen2 managed image in Shar
 build-azure-sig-ubuntu-1804-gen2: ## Builds Ubuntu 18.04 Gen2 managed image in Shared Image Gallery
 build-azure-sig-ubuntu-2004-gen2: ## Builds Ubuntu 20.04 Gen2 managed image in Shared Image Gallery
 build-azure-sig-ubuntu-2204-gen2: ## Builds Ubuntu 22.04 Gen2 managed image in Shared Image Gallery
+build-azure-sig-ubuntu-2004-cvm: ## Builds Ubuntu 20.04 CVM managed image in Shared Image Gallery
+build-azure-sig-ubuntu-2204-cvm: ## Builds Ubuntu 22.04 CVM managed image in Shared Image Gallery
 build-azure-vhds: $(AZURE_BUILD_VHD_TARGETS) ## Builds all Azure VHDs
-build-azure-sigs: $(AZURE_BUILD_SIG_TARGETS) $(AZURE_BUILD_SIG_GEN2_TARGETS) ## Builds all Azure Shared Image Gallery images
+build-azure-sigs: $(AZURE_BUILD_SIG_TARGETS) $(AZURE_BUILD_SIG_GEN2_TARGETS) $(AZURE_BUILD_SIG_CVM_TARGETS) ## Builds all Azure Shared Image Gallery images
 
 build-do-ubuntu-1804: ## Builds Ubuntu 18.04 DigitalOcean Snapshot
 build-do-ubuntu-2004: ## Builds Ubuntu 20.04 DigitalOcean Snapshot
@@ -784,8 +800,10 @@ validate-azure-vhd-windows-2004: ## Validate Windows Server 2004 SAC VHD image A
 validate-azure-sig-centos-7-gen2: ## Validates CentOS 7 Azure managed image in Shared Image Gallery Packer config
 validate-azure-sig-ubuntu-1804-gen2: ## Validates Ubuntu 18.04 Azure managed image in Shared Image Gallery Packer config
 validate-azure-sig-ubuntu-2004-gen2: ## Validates Ubuntu 20.04 Azure managed image in Shared Image Gallery Packer config
+validate-azure-sig-ubuntu-2004-cvm: ## Validates Ubuntu 20.04 CVM Azure managed image in Shared Image Gallery Packer config
 validate-azure-sig-ubuntu-2204-gen2: ## Validates Ubuntu 22.04 Azure managed image in Shared Image Gallery Packer config
-validate-azure-all: $(AZURE_VALIDATE_SIG_TARGETS) $(AZURE_VALIDATE_VHD_TARGETS) $(AZURE_VALIDATE_SIG_GEN2_TARGETS) ## Validates all images for Azure Packer config
+validate-azure-sig-ubuntu-2204-cvm: ## Validates Ubuntu 22.04 CVM Azure managed image in Shared Image Gallery Packer config
+validate-azure-all: $(AZURE_VALIDATE_SIG_TARGETS) $(AZURE_VALIDATE_VHD_TARGETS) $(AZURE_VALIDATE_SIG_GEN2_TARGETS) $(AZURE_VALIDATE_SIG_CVM_TARGETS) ## Validates all images for Azure Packer config
 
 validate-do-ubuntu-1804: ## Validates Ubuntu 18.04 DigitalOcean Snapshot Packer config
 validate-do-ubuntu-2004: ## Validates Ubuntu 20.04 DigitalOcean Snapshot Packer config

--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -62,6 +62,16 @@
   loop: "{{ extra_repos.split() }}"
   when: extra_repos != ""
 
+- name: Hold nullboot
+  ansible.builtin.dpkg_selections:
+    name: nullboot
+    selection: hold
+  when: packer_build_name is search('cvm')
+
+- name: Add '--no-tpm --no-efivars' to nullboot post install script
+  command: "sed -i 's/nullbootctl/nullbootctl --no-tpm --no-efivars/' /var/lib/dpkg/info/nullboot.postinst"
+  when: packer_build_name is search('cvm')
+
 - name: perform a dist-upgrade
   apt:
     force_apt_get: True
@@ -103,3 +113,8 @@
   until: apt_lock_status is not failed
   retries: 5
   delay: 10
+
+- name: Remove '--no-tpm --no-efivars' from nullboot post install script
+  command: "sed -i 's/nullbootctl --no-tpm --no-efivars/nullbootctl/' /var/lib/dpkg/info/nullboot.postinst"
+  when: packer_build_name is search('cvm')
+

--- a/images/capi/azure_targets.sh
+++ b/images/capi/azure_targets.sh
@@ -4,3 +4,5 @@ SIG_TARGETS="ubuntu-1804 ubuntu-2004 ubuntu-2204 centos-7 rhel-8 windows-2019 wi
 SIG_CI_TARGETS="ubuntu-2004 ubuntu-2204 windows-2019-containerd windows-2022-containerd flatcar"
 SIG_GEN2_TARGETS="ubuntu-1804 ubuntu-2004 ubuntu-2204 centos-7 flatcar"
 SIG_GEN2_CI_TARGETS="ubuntu-2004 ubuntu-2204 flatcar"
+SIG_CVM_TARGETS="ubuntu-2004 ubuntu-2204 windows-2019-containerd windows-2022-containerd"
+SIG_CVM_CI_TARGETS="ubuntu-2204 windows-2022-containerd"

--- a/images/capi/packer/azure/azure-sig-cvm.json
+++ b/images/capi/packer/azure/azure-sig-cvm.json
@@ -1,0 +1,7 @@
+{
+  "image_name": "capi-{{user `distribution`}}-{{user `distribution_version`}}-cvm",
+  "replication_regions": "{{env `AZURE_LOCATION`}}",
+  "resource_group_name": "{{env `RESOURCE_GROUP_NAME`}}",
+  "shared_image_gallery_name": "{{env `GALLERY_NAME`}}",
+  "sig_image_version": "0.3.{{user `build_timestamp`}}"
+}

--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -34,6 +34,8 @@ packer validate -syntax-only $PACKER_FILE || exit 1
 
 az sig create --resource-group ${RESOURCE_GROUP_NAME} --gallery-name ${GALLERY_NAME}
 
+SECURITY_TYPE_CVM_SUPPORTED_FEATURE="SecurityType=ConfidentialVmSupported"
+
 create_image_definition() {
   az sig image-definition create \
     --resource-group ${RESOURCE_GROUP_NAME} \
@@ -43,7 +45,8 @@ create_image_definition() {
     --offer ${SIG_OFFER:-capz-demo} \
     --sku ${SIG_SKU:-$2} \
     --hyper-v-generation ${3} \
-    --os-type ${4}
+    --os-type ${4} \
+    --features ${5:-''}
 }
 
 SIG_TARGET=$1
@@ -73,6 +76,14 @@ case ${SIG_TARGET} in
   windows-2022-containerd)
     create_image_definition ${SIG_TARGET} "win-2022-containerd" "V1" "Windows"
   ;;
+  windows-2019-containerd-cvm)
+    SKU="windows-2019-cvm-containerd"
+    create_image_definition ${SKU} ${SKU} "V2" "Windows" ${SECURITY_TYPE_CVM_SUPPORTED_FEATURE}
+  ;;
+  windows-2022-containerd-cvm)
+    SKU="windows-2022-cvm-containerd"
+    create_image_definition ${SKU} ${SKU} "V2" "Windows" ${SECURITY_TYPE_CVM_SUPPORTED_FEATURE}
+  ;;
   flatcar)
     SKU="flatcar-${FLATCAR_CHANNEL}-${FLATCAR_VERSION}"
     create_image_definition ${SKU} ${SKU} "V1" "Linux"
@@ -83,8 +94,14 @@ case ${SIG_TARGET} in
   ubuntu-2004-gen2)
     create_image_definition ${SIG_TARGET} "20_04-lts-gen2" "V2" "Linux"
   ;;
+  ubuntu-2004-cvm)
+    create_image_definition ${SIG_TARGET} "20_04-lts-cvm" "V2" "Linux" ${SECURITY_TYPE_CVM_SUPPORTED_FEATURE}
+  ;;
   ubuntu-2204-gen2)
     create_image_definition ${SIG_TARGET} "22_04-lts-gen2" "V2" "Linux"
+  ;;
+  ubuntu-2204-cvm)
+    create_image_definition ${SIG_TARGET} "22_04-lts-cvm" "V2" "Linux" ${SECURITY_TYPE_CVM_SUPPORTED_FEATURE}
   ;;
   centos-7-gen2)
     create_image_definition "centos-7-gen2" "centos-7-gen2" "V2" "Linux"

--- a/images/capi/packer/azure/ubuntu-2004-cvm.json
+++ b/images/capi/packer/azure/ubuntu-2004-cvm.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "ubuntu-2004-cvm",
+  "distribution": "ubuntu",
+  "distribution_release": "focal",
+  "distribution_version": "2004",
+  "image_offer": "0001-com-ubuntu-confidential-vm-focal",
+  "image_publisher": "Canonical",
+  "image_sku": "20_04-lts-cvm"
+}

--- a/images/capi/packer/azure/ubuntu-2204-cvm.json
+++ b/images/capi/packer/azure/ubuntu-2204-cvm.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "ubuntu-2204-cvm",
+  "distribution": "ubuntu",
+  "distribution_release": "jammy",
+  "distribution_version": "2204",
+  "image_offer": "0001-com-ubuntu-confidential-vm-jammy",
+  "image_publisher": "Canonical",
+  "image_sku": "22_04-lts-cvm"
+}

--- a/images/capi/packer/azure/windows-2019-containerd-cvm.json
+++ b/images/capi/packer/azure/windows-2019-containerd-cvm.json
@@ -1,0 +1,16 @@
+{
+  "additional_registry_images": "false",
+  "additional_registry_images_list": "",
+  "build_name": "windows-2019-containerd-cvm",
+  "distribution": "windows",
+  "distribution_version": "2019",
+  "image_offer": "windows-cvm",
+  "image_publisher": "MicrosoftWindowsServer",
+  "image_sku": "2019-datacenter-cvm",
+  "image_version": "latest",
+  "load_additional_components": "false",
+  "runtime": "containerd",
+  "vm_size": "Standard_D4s_v3",
+  "windows_updates_kbs": "",
+  "wins_url": ""
+}

--- a/images/capi/packer/azure/windows-2022-containerd-cvm.json
+++ b/images/capi/packer/azure/windows-2022-containerd-cvm.json
@@ -1,0 +1,16 @@
+{
+  "additional_registry_images": "false",
+  "additional_registry_images_list": "",
+  "build_name": "windows-2022-containerd-cvm",
+  "distribution": "windows",
+  "distribution_version": "2022",
+  "image_offer": "windows-cvm",
+  "image_publisher": "MicrosoftWindowsServer",
+  "image_sku": "2022-datacenter-cvm",
+  "image_version": "latest",
+  "load_additional_components": "false",
+  "runtime": "containerd",
+  "vm_size": "Standard_D4s_v3",
+  "windows_updates_kbs": "",
+  "wins_url": ""
+}


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds support for [Azure Confidential VM images](https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview#size-support). These images are necessary in order to enable the [Cluster API Provider Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3265) support nodes hosted on Confidential VMs. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1154

**Additional context**

Related [CAPZ PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/3265).

NOTE: Building a CAPI Ubuntu 22.04 CVM image from a VM instance with vTPM disabled fails due to [this](https://bugs.launchpad.net/ubuntu/+source/nullboot/+bug/1993256) bug(?) in nullboot. At the same time, Azure (and thus also packer) does not [support](https://github.com/hashicorp/packer-plugin-azure/pull/257/files#diff-542c8fccfc4385f43d11c723777a061dd22251a34db06cb5499f5d626df71326R1072) publishing trusted launch images to [managed images](https://github.com/hashicorp/packer-plugin-azure/pull/257#pullrequestreview-1287854834) (i.e. when `vTpmEnabled: true`, we can't publish a managed image, which is currently what we do now for all linux images). Because of this we are currently unable to build an CAPI Ubuntu 22.04 for CVM image.