### PR TITLE
Fix Ansible failure: Invalid variable name in 'register' specified: 'import'

### DIFF
--- a/images/capi/ansible/windows/roles/load_additional_components/tasks/url.yml
+++ b/images/capi/ansible/windows/roles/load_additional_components/tasks/url.yml
@@ -72,8 +72,8 @@
   poll: 60
   retries: 5
   delay: 3
-  register: import
-  until: import is not failed
+  register: docker_import
+  until: docker_import is not failed
   when: runtime == "docker" 
 
 - name: Remove downloaded files


### PR DESCRIPTION
What this PR does / why we need it:

Renames Ansible variable `import` which seems to be somewhat reserved name for the latest Ansible causing the build of the Windows Server 2019 image to fail.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1151

**Additional context**
Add any other context for the reviewers

I have nearly zero experience with Ansible, but here are my observations:

Without this fix, Ansible task `Load additional Docker images` failed for me with the following error

```
...
    virtualbox-iso: TASK [load_additional_components : Load additional Docker images] **************
    virtualbox-iso: ERROR! Invalid variable name in 'register' specified: 'import'
    virtualbox-iso: skipping: [default] => (item=)
    virtualbox-iso: skipping: [default]
2023/05/03 20:21:14 [INFO] (telemetry) ending ansible
==> virtualbox-iso: Error executing Ansible: Non-zero exit status: exit status 1
```

With this fix, Ansible continued fine:

```
...
    virtualbox-iso:
    virtualbox-iso: TASK [load_additional_components : Load additional images to containerd] *******
    virtualbox-iso: skipping: [default] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'item': '', 'ansible_loop_var': 'item'})
    virtualbox-iso: skipping: [default]
    virtualbox-iso:
    virtualbox-iso: TASK [load_additional_components : Load additional Docker images] **************
    virtualbox-iso: skipping: [default] => (item=)
    virtualbox-iso: skipping: [default]
    virtualbox-iso:
    virtualbox-iso: TASK [load_additional_components : Remove downloaded files] ********************
    virtualbox-iso: skipping: [default]
    virtualbox-iso:
    virtualbox-iso: TASK [include_role : debug] ****************************************************
    virtualbox-iso:
...
```