### PR TITLE
Update container image docs for v0.1.15 release

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -14,9 +14,11 @@ Run the docker build target of Makefile
    ```
 
 ## Using a Container Image
-The latest container image can be pulled from GCR as below -
+
+The latest image-builder container image release is available here:
+
 ```commandline
-docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd64:v0.1.13
+docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15
 ```
 
 ### Examples
@@ -25,7 +27,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
     - If the AWS CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials.
 
     ```commandline
-    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.13 build-ami-ubuntu-2004
+    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15 build-ami-ubuntu-2004
     ```
     - Another alternative is to use an `aws-creds.env` file to load the credentials and pass it during docker run.
 
@@ -36,7 +38,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
       ```
 
     ```commandline
-        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.13 build-ami-ubuntu-2004
+        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15 build-ami-ubuntu-2004
     ```
 
 - AZURE
@@ -51,7 +53,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
       ```
 
     ```commandline
-    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.13 build-azure-sig-ubuntu-2004
+    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15 build-azure-sig-ubuntu-2004
     ```
 
 - vSphere OVA
@@ -60,7 +62,7 @@ docker pull gcr.io/k8s-staging-scl-image-builder/cluster-node-image-builder-amd6
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the Docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
 
     ```commandline
-    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.13 build-node-ova-vsphere-ubuntu-2004
+    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15 build-node-ova-vsphere-ubuntu-2004
     ```
 
 In addition to this, further customizations can be done as discussed [here](./capi.md#customization).


### PR DESCRIPTION
What this PR does / why we need it:

Updates references in image-builder docs to the [v0.1.15 release](https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.15).
