### PR TITLE
Add release tools and documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Image Builder Releases
+
+The current release of Image Builder is [v0.1.15][] (May 11, 2023). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15`.
+
+## Release Process
+
+For more detail about image-builder project releases, see the [Image Builder Book][].
+
+
+[v0.1.15]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.15
+[Image Builder Book]: https://image-builder.sigs.k8s.io/capi/releasing.html

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,4 +20,5 @@
   - [VirtualBox](./capi/providers/virtualbox.md)
   - [Testing the Images](./capi/goss/goss.md)
   - [Using Container Images](./capi/container-image.md)
+  - [Releasing](./capi/releasing.md)
 - [Glossary](./glossary.md)

--- a/docs/book/src/capi/releasing.md
+++ b/docs/book/src/capi/releasing.md
@@ -1,0 +1,86 @@
+# Image Builder Releases
+
+The current release of Image Builder is [v0.1.15][] (May 11, 2023). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.15`.
+
+## Release Process
+
+Releasing image-builder is a simple process: project maintainers should be able to follow the steps below in order to create a new release.
+
+### Create a tag
+
+Releases in image-builder follow [semantic versioning][semver] conventions. Currently the project tags only patch releases on the master branch.
+
+- Check out the existing branch and make sure you have the latest changes:
+  - `git checkout master`
+  - `git fetch upstream`
+    - *This assumes you have an "upstream" git remote pointing at github.com/kubernetes-sigs/image-builder*
+  - `git rebase upstream/master`
+    - *If the HEAD commit isn't meant for release, reset to the intended commit before proceeding.*
+- Ensure you can sign tags:
+  - Set up GPG, SSH, or S/MIME [at GitHub](https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification) if you haven't already.
+  - `export GPG_TTY=$(tty)`
+    - *If signing tags with GPG, makes your key available to the `git tag` command.*
+- Create a new tag:
+  - `export IB_VERSION=v0.1.x`
+    - *Replace `x` with the next patch version. For example: `v0.1.16`.*
+  - `git tag -s -m "Image Builder ${IB_VERSION}" ${IB_VERSION}`
+  - `git push upstream ${IB_VERSION}`
+
+### Promote Image to Production
+
+Pushing the tag in the previous step triggered a job to build the container image and publish it to the staging registry.
+
+- Images are built by the [pr-container-image-build][] job. This will push the image to a [staging repository][].
+- Wait for the above pr-container-image-build job to complete and for the tagged image to exist in the staging directory.
+- If you don't have a GitHub token, create one via [Personal access tokens][]. Make sure you give the token the `repo` scope.
+- Create a GitHub pull request to promote the image:
+  - `export GITHUB_TOKEN=<your GH token>`
+  - `make -C images/capi promote-image`
+
+This will create a PR in [k8s.io](https://github.com/kubernetes/k8s.io) and assign the image-builder maintainers. Example PR: https://github.com/kubernetes/k8s.io/pull/5262.
+
+When reviewing this PR, confirm that the addition matches the SHA in the [staging repository][].
+
+### Publish GitHub Release
+
+While waiting for the above PR to merge, create a GitHub draft release for the tag you created in the first step.
+
+- Visit the [releases page][] and click the "Draft a new release" button.
+  - *If you don't see that button, you don't have all maintainer permissions.*
+- Choose the new tag from the drop-down list, and type it in as the release title too.
+- Click the "Generate release notes" button to auto-populate the release description.
+- At the top, before `## What's Changed`, insert a reference to the container artifact, replacing `x` with the patch version:
+
+    ```
+    This release of the image-builder container is available at:
+
+    `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.x`
+    ```
+- Proofread the release notes and make any necessary edits.
+- Click the "Save draft" button.
+- When the pull request from the previous step has merged, check that the image-builder container is actually available. This may take up to an hour after the PR merges.
+  - `docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:${IB_VERSION}`
+- When `docker pull` succeeds, return to the GitHub draft release, ensure "Set as the latest release" is true, and click the "Publish release" button.
+
+### Update Documentation
+
+There are several files in image-builder itself that refer to the latest release (including this one). Create a pull request that updates these to the newly published version.
+
+Wait for this PR to merge before communicating the release to users, so image-builder documentation is consistent.
+
+### Publicize Release
+
+In the [#image-builder channel][] on the Kubernetes Slack, post a message announcing the new release. Include a link to the GitHub release and a thanks to the contributors:
+
+```
+Image-builder v0.1.16 is now available: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.16
+Thanks to all contributors!
+```
+
+[v0.1.15]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.15
+[#image-builder channel]: https://kubernetes.slack.com/archives/C01E0Q35A8J
+[Personal access tokens]: https://github.com/settings/tokens
+[pr-container-image-build]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-builder#pr-container-image-build
+[releases page]: https://github.com/kubernetes-sigs/image-builder/releases
+[semver]: https://semver.org/#semantic-versioning-200
+[staging repository]: https://console.cloud.google.com/gcr/images/k8s-staging-scl-image-builder/GLOBAL/cluster-node-image-builder-amd64

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -156,6 +156,13 @@ deps-nutanix:
 	hack/ensure-packer.sh
 	hack/ensure-goss.sh
 
+.PHONY: deps-release
+deps-release: ## Installs/checks dependencies for project releases
+	hack/ensure-go.sh
+	hack/ensure-jq.sh
+	hack/ensure-kpromo.sh
+	hack/ensure-yq.sh
+
 ## --------------------------------------
 ## Container variables
 ## --------------------------------------
@@ -948,9 +955,16 @@ test-azure: ## Run the tests for Azure builders
 ## --------------------------------------
 ##@ Release
 
+USER_FORK ?= $(shell git config --get remote.origin.url | cut -d/ -f4)
+IMAGE_REVIEWERS ?= $(shell ./hack/get-project-maintainers.sh)
+
 .PHONY: release-staging
-release-staging: ## Builds and push container images to the staging bucket.
+release-staging: ## Build and push a container image to the staging registry.
 	TAG=$(IB_VERSION) REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build docker-push
+
+.PHONY: promote-images
+promote-image: deps-release ## Create a pull request to promote a staging image to production.
+	kpromo pr --project scl-image-builder --tag $(IB_VERSION) --reviewers "$(IMAGE_REVIEWERS)" --fork $(USER_FORK)
 
 ## --------------------------------------
 ## Sort JSON

--- a/images/capi/hack/ensure-kpromo.sh
+++ b/images/capi/hack/ensure-kpromo.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+MINIMUM_KPROMO_VERSION="v3.6.0"
+
+# Ensure the kpromo tool exists and is a viable version.
+verify_kpromo_version() {
+  if [[ -z "$(command -v kpromo)" ]]; then
+    if [[ "${INSTALL_KPROMO:-"true"}" == "true" ]]; then
+      go install sigs.k8s.io/promo-tools/v3/cmd/kpromo@${MINIMUM_KPROMO_VERSION}
+      export PATH=$(go env GOPATH)/bin:$PATH
+    else
+      cat <<EOF
+Can't find 'kpromo' in PATH, please fix and retry.
+See https://github.com/kubernetes-sigs/promo-tools#installation for installation instructions.
+EOF
+      return 2
+    fi
+  fi
+
+  local kpromo_version
+  kpromo_version=$(kpromo version --json 2>&1 | jq -r .gitVersion)
+  if [[ "${MINIMUM_KPROMO_VERSION}" != $(echo -e "${MINIMUM_KPROMO_VERSION}\n${kpromo_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${kpromo_version}" != "devel" ]]; then
+    cat <<EOF
+Detected kpromo version: ${kpromo_version[*]}.
+Image builder releases require ${MINIMUM_KPROMO_VERSION} or greater.
+Please install kpromo ${MINIMUM_KPROMO_VERSION} or later.
+See https://github.com/kubernetes-sigs/promo-tools#installation for
+instructions, or remove the kpromo binary and re-run this script.
+EOF
+    return 2
+  fi
+}
+
+echo "Checking if kpromo is available"
+verify_kpromo_version
+
+kpromo version

--- a/images/capi/hack/ensure-yq.sh
+++ b/images/capi/hack/ensure-yq.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+_version="v4.33.3"
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+source hack/utils.sh
+
+if command -v yq >/dev/null 2>&1; then exit 0; fi
+
+mkdir -p .local/bin && cd .local/bin
+
+ARCH=${ARCH:-$(uname -m)}
+if [[ ${HOSTOS} == "linux" ]]; then
+  _binfile="yq_linux_${ARCH}"
+elif [[ ${HOSTOS} == "darwin" ]]; then
+  _binfile="yq_darwin_${ARCH}"
+fi
+_bin_url="https://github.com/mikefarah/yq/releases/download/${_version}/${_binfile}"
+curl -SsL "${_bin_url}" -o yq
+chmod 0755 yq
+echo "'yq' has been installed to $(pwd), make sure this directory is in your \$PATH"

--- a/images/capi/hack/get-project-maintainers.sh
+++ b/images/capi/hack/get-project-maintainers.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../../..
+
+KEYS=()
+while IFS='' read -r line; do KEYS+=("$line"); done < <(yq e '.aliases["image-builder-maintainers"][]' ${REPO_ROOT}/OWNERS_ALIASES)
+echo "${KEYS[@]/#/@}"


### PR DESCRIPTION
/kind documentation

What this PR does / why we need it:

Adds docs, a script, and a `make` target to help with future releases of image-builder.

Which issue(s) this PR fixes: 

**Additional context**
