### PR TITLE
Add AverageMarcus to project maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,13 @@
 
 aliases:
   image-builder-maintainers:
+    - AverageMarcus
     - jsturtevant
     - kkeshavamurthy
     - mboersma
   image-builder-reviewers:
     - EleanorRigby
     - randomvariable
-    - AverageMarcus
   image-builder-azure-reviewers:
     - jsturtevant
     - mboersma


### PR DESCRIPTION
What this PR does / why we need it:

Moves @AverageMarcus from image-builder reviewer to maintainer.

Which issue(s) this PR fixes:

N/A

**Additional context**:

As discussed at image-builder office hours today, we would like to nominate @AverageMarcus as a project maintainer.

@AverageMarcus has been active in image-builder for a long time, contributing significant pull requests and curating issues. He has provided excellent feedback on numerous PRs, showing that the maintainer hat already fits. And last but not least, Marcus provided the energy and initiative to restart image-builder office hours, which has already brightened the future of this crucial infrastructure project. Thanks @AverageMarcus!

(Let's leave this issue open for lazy consensus until Friday, May 26.)