### PR TITLE
Skip Ubuntu 18.04 in ova CI tests

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -22,7 +22,7 @@ CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
 export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
-TARGETS=("ubuntu-1804" "ubuntu-2004" "ubuntu-2204" "photon-3" "photon-4" "centos-7" "rockylinux-8" "flatcar")
+TARGETS=("ubuntu-2004" "ubuntu-2204" "photon-3" "photon-4" "centos-7" "rockylinux-8" "flatcar")
 
 on_exit() {
   # kill the VPN


### PR DESCRIPTION
What this PR does / why we need it:

Removes `ubuntu-18.04` from the script that is run as part of the default `pull-ova-all` CI job. Ubuntu 18.04 is no longer supported, and this builder has been flaky with unhelpful errors such as:

```
[1;31m==> vsphere-iso.vsphere: error typing a boot command (code, down) `23, false`: ServerFaultCode: A general system error occurred: Invalid fault[0m
```

Which issue(s) this PR fixes:

**Additional context**

See also #989