### PR TITLE
update CAPG owners alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,13 +45,8 @@ aliases:
     - mboersma
   cluster-api-gcp-maintainers:
     - cpanato
-    - detiber
     - dims
-    - gab-satchi
-    - justinsb
-    - krousey
-    - rsmitty
-    - vincepri
+    - richardcase
   cluster-api-digitalocean-maintainers:
     - cpanato
     - MorrisLaw


### PR DESCRIPTION
What this PR does / why we need it:

- update CAPG owners alias
to match what we have in CAPG repo

/assign @fabriziopandini @richardcase @dims 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers