### PR TITLE
update CAPDO owners alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -54,7 +54,7 @@ aliases:
     - vincepri
   cluster-api-digitalocean-maintainers:
     - cpanato
-    - MorrisLaw
+    - gottwald
     - prksu
     - timoreimann
   cluster-api-openstack-maintainers:


### PR DESCRIPTION
What this PR does / why we need it:

- update CAPDO owners alias
to match what we have in CAPDO repo

/assign @fabriziopandini @timoreimann  @gottwald  

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers