### PR TITLE
use an env for qemu flatcar pypy http origin

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -89,6 +89,9 @@
       "type": "shell"
     },
     {
+      "environment_vars": [
+        "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
+      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",
       "type": "shell"

--- a/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
+++ b/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
@@ -21,15 +21,16 @@ if [[ -e ${BINDIR}/.bootstrapped ]]; then
   exit 0
 fi
 
+PYPY_HTTP_SOURCE=${PYPY_HTTP_SOURCE:="https://github.com/squeaky-pl/portable-pypy"}
 PYPY_VERSION=7.2.0
 PYTHON3_VERSION=3.6
 
-curl -sfL https://github.com/squeaky-pl/portable-pypy/releases/download/pypy-${PYPY_VERSION}/pypy-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
+curl -sfL ${PYPY_HTTP_SOURCE}/releases/download/pypy-${PYPY_VERSION}/pypy-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
 mv -n pypy-${PYPY_VERSION}-linux_x86_64-portable pypy2
 ln -s ./pypy2/bin/pypy python2
 ln -s ./pypy2/bin/pypy python
 
-curl -sfL  https://github.com/squeaky-pl/portable-pypy/releases/download/pypy${PYTHON3_VERSION}-${PYPY_VERSION}/pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
+curl -sfL  ${PYPY_HTTP_SOURCE}/releases/download/pypy${PYTHON3_VERSION}-${PYPY_VERSION}/pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
 mv -n pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable pypy3
 ln -s ./pypy3/bin/pypy3 python3
 

--- a/images/capi/packer/nutanix/packer.json
+++ b/images/capi/packer/nutanix/packer.json
@@ -49,7 +49,8 @@
   "provisioners": [
     {
       "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
+        "BUILD_NAME={{user `build_name`}}",
+        "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
       ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",

--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -38,6 +38,9 @@
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
+      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",
       "type": "shell"

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -334,7 +334,8 @@
   "provisioners": [
     {
       "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
+        "BUILD_NAME={{user `build_name`}}",
+        "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
       ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -62,6 +62,9 @@
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
+      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",
       "type": "shell"

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -50,6 +50,9 @@
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
+      ],
       "execute_command": "BUILD_NAME={{user `build_name`}}; if [[ \"${BUILD_NAME}\" == *\"flatcar\"* ]]; then sudo {{.Vars}} -S -E bash '{{.Path}}'; fi",
       "script": "./packer/files/flatcar/scripts/bootstrap-flatcar.sh",
       "type": "shell"


### PR DESCRIPTION
What this PR does / why we need it:
* we need to rebuild capi flatcar images in an air-gapped environment
* flatcar's pypy portable binaires http source are hardcoded in a shell wrapper ( https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh#L27-L34 )
* this wrapper bootstrap script is only used by flatcar

We need to expose these URLs suffixes in a simple `pypy_http_source` packer var to be able to tune pypy tgz http origin if needed.