### PR TITLE
Refactor Ignition config files

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -968,6 +968,6 @@ json-sort: ## Sort all JSON files alphabetically
 ## --------------------------------------
 ##@ Ignition
 .PHONY: gen-ignition
-ignition_files = bootstrap
+ignition_files = bootstrap bootstrap-pass-auth bootstrap-cloud
 gen-ignition: deps-ignition ## Generates Ignition files from CLC
 	for f in $(ignition_files); do (ct < packer/files/flatcar/clc/$$f.yaml | jq '.' > packer/files/flatcar/ignition/$$f.json) || exit 1; done

--- a/images/capi/packer/files/flatcar/clc/bootstrap-cloud.yaml
+++ b/images/capi/packer/files/flatcar/clc/bootstrap-cloud.yaml
@@ -1,0 +1,13 @@
+# This file is used for initial provisioning of a Flatcar machine on platforms which automatically
+# authorize SSH keys (typically cloud providers such as AWS or Azure). On such platforms, no SSH
+# configuration needs to be done via Ignition. The actions in this file are performed before Packer
+# provisioners (e.g. Ansible) are executed.
+systemd:
+  units:
+  - name: docker.service
+    enable: true
+  # Mask update-engine and locksmithd to disable automatic updates during image creation.
+  - name: update-engine.service
+    mask: true
+  - name: locksmithd.service
+    mask: true

--- a/images/capi/packer/files/flatcar/clc/bootstrap-pass-auth.yaml
+++ b/images/capi/packer/files/flatcar/clc/bootstrap-pass-auth.yaml
@@ -1,0 +1,21 @@
+# This file is used for initial provisioning of a Flatcar machine on platforms which use SSH
+# password authentication during the build process. The actions in this file are performed before
+# Packer provisioners (e.g. Ansible) are executed.
+passwd:
+  users:
+  - name: builder
+    # "BUILDERPASSWORDHASH" gets overwritten by Packer on platforms where SSH password auth is used.
+    password_hash: BUILDERPASSWORDHASH
+    groups:
+    - wheel
+    - sudo
+    - docker
+systemd:
+  units:
+  - name: docker.service
+    enable: true
+  # Mask update-engine and locksmithd to disable automatic updates during image creation.
+  - name: update-engine.service
+    mask: true
+  - name: locksmithd.service
+    mask: true

--- a/images/capi/packer/files/flatcar/ignition/bootstrap-cloud.json
+++ b/images/capi/packer/files/flatcar/ignition/bootstrap-cloud.json
@@ -1,0 +1,29 @@
+{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.3.0"
+  },
+  "networkd": {},
+  "passwd": {},
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "enable": true,
+        "name": "docker.service"
+      },
+      {
+        "mask": true,
+        "name": "update-engine.service"
+      },
+      {
+        "mask": true,
+        "name": "locksmithd.service"
+      }
+    ]
+  }
+}

--- a/images/capi/packer/files/flatcar/ignition/bootstrap-pass-auth.json
+++ b/images/capi/packer/files/flatcar/ignition/bootstrap-pass-auth.json
@@ -1,0 +1,41 @@
+{
+  "ignition": {
+    "config": {},
+    "security": {
+      "tls": {}
+    },
+    "timeouts": {},
+    "version": "2.3.0"
+  },
+  "networkd": {},
+  "passwd": {
+    "users": [
+      {
+        "groups": [
+          "wheel",
+          "sudo",
+          "docker"
+        ],
+        "name": "builder",
+        "passwordHash": "BUILDERPASSWORDHASH"
+      }
+    ]
+  },
+  "storage": {},
+  "systemd": {
+    "units": [
+      {
+        "enable": true,
+        "name": "docker.service"
+      },
+      {
+        "mask": true,
+        "name": "update-engine.service"
+      },
+      {
+        "mask": true,
+        "name": "locksmithd.service"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
What this PR does / why we need it:

Following https://github.com/kubernetes-sigs/image-builder/pull/1150#issuecomment-1571721560, we're replacing the generic bootstrap Ignition config with two separate configs - one for cloud platforms which have their own mechanism for authorizing SSH keys during machine bootstrap and another for platforms on which we have to rely on SSH password auth.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): None

**Additional context**
We need to add this change set separately from modifying consumer code because we need fully-qualified and merged GitHub blobs to exist before we can modify Packer builders to use the new files.