### PR TITLE
Remove inactive reviewer from project owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,6 @@ aliases:
     - kkeshavamurthy
     - mboersma
   image-builder-reviewers:
-    - EleanorRigby
     - randomvariable
   image-builder-azure-reviewers:
     - jsturtevant


### PR DESCRIPTION
What this PR does / why we need it:

Removes @EleanorRigby from the image-builder-reviewers list, as they have not been active in this project or on GitHub since [February 2021](https://github.com/EleanorRigby?tab=overview&from=2021-02-01&to=2021-02-28). I also reached out to them on the Kubernetes Slack a week ago, but have not received a reply.

I'm a relatively new maintainer of image-builder, but I can see this user had a huge role in the initial creation and upkeep of this project. Thanks @EleanorRigby!

Which issue(s) this PR fixes:

N/A

**Additional context**
