### PR TITLE
Authenticate pip with Azure internal feed

### DIFF
--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -90,6 +90,10 @@ jobs:
     workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
     env:
       AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
+  - task: PipAuthenticate@1
+    inputs:
+      artifactFeeds: 'AzureContainerUpstream'
+      onlyAddExtraIndex: true
   - script: |
       set -x
       set -e -o pipefail


### PR DESCRIPTION
What this PR does / why we need it:

Azure pipelines recently began enforcing "Central Feed Services," essentially requiring that package managers such as `pip` register with secure internal sources. 

Without using the [`PipAuthenticate@1`](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/pip-authenticate-v1?view=azure-pipelines) task, an invalid `PIP_INDEX_URL` is now injected into the pipeline, in order to fail the build and direct attention to a security announcement and mitigation document. Inserting this additional task in the script before `pip install` is invoked follows Azure's recommendations and seems to work in the real world.

Which issue(s) this PR fixes:

N/A

**Additional context**
