### PR TITLE
Include main in branches for Azure nightly job

### DIFF
--- a/images/capi/packer/azure/.pipelines/smoke-test.yaml
+++ b/images/capi/packer/azure/.pipelines/smoke-test.yaml
@@ -19,6 +19,7 @@ schedules:
     branches:
       include:
         - master
+        - main
 
 stages:
   - stage: vhd


### PR DESCRIPTION
What this PR does / why we need it:

Includes the `main` branch in the triggers for the Azure nightly build job in preparation of renaming the master branch.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Towards: https://github.com/kubernetes-sigs/image-builder/issues/1161

**Additional context**
Add any other context for the reviewers