### PR TITLE
Bump packer to 1.8.7

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.8.6"
+_version="1.8.7"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

See https://github.com/hashicorp/packer/releases/tag/v1.8.7

Which issue(s) this PR fixes: 

N/A

**Additional context**

Packer's latest release is actually v1.9.1, but it seems safer to update to the latest patch in this series before changing the minor version.