### PR TITLE
Use required_plugin with DigitalOcean provider

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -486,10 +486,12 @@ $(AZURE_VALIDATE_SIG_CVM_TARGETS): deps-azure
 
 .PHONY: $(DO_BUILD_TARGETS)
 $(DO_BUILD_TARGETS): deps-do
+	$(PACKER) init packer/digitalocean/config.pkr.hcl
 	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst build-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
 
 .PHONY: $(DO_VALIDATE_TARGETS)
 $(DO_VALIDATE_TARGETS): deps-do
+	$(PACKER) init packer/digitalocean/config.pkr.hcl
 	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst validate-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
 
 .PHONY: $(OPENSTACK_BUILD_TARGETS)

--- a/images/capi/packer/digitalocean/config.pkr.hcl
+++ b/images/capi/packer/digitalocean/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    digitalocean = {
+      source =  "github.com/digitalocean/digitalocean"
+      version = ">=1.1.1"
+    }
+  }
+}


### PR DESCRIPTION
What this PR does / why we need it:

The DigitalOcean plugin has been removed as a vendor plugin from the latest Packer version and now needs to be referenced as an external plugin.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1180

**Additional context**
Add any other context for the reviewers

See: https://github.com/kubernetes-sigs/image-builder/pull/1147#issuecomment-1576144878