### PR TITLE
Shrink qemu ubuntu image size

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -190,6 +190,7 @@
     state: "{{ item.state }}"
     path: "{{ item.path }}"
   loop:
+  - { path: /swap.img, state: absent }
   - { path: /swapfile, state: absent }
   - { path: /mnt/resource/swapfile, state: absent }
   when: ansible_memory_mb.swap.total != 0
@@ -226,6 +227,12 @@
     state: absent
     path: /usr/share/oem/config.ign
   when: ansible_os_family == "Flatcar"
+
+- name: fstrim
+  systemd:
+    name: fstrim.service
+    state: started
+  when: ansible_os_family == "Debian"
 
 - name: start ssh
   systemd:

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04.efi/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04.efi/user-data
@@ -27,6 +27,8 @@ autoinstall:
   # For more information on how partitioning is configured,
   # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
   storage:
+    swap:
+      size: 0
     grub:
       reorder_uefi: false
       replace_linux_default: false
@@ -99,11 +101,14 @@ autoinstall:
   # 1. Disables swapfiles
   # 2. Removes the existing swapfile
   # 3. Removes the swapfile entry from /etc/fstab
-  # 4. Cleans up any packages that are no longer required
-  # 5. Removes the cached list of packages
+  # 4. Removes snapd, https://bugs.launchpad.net/subiquity/+bug/1946609
+  # 5. Cleans up any packages that are no longer required
+  # 6. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - chroot /target apt-get purge -y snapd
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean
+    - curtin in-target --target=/target -- rm -rf /var/lib/apt/lists/*

--- a/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
+++ b/images/capi/packer/ova/linux/ubuntu/http/22.04/user-data
@@ -30,6 +30,8 @@ autoinstall:
   # For more information on how partitioning is configured,
   # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
   storage:
+    swap:
+      size: 0
     grub:
       replace_linux_default: false
     config:
@@ -79,11 +81,14 @@ autoinstall:
   # 1. Disables swapfiles
   # 2. Removes the existing swapfile
   # 3. Removes the swapfile entry from /etc/fstab
-  # 4. Cleans up any packages that are no longer required
-  # 5. Removes the cached list of packages
+  # 4. Removes snapd, https://bugs.launchpad.net/subiquity/+bug/1946609
+  # 5. Cleans up any packages that are no longer required
+  # 6. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - chroot /target apt-get purge -y snapd
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean
+    - curtin in-target --target=/target -- rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Use fstrim command at the end of sysprep role

It frees all unused storage, so `qemu-img convert` command at the end of packer execution can shrink the image size.
I was inspired by commit messages in the packer-plugin-qemu repository:
- https://github.com/hashicorp/packer-plugin-qemu/commit/4dabb9ae94b6653562dd391bef4836d7a7ae791c
- https://github.com/hashicorp/packer-plugin-qemu/commit/7d78e9f6a0a552150a0b4413ee1d4c86c43654cb

Also, remove snapd(we do not need that) and repair autoinstall late-commands(see https://ubuntu.com/server/docs/install/autoinstall-reference#late-commands)

What this PR does / why we need it:
Image size before(**12G**):
```
$ qemu-img info output/ubuntu-2204-kube-v1.26.3/ubuntu-2204-kube-v1.26.3
image: output/ubuntu-2204-kube-v1.26.3/ubuntu-2204-kube-v1.26.3
file format: qcow2
virtual size: 20G (21474836480 bytes)
disk size: 12G
cluster_size: 65536
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
```
Image size after (**4.4G**):
```bash
$ qemu-img info output/ubuntu-2204-kube-v1.26.3/ubuntu-2204-kube-v1.26.3
image: output/ubuntu-2204-kube-v1.26.3/ubuntu-2204-kube-v1.26.3
file format: qcow2
virtual size: 20G (21474836480 bytes)
disk size: 4.4G
cluster_size: 65536
Format specific information:
    compat: 1.1
    lazy refcounts: false
    refcount bits: 16
    corrupt: false
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1155, fixes #1169

**Additional context**
- https://stackoverflow.com/a/48232259
- https://serverfault.com/a/1003726