### PR TITLE
Update Rocky Linux from 8.7 to 8.8

### DIFF
--- a/images/capi/packer/qemu/qemu-rockylinux-8.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-8.json
@@ -8,7 +8,7 @@
   "distro_version": "8",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
   "guest_os_type": "centos8-64",
-  "iso_checksum": "13c3e7fca1fd32df61695584baafc14fa28d62816d0813116d23744f5394624b",
+  "iso_checksum": "4ce0948699a26f66dffd705c0459d428439cef02d5db43d36a6ae62ba494fe9e",
   "iso_checksum_type": "sha256",
   "iso_url": "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.8-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 8",

--- a/images/capi/packer/qemu/qemu-rockylinux-8.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-8.json
@@ -10,7 +10,7 @@
   "guest_os_type": "centos8-64",
   "iso_checksum": "13c3e7fca1fd32df61695584baafc14fa28d62816d0813116d23744f5394624b",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.7-x86_64-minimal.iso",
+  "iso_url": "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.8-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 8",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"


### PR DESCRIPTION
What this PR does / why we need it: Image builder is getting HTTP 404 when building Rocky Linux 8, as minimal iso 8.7 isn't available anymore. This PR changes Rocky Linux to 8.8.
