### PR TITLE
Remove leftover CAPI OWNERS file

### DIFF
--- a/images/capi/OWNERS
+++ b/images/capi/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - cluster-api-maintainers


### PR DESCRIPTION
What this PR does / why we need it: Removed leftover OWNERS file that no longer makes sense.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Previously discussed on Slack - https://kubernetes.slack.com/archives/C01E0Q35A8J/p1686300676548029