### PR TITLE
Bump containerd-wasm-shims to v0.6.0

### DIFF
--- a/images/capi/packer/config/wasm-shims.json
+++ b/images/capi/packer/config/wasm-shims.json
@@ -1,6 +1,6 @@
 {
   "containerd_wasm_shims_runtimes": "",
-  "containerd_wasm_shims_sha256": "52e6289f7272aa9e7ff3a13aab85bdf889e1f3b29aada40df53e7b519b42e6c0",
+  "containerd_wasm_shims_sha256": "7eb0838e61c103ccb71aa7a614f458cd9597f086df45460fe94c42090b1600f0",
   "containerd_wasm_shims_url": "https://github.com/deislabs/containerd-wasm-shims/releases/download/{{user `containerd_wasm_shims_version`}}/containerd-wasm-shims-v1-linux-x86_64.tar.gz",
-  "containerd_wasm_shims_version": "v0.4.0"
+  "containerd_wasm_shims_version": "v0.6.0"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Updates the default release of containerd WASM shims to [v0.6.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.6.0).

Which issue(s) this PR fixes: 

N/A

**Additional context**
