### PR TITLE
Arm64: flatcar: fix portable python3/python2 download

### DIFF
--- a/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
+++ b/images/capi/packer/files/flatcar/scripts/bootstrap-flatcar.sh
@@ -21,22 +21,32 @@ if [[ -e ${BINDIR}/.bootstrapped ]]; then
   exit 0
 fi
 
-PYPY_HTTP_SOURCE=${PYPY_HTTP_SOURCE:="https://github.com/squeaky-pl/portable-pypy"}
-PYPY_VERSION=7.2.0
-PYTHON3_VERSION=3.6
+PYPY_HTTP_SOURCE=${PYPY_HTTP_SOURCE:="https://downloads.python.org/pypy"}
+PYPY_VERSION=v7.3.11
+PYTHON3_VERSION=3.9
+PYTHON2_VERSION=2.7
 
-curl -sfL ${PYPY_HTTP_SOURCE}/releases/download/pypy-${PYPY_VERSION}/pypy-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
-mv -n pypy-${PYPY_VERSION}-linux_x86_64-portable pypy2
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  PYPY_ARCH="aarch64"
+else
+  PYPY_ARCH="linux64"
+fi
+
+curl -sfL ${PYPY_HTTP_SOURCE}/pypy${PYTHON2_VERSION}-${PYPY_VERSION}-${PYPY_ARCH}.tar.bz2 | tar -xjf -
+mv -n pypy${PYTHON2_VERSION}-${PYPY_VERSION}-${PYPY_ARCH} pypy2
 ln -s ./pypy2/bin/pypy python2
-ln -s ./pypy2/bin/pypy python
+${BINDIR}/python2 -m ensurepip
 
-curl -sfL  ${PYPY_HTTP_SOURCE}/releases/download/pypy${PYTHON3_VERSION}-${PYPY_VERSION}/pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable.tar.bz2 | tar -xjf -
-mv -n pypy${PYTHON3_VERSION}-${PYPY_VERSION}-linux_x86_64-portable pypy3
+curl -sfL ${PYPY_HTTP_SOURCE}/pypy${PYTHON3_VERSION}-${PYPY_VERSION}-${PYPY_ARCH}.tar.bz2 | tar -xjf -
+mv -n pypy${PYTHON3_VERSION}-${PYPY_VERSION}-${PYPY_ARCH} pypy3
 ln -s ./pypy3/bin/pypy3 python3
+ln -s ./pypy3/bin/pypy3 python
 
 ${BINDIR}/python --version
+${BINDIR}/python3 -m ensurepip
+./pypy3/bin/pip3 install virtualenv
 
-${BINDIR}/pypy2/bin/virtualenv-pypy ${BUILDER_ENV}
+${BINDIR}/pypy3/bin/virtualenv ${BUILDER_ENV}
 chown -R core ${BUILDER_ENV}
 
 ln -s builder-env/bin/pip ${BINDIR}/pip


### PR DESCRIPTION
What this PR does / why we need it:

When creating a Flatcar ARM64 image, https://github.com/squeaky-pl/portable-pypy does not contain the required binaries for ARM64.  Switching https://downloads.python.org/pypy/pypy resolves the issue.