### PR TITLE
Update containerd to 1.6.21

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,7 +1,7 @@
 {
   "containerd_additional_settings": null,
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
-  "containerd_sha256": "1d86b534c7bba51b78a7eeb1b67dd2ac6c0edeb01c034cc5f590d5ccd824b416",
-  "containerd_sha256_windows": "7718a5f68a21106026ac16ce4bc7575d33db5a7d70f729545fb476160b215e10",
-  "containerd_version": "1.6.20"
+  "containerd_sha256": "57ea580e90e744cef5d79008661b69b35401b62da7cca1f908678a90d112ea88",
+  "containerd_sha256_windows": "cc212cddcbf971c5a48cd7e992318115ed6c34040ee9fa95c4353477b6ece19e",
+  "containerd_version": "1.6.21"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Update containerd to 1.6.21

Changes [can be found here](https://github.com/containerd/containerd/releases/tag/v1.6.21)


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers