### PR TITLE
Add fallback for gcloud command

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -170,7 +170,7 @@ deps-release: ## Installs/checks dependencies for project releases
 ## --------------------------------------
 ## Container variables
 ## --------------------------------------
-REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
+REGISTRY ?= gcr.io/$(or $(shell gcloud config get-value project),scl-image-builder)
 STAGING_REGISTRY := gcr.io/k8s-staging-scl-image-builder
 IMAGE_NAME ?= cluster-node-image-builder
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)


### PR DESCRIPTION
What this PR does / why we need it:

* Adds fallback value if `gcloud` command fails

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1047

**Additional context**
N/A