### PR TITLE
CAPC: add ConfigDrive to cloud-init datasource_list in cloudstack images

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/cloudstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/cloudstack.yml
@@ -16,7 +16,7 @@
   copy:
     dest: /etc/cloud/cloud.cfg.d/cloudstack.cfg
     content: |-
-      datasource_list: ['CloudStack']
+      datasource_list: ['CloudStack', 'ConfigDrive']
       datasource:
         CloudStack:
           max_wait: 120


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds ConfigDrive to database_list of cloudstack images so control plane nodes and worker nodes can get userdata from ConfigDrive ISO on CloudStack platforms

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes https://github.com/apache/cloudstack/issues/7648

**Additional context**
Add any other context for the reviewers