### PR TITLE
Update main branch referenced in docs

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -57,7 +57,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     ```
 
 - vSphere OVA
-    - `vsphere.json` configuration file with user and hypervisor credentials. A template of this file can be found [here](https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/packer/ova/vsphere.json)
+    - `vsphere.json` configuration file with user and hypervisor credentials. A template of this file can be found [here](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/ova/vsphere.json)
 
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the Docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
 

--- a/docs/book/src/capi/quickstart.md
+++ b/docs/book/src/capi/quickstart.md
@@ -11,7 +11,7 @@ To get the latest image-builder source on your machine, choose one of the follow
 Tarball download:
 
 ```sh
-curl -L https://github.com/kubernetes-sigs/image-builder/tarball/master -o image-builder.tgz
+curl -L https://github.com/kubernetes-sigs/image-builder/tarball/main -o image-builder.tgz
 mkdir image-builder
 tar xzf image-builder.tgz --strip-components 1 -C image-builder
 rm image-builder.tgz

--- a/docs/book/src/capi/releasing.md
+++ b/docs/book/src/capi/releasing.md
@@ -8,13 +8,13 @@ Releasing image-builder is a simple process: project maintainers should be able 
 
 ### Create a tag
 
-Releases in image-builder follow [semantic versioning][semver] conventions. Currently the project tags only patch releases on the master branch.
+Releases in image-builder follow [semantic versioning][semver] conventions. Currently the project tags only patch releases on the main branch.
 
 - Check out the existing branch and make sure you have the latest changes:
-  - `git checkout master`
+  - `git checkout main`
   - `git fetch upstream`
     - *This assumes you have an "upstream" git remote pointing at github.com/kubernetes-sigs/image-builder*
-  - `git rebase upstream/master`
+  - `git rebase upstream/main`
     - *If the HEAD commit isn't meant for release, reset to the intended commit before proceeding.*
 - Ensure you can sign tags:
   - Set up GPG, SSH, or S/MIME [at GitHub](https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification) if you haven't already.


### PR DESCRIPTION
What this PR does / why we need it:

Updates any references to the `master` branch in the documentation to now point to `main`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Towards #1161

**Additional context**
Not to be merged until _after_ the branch rename.

/hold for branch rename