### PR TITLE
Fix host arch detection for arm64

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -32,6 +32,9 @@ case "${_hostarch}" in
 *aarch64*)
   HOSTARCH=arm64
   ;;
+*arm64*)
+  HOSTARCH=arm64
+  ;;
 *x86_64*)
   HOSTARCH=amd64
   ;;


### PR DESCRIPTION
What this PR does / why we need it:

#1204 didn't take into account that `uname -m` returns `arm64` on Apple Silicon. So after that change, I was unable to run image-builder targets locally:

```shell
% noproxy=* make -C images/capi build-azure-sig-flatcar-gen2
hack/ensure-ansible.sh
unsupported HOSTARCH=arm64
make: *** [deps-azure] Error 1
```

Which issue(s) this PR fixes:

N/A

**Additional context**
