### PR TITLE
Bump nightly CI to use latest Kubernetes patch versions

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.24.14-00",
-  "kubernetes_rpm_version": "1.24.14-0",
-  "kubernetes_semver": "v1.24.14",
+  "kubernetes_deb_version": "1.24.15-00",
+  "kubernetes_rpm_version": "1.24.15-0",
+  "kubernetes_semver": "v1.24.15",
   "kubernetes_series": "v1.24",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.25.10-00",
-  "kubernetes_rpm_version": "1.25.10-0",
-  "kubernetes_semver": "v1.25.10",
+  "kubernetes_deb_version": "1.25.11-00",
+  "kubernetes_rpm_version": "1.25.11-0",
+  "kubernetes_semver": "v1.25.11",
   "kubernetes_series": "v1.25",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-26.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-26.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.26.5-00",
-  "kubernetes_rpm_version": "1.26.5-0",
-  "kubernetes_semver": "v1.26.5",
+  "kubernetes_deb_version": "1.26.6-00",
+  "kubernetes_rpm_version": "1.26.6-0",
+  "kubernetes_semver": "v1.26.6",
   "kubernetes_series": "v1.26",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.27.2-00",
-  "kubernetes_rpm_version": "1.27.2-0",
-  "kubernetes_semver": "v1.27.2",
+  "kubernetes_deb_version": "1.27.3-00",
+  "kubernetes_rpm_version": "1.27.3-0",
+  "kubernetes_semver": "v1.27.3",
   "kubernetes_series": "v1.27",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/scripts/ci-gce-nightly.sh
+++ b/images/capi/scripts/ci-gce-nightly.sh
@@ -40,21 +40,12 @@ groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
 chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
 # use the packer user to run the build
 
-# build image for 1.24
-# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-24.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
-
-# build image for 1.25
-# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-25.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
-
-# build image for 1.26
-# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-26.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
-
-# build image for 1.27
-# using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=packer/gce/ci/nightly/overwrite-1-27.json PACKER_FLAGS=-force make deps-gce build-gce-all'"
+# Build image for each available config
+for f in packer/gce/ci/nightly/*.json
+do
+  # using PACKER_FLAGS=-force to overwrite the previous image and keep the same name
+  su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT PACKER_VAR_FILES=${f} PACKER_FLAGS=-force make deps-gce build-gce-all'"
+done
 
 echo "Displaying the generated image information"
 filter="name~cluster-api-ubuntu-*"


### PR DESCRIPTION
What this PR does / why we need it:

Updated the nightly CI to use the latest patch versions.
Refactored the ci-gce-nightly.sh to dynamically look up the test configs in `packer/gce/ci`

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers