### PR TITLE
Add fallback for tools that don't have darwin/arm64 binaries

### DIFF
--- a/images/capi/hack/ensure-goss.sh
+++ b/images/capi/hack/ensure-goss.sh
@@ -22,6 +22,9 @@ set -o pipefail
 
 source hack/utils.sh
 
+# There is no darwin/arm64 version so we need to default HOSTARCH to amd64 if on an M1/M2 Mac
+HOSTARCH=$(hostarch_without_darwin_arm64)
+
 # SHA are for amd64 arch.
 _version="3.1.4"
 darwin_sha256="ddb663a3e4208639d90b89ebdb69dc240ec16d6b01877ccbf968f76a58a89f99"

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -99,3 +99,11 @@ ensure_py3() {
     ensure_py3_bin pip3
   fi
 }
+
+hostarch_without_darwin_arm64() {
+  if [ "${HOSTOS}" == "darwin" ] && [ "${HOSTARCH}" == "arm64" ]; then
+    echo "amd64"
+  else
+    echo ${HOSTARCH}
+  fi
+}

--- a/images/capi/packer/azure/scripts/ensure-kustomize.sh
+++ b/images/capi/packer/azure/scripts/ensure-kustomize.sh
@@ -31,6 +31,9 @@ if command -v kustomize >/dev/null 2>&1; then exit 0; fi
 
 mkdir -p .local/bin && cd .local/bin
 
+# There is no darwin/arm64 version so we need to default HOSTARCH to amd64 if on an M1/M2 Mac
+HOSTARCH=$(hostarch_without_darwin_arm64)
+
 KUSTOMIZE_VERSION=4.5.2
 _binfile="kustomize-v${KUSTOMIZE_VERSION}.tar.gz"
 


### PR DESCRIPTION
What this PR does / why we need it:

Adds a helper function to fallback to `amd64` on an M1/M2 Mac when a tool doesn't provide an arm64 binary.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers