### PR TITLE
Make containerd unpack location configurable

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -50,7 +50,7 @@
   unarchive:
     remote_src: True
     src: /tmp/containerd.tar.gz
-    dest: /
+    dest: "{{ containerd_prefix | default('/') }}"
     extra_opts:
       - --no-overwrite-dir
   when: ansible_os_family != "Flatcar"
@@ -70,7 +70,7 @@
   unarchive:
     remote_src: True
     src: /tmp/containerd.tar.gz
-    dest: /
+    dest: "{{ containerd_prefix | default('/') }}"
     extra_opts:
       - --absolute-names
       - --transform


### PR DESCRIPTION
What this PR does / why we need it:

Specify the directory where containerd is copied to while being unarchived. 

I've observed while building CAPI images for Ubuntu and Flatcar that the tasks immediatly following the unarchive of containerd fail because the `bash` command can no longer be found. 

Example for flatcar:
```
    openstack.flatcar:                                                                                                                                            
    openstack.flatcar: TASK [containerd : unpack containerd for Flatcar to /opt/bin] ******************                                                           
    openstack.flatcar: Saturday 01 July 2023  12:41:14 +1200 (0:00:00.026)       0:01:00.272 *********                                                            
    openstack.flatcar: [WARNING]: Error deleting remote temporary files (rc: 1, stderr: /bin/bash: No                                                             
    openstack.flatcar: such file or directory })                                                                                                                  
    openstack.flatcar: changed: [default] => {"changed": true, "dest": "/", "extract_results": {"cmd": ["/usr/bin/gtar", "--extract", "-C", "/", "-z", "--show-tra
nsformed-names", "--absolute-names", "--transform", "s@usr@opt@", "--transform", "s@sbin@bin@", "--transform", "s@opt/local@opt@", "-f", "/tmp/containerd.tar.gz"]
, "err": "", "out": "", "rc": 0}, "gid": 0, "group": "root", "handler": "TgzArchive", "mode": "0755", "owner": "root", "secontext": "system_u:object_r:unlabeled_t
:s0", "size": 4096, "src": "/tmp/containerd.tar.gz", "state": "directory", "uid": 0}                                                                              
    openstack.flatcar:                                                                                                                                            
    openstack.flatcar: TASK [containerd : unpack containerd-wasm-shims for Flatcar to /opt/bin] *******                                                           
    openstack.flatcar: Saturday 01 July 2023  12:41:21 +1200 (0:00:06.194)       0:01:06.466 *********                                                            
    openstack.flatcar: skipping: [default] => {"changed": false, "skip_reason": "Conditional result was False"}                                                   
    openstack.flatcar:                                                                                                                                            
    openstack.flatcar: TASK [containerd : delete /opt/cni directory] **********************************                                                           
    openstack.flatcar: Saturday 01 July 2023  12:41:21 +1200 (0:00:00.030)       0:01:06.497 *********                                                            
    openstack.flatcar: fatal: [default]: FAILED! => {"changed": false, "module_stderr": "/bin/bash: No such file or directory\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
    openstack.flatcar:
    openstack.flatcar: PLAY RECAP *********************************************************************
    openstack.flatcar: default                    : ok=23   changed

```

Changing the `dest` where the containerd archive is unpacked to `"{{ sysuser_prefix }}"` fixes this for both Ubuntu and Flatcar.


```
    openstack.flatcar: TASK [containerd : unpack containerd for Flatcar to /opt/bin] ******************                                                           
    openstack.flatcar: Saturday 01 July 2023  12:27:29 +1200 (0:00:00.025)       0:01:03.044 *********                                                            
    openstack.flatcar: changed: [default] => {"changed": true, "dest": "/opt", "extract_results": {"cmd": ["/usr/bin/gtar", "--extract", "-C", "/opt", "-z", "--sh
ow-transformed-names", "--absolute-names", "--transform", "s@usr@opt@", "--transform", "s@sbin@bin@", "--transform", "s@opt/local@opt@", "-f", "/tmp/containerd.ta
r.gz"], "err": "", "out": "", "rc": 0}, "gid": 0, "group": "root", "handler": "TgzArchive", "mode": "0755", "owner": "root", "secontext": "system_u:object_r:usr_t
:s0", "size": 4096, "src": "/tmp/containerd.tar.gz", "state": "directory", "uid": 0}                                                                              
    openstack.flatcar:                                                                                                                                            
    openstack.flatcar: TASK [containerd : unpack containerd-wasm-shims for Flatcar to /opt/bin] *******                                                           
    openstack.flatcar: Saturday 01 July 2023  12:27:35 +1200 (0:00:06.332)       0:01:09.376 *********                                                            
    openstack.flatcar: skipping: [default] => {"changed": false, "skip_reason": "Conditional result was False"}                                                   
    openstack.flatcar:                                                                                                                                            
    openstack.flatcar: TASK [containerd : delete /opt/cni directory] **********************************                                                           
    openstack.flatcar: Saturday 01 July 2023  12:27:35 +1200 (0:00:00.025)       0:01:09.402 *********                                                            
    openstack.flatcar: ok: [default] => {"changed": false, "path": "/opt/cni", "state": "absent"}                                                                 
    openstack.flatcar:                                                           
```
Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

I haven't seen any issues that specifically reference this problem.

**Additional context**
Add any other context for the reviewers

Cloud Infrastructure: Openstack Glance qcow2 or raw

I'm running the image_builder using `packer+ansible` to create the images directly in OpenStack.

I'm using the following for `sysuser_prefix`:
Flatcar:
```json
 "sysuser_prefix": "/opt"
```

Ubuntu:
```json
 "sysuser_prefix": "/usr"
```