### PR TITLE
Updated wasm-shims to 0.7.0, added support for wws

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -55,7 +55,7 @@
       - --no-overwrite-dir
   when: ansible_os_family != "Flatcar"
 
-# install containerd Wasm shims when the runtimes are not empty -- current known runtimes are 'slight' and 'spin'
+# install containerd Wasm shims when the runtimes are not empty -- current known runtimes are 'slight', 'spin', and 'wws'
 # see: https://github.com/kubernetes-sigs/image-builder/pull/1037
 - name: unpack containerd-wasm-shims
   unarchive:
@@ -81,7 +81,7 @@
       - 's@opt/local@opt@'
   when: ansible_os_family == "Flatcar"
 
-# install containerd Wasm shims when the runtimes are not empty -- current known runtimes are 'slight' and 'spin'
+# install containerd Wasm shims when the runtimes are not empty -- current known runtimes are 'slight', 'spin', and 'wws'
 # see: https://github.com/kubernetes-sigs/image-builder/pull/1037
 - name: unpack containerd-wasm-shims for Flatcar to /opt/bin
   unarchive:

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -24,6 +24,10 @@ imports = ["/etc/containerd/conf.d/*.toml"]
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight]
     runtime_type = "io.containerd.slight.v1"
 {% endif %}
+{% if 'wws' in containerd_wasm_shims_runtimes %}
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wws]
+    runtime_type = "io.containerd.wws.v1"
+{% endif %}
 {% endif %}
 {% if packer_builder_type.startswith('azure') %}
   [plugins."io.containerd.grpc.v1.cri".registry.headers]

--- a/images/capi/packer/azure/azure-config.json
+++ b/images/capi/packer/azure/azure-config.json
@@ -2,7 +2,7 @@
   "azure_location": "{{env `AZURE_LOCATION`}}",
   "client_id": "{{env `AZURE_CLIENT_ID`}}",
   "client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-  "containerd_wasm_shims_runtimes": "spin,slight",
+  "containerd_wasm_shims_runtimes": "spin,slight,wws",
   "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
   "vm_size": "Standard_B2ms"
 }

--- a/images/capi/packer/config/wasm-shims.json
+++ b/images/capi/packer/config/wasm-shims.json
@@ -1,6 +1,6 @@
 {
   "containerd_wasm_shims_runtimes": "",
-  "containerd_wasm_shims_sha256": "7eb0838e61c103ccb71aa7a614f458cd9597f086df45460fe94c42090b1600f0",
+  "containerd_wasm_shims_sha256": "8BCDAAB42B033733881D9D6D124EE892D22A110E8338B03DA6E601D43BFB5BF1",
   "containerd_wasm_shims_url": "https://github.com/deislabs/containerd-wasm-shims/releases/download/{{user `containerd_wasm_shims_version`}}/containerd-wasm-shims-v1-linux-x86_64.tar.gz",
-  "containerd_wasm_shims_version": "v0.6.0"
+  "containerd_wasm_shims_version": "v0.7.0"
 }

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -21,7 +21,12 @@ command:
     stdout: [ ]
     stderr: ["io.containerd.spin.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
     timeout: 0
-  grep -E 'io\.containerd\.(slight|spin)\.v1' /etc/containerd/config.toml:
+  containerd-shim-wws-v1:
+    exit-status: 1
+    stdout: [ ]
+    stderr: ["io.containerd.wws.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
+    timeout: 0
+  grep -E 'io\.containerd\.(slight|spin|wws)\.v1' /etc/containerd/config.toml:
     exit-status: 0
     stdout: [ ]
     stderr: [ ]


### PR DESCRIPTION
What this PR does / why we need it:
* Upgrades [containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims/releases) from 0.6.0 to 0.7.0
* Adds support for wws (Wasm Workers Server) wasm runtime

**Additional context**
* Tested locally in a capz cluster, following [Quickstart guide on containerd-wasm-shims](https://github.com/deislabs/containerd-wasm-shims#quickstarts)

```console
$ curl 10.96.59.31/hello
hello world!
$ curl 10.96.52.69/hello
Hello world from Spin!
$ curl 10.109.226.230/hello
<!DOCTYPE html>
<head>
  <title>Wasm Workers Server</title>
...
```