### PR TITLE
fix: making nvidia standalone due to conflicts with load_additional_components  

### DIFF
--- a/images/capi/ansible/roles/nvidia/README.md
+++ b/images/capi/ansible/roles/nvidia/README.md
@@ -8,7 +8,7 @@ An example of the fields you need are defined below. Make sure to review and cha
 
 ```json
 {
-  "ansible_user_vars": "additional_s3=true nvidia_s3_url=https://s3-endpoint nvidia_bucket=nvidia nvidia_bucket_access=ACCESS_KEY nvidia_bucket_secret=SECRET_KEY nvidia_installer_location=NVIDIA-Linux-x86_64-525.85.05-grid.run nvidia_tok_location=client_configuration_token.tok gridd_feature_type=4"
+  "ansible_user_vars": "nvidia_s3_url=https://s3-endpoint nvidia_bucket=nvidia nvidia_bucket_access=ACCESS_KEY nvidia_bucket_secret=SECRET_KEY nvidia_installer_location=NVIDIA-Linux-x86_64-525.85.05-grid.run nvidia_tok_location=client_configuration_token.tok gridd_feature_type=4",
   "node_custom_roles_pre": "nvidia"
 }
 
@@ -18,7 +18,8 @@ The role has to be installed via the `node_custom_roles_pre` option to avoid a k
 the driver won't work with it when the image is booted. This is because the DKMS hook doesn't get run due to the driver 
 being installed after the kernel has been installed. To get around this, we install the driver first.
 
-The `nvidia` custom role makes use of the `s3->load_additional_components` role so that it can fetch the items required from an S3 endpoint.
+The `nvidia` custom role does not make use of the `load_additional_components->s3` role due to a conflict that can occur when attempting to also use other aspects of `load_additional_components`.
+As the `nvidia` role is loaded as part of `node_custom_roles_pre`, it means that `load_additional_components` could be called out of order.
 
 The reasoning behind requiring an S3 endpoint was due to the fact NVIDIA will soon (July 2023) no longer support an internal licensing server being hosted by a customer.
 

--- a/images/capi/ansible/roles/nvidia/tasks/main.yml
+++ b/images/capi/ansible/roles/nvidia/tasks/main.yml
@@ -35,13 +35,15 @@
   delay: 10
   when: ansible_os_family == "Debian"
 
-- name: Install packages for building NVIDIA driver kernel module
+- name: Install packages for building NVIDIA driver kernel module and interacting with s3 endpoint
   become: true
   ansible.builtin.apt:
     pkg:
       - build-essential
       - wget
       - dkms
+      - python3-boto3
+      - python3-botocore
   when: ansible_os_family == "Debian"
 
 - name: Make /etc/nvidia/ClientConfigToken directory
@@ -54,16 +56,17 @@
     mode: 0755
 
 - name: Download NVIDIA License Token
-  ansible.builtin.include_role:
-    name: load_additional_components
-  vars:
-    additional_s3_endpoint: "{{ nvidia_s3_url }}"
-    additional_s3_access: "{{ nvidia_bucket_access }}"
-    additional_s3_secret: "{{ nvidia_bucket_secret }}"
-    additional_s3_bucket: "{{ nvidia_bucket }}"
-    additional_s3_ceph: "{{ nvidia_ceph }}"
-    additional_s3_object: "{{ nvidia_tok_location }}"
-    additional_s3_destination_path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
+  amazon.aws.s3_object:
+    endpoint_url: "{{ nvidia_s3_url }}"
+    access_key: "{{ nvidia_bucket_access }}"
+    secret_key: "{{ nvidia_bucket_secret }}"
+    bucket: "{{ nvidia_bucket }}"
+    object: "{{ nvidia_tok_location }}"
+    dest: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
+    mode: get
+    ceph: "{{ nvidia_ceph }}"
+  retries: 5
+  delay: 3
 
 - name: Set Permissions of NVIDIA License Token
   file:
@@ -80,19 +83,20 @@
     dest: /etc/nvidia/gridd.conf
     mode: 0644
 
-- name: Download NVIDIA driver
-  ansible.builtin.include_role:
-    name: load_additional_components
-  vars:
-    additional_s3_endpoint: "{{ nvidia_s3_url }}"
-    additional_s3_access: "{{ nvidia_bucket_access }}"
-    additional_s3_secret: "{{ nvidia_bucket_secret }}"
-    additional_s3_bucket: "{{ nvidia_bucket }}"
-    additional_s3_ceph: "{{ nvidia_ceph }}"
-    additional_s3_object: "{{ nvidia_installer_location }}"
-    additional_s3_destination_path: /tmp/NVIDIA-Linux-gridd.run
+- name: Download NVIDIA driver installer file
+  amazon.aws.s3_object:
+    endpoint_url: "{{ nvidia_s3_url }}"
+    access_key: "{{ nvidia_bucket_access }}"
+    secret_key: "{{ nvidia_bucket_secret }}"
+    bucket: "{{ nvidia_bucket }}"
+    object: "{{ nvidia_installer_location }}"
+    dest: /tmp/NVIDIA-Linux-gridd.run
+    mode: get
+    ceph: "{{ nvidia_ceph }}"
+  retries: 5
+  delay: 3
 
-- name: Set Permissions of NVIDIA driver
+- name: Set Permissions of NVIDIA driver installer file
   file:
     path: /tmp/NVIDIA-Linux-gridd.run
     state: file
@@ -104,3 +108,18 @@
   become: true
   ansible.builtin.command:
     cmd: "/tmp/NVIDIA-Linux-gridd.run -s --dkms --no-cc-version-check"
+
+- name: Remove the NVIDIA driver installer file
+  file:
+    path: /tmp/NVIDIA-Linux-gridd.run
+    state: absent
+
+- name: Cleanup packages for interacting with s3 endpoint
+  become: true
+  ansible.builtin.apt:
+    state: absent
+    purge: true
+    pkg:
+      - python3-boto3
+      - python3-botocore
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
What this PR does / why we need it:
I've been trying to get some additional container images baked into the image I'm building to speed up deployment time and I've hit a snag.

During the process I've had multiple failed builds and it stems from the following bits within the `nvidia` role.
```
  ansible.builtin.include_role:
    name: load_additional_components
```

When the `nvidia` role is loaded in via `node_custom_roles_pre`, which is the recommended approach to avoid issues with dkms/kernel updates during the image build, it also calls the `load_additional_components` role. 

You may or may not already have spotted the problem, but I'll continue my tale!

If you're trying to do anything else that also requires that role, then it'll try to do it in the pre-steps. This is obviously bad if you're doing what I am which is pulling a container image as `containerd` and the associated tools are non-existent at this time. 
I tried to get a few workarounds in place to avoid having the S3 code essentially twice but there is nothing that can be done without a bunch of conditionals which in my opinion would mess up the code base.

This PR basically makes `nvidia` a self-contained role and it allows the `load_additional_components` role to run during the natural course of the build rather than whenever `nvidia` is called.

Hope that makes sense!