### PR TITLE
Add chrony hook for Openstack

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -31,3 +31,16 @@
     state: stopped
     enabled: false
   when: ansible_os_family == "Debian"
+
+- name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: a+x
+  vars:
+    server_dir: "/var/lib/dhcp"
+    chrony_helper_dir: "/usr/libexec/chrony"
+  loop:
+    - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -47,3 +47,16 @@
     state: stopped
     enabled: false
   when: ansible_os_family == "Debian"
+
+- name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: a+x
+  vars:
+    server_dir: "/var/lib/dhcp"
+    chrony_helper_dir: "/usr/libexec/chrony"
+  loop:
+    - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
+    - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -433,6 +433,10 @@ ubuntu:
       cloud-initramfs-copymods:
       cloud-initramfs-dyn-netconf:
   qemu:
+    service:
+      networkd-dispatcher:
+        enabled: true
+        running: true
     package:
       linux-cloud-tools-virtual:
       linux-tools-virtual:


### PR DESCRIPTION
Add the networkd-dispatcher for chrony, this will make sure that Openstack images, check for the DNS srv record and DHCP option 42.

What this PR does / why we need it:

The current Openstack images do not install the NTP servers in chrony when DHCP option 42 set or the _ntp._udp DNS SRV records are there. To fix this the networkd-dispatcher is needed.
