### PR TITLE
qemu: configure networkd-dispatcher only if ansible_os_family is Debian

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -44,3 +44,4 @@
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
+  when: ansible_os_family == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -60,3 +60,4 @@
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION


**What this PR does / why we need it:**

configure networkd-dispatcher only if ansible_os_family is Debian, when build qemu/openstack images.

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #**


When built a rockylinux-8 image, it failed with error

`
03:33:13     qemu: TASK [providers : Copy networkd-dispatcher scripts to add DHCP provided NTP servers] ***
03:33:13     qemu: failed: [default] (item={'src': 'files/etc/networkd-dispatcher/routable.d/20-chrony.j2', 'dest': '/etc/networkd-dispatcher/routable.d/20-chrony'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "30a51e04a079692488b0ff9a8110f944edc4ccd0", "item": {"dest": "/etc/networkd-dispatcher/routable.d/20-chrony", "src": "files/etc/networkd-dispatcher/routable.d/20-chrony.j2"}, "msg": "Destination directory /etc/networkd-dispatcher/routable.d does not exist"}
03:33:15     qemu: failed: [default] (item={'src': 'files/etc/networkd-dispatcher/off.d/20-chrony.j2', 'dest': '/etc/networkd-dispatcher/off.d/20-chrony'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "166b935120885092c7ac9c5e8dc2512ffceeb470", "item": {"dest": "/etc/networkd-dispatcher/off.d/20-chrony", "src": "files/etc/networkd-dispatcher/off.d/20-chrony.j2"}, "msg": "Destination directory /etc/networkd-dispatcher/off.d does not exist"}
03:33:16     qemu: failed: [default] (item={'src': 'files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2', 'dest': '/etc/networkd-dispatcher/no-carrier.d/20-chrony'}) => {"ansible_loop_var": "item", "changed": false, "checksum": "2274084fa730b0f786991695f08c82cd49516376", "item": {"dest": "/etc/networkd-dispatcher/no-carrier.d/20-chrony", "src": "files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2"}, "msg": "Destination directory /etc/networkd-dispatcher/no-carrier.d does not exist"}
`

**Additional context**
**Add any other context for the reviewers**

This is a regression issue of #1225 