### PR TITLE
Adding the destroy field to vsphere-clone and vsphere-iso builders

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -147,6 +147,7 @@
       "create_snapshot": "{{user `create_snapshot`}}",
       "datacenter": "{{user `datacenter`}}",
       "datastore": "{{user `datastore`}}",
+      "destroy": "{{user `destroy`}}",
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "firmware": "{{user `firmware`}}",
       "floppy_dirs": "{{ user `floppy_dirs`}}",
@@ -203,6 +204,7 @@
       "cpu_cores": "{{user `cpu_cores`}}",
       "datacenter": "{{user `datacenter`}}",
       "datastore": "{{user `datastore`}}",
+      "destroy": "{{user `destroy`}}",
       "disk_controller_type": "{{user `disk_controller_type`}}",
       "export": {
         "force": true,
@@ -468,6 +470,7 @@
     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
     "crictl_version": null,
     "datastore": "",
+    "destroy": "false",
     "disk_size": "20480",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "export_manifest": "none",


### PR DESCRIPTION
What this PR does / why we need it:
Adding the `destroy` field to `vsphere-clone` and `vsphere-iso` builders so that Packer VM can be deleted after successful VM generation.

Before
```
    vsphere: Writing ovf...
==> vsphere: Clear boot order...
==> vsphere: Running post-processor: packer-manifest (type manifest)
```

Now after setting the `destroy` parameter to `true`
```
    vsphere-iso.vsphere: Writing ovf...
==> vsphere-iso.vsphere: Clear boot order...
==> vsphere-iso.vsphere: Destroying VM...
==> vsphere-iso.vsphere: Running post-processor: packer-manifest (type manifest)
```


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1242 

**Additional context**
- Added the `destroy` to only `vsphere-iso` (Not applicable for other builders)
- Not to change any existing behaviors `destroy` parameter value is set to `false`.