### PR TITLE
Bump Packer to v1.9.2

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,7 +20,8 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-_version="1.9.1"
+# **DO NOT** change the Packer version: v1.9.2 is the last release under the MPL v2.0 license.
+_version="1.9.2"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates the version of Packer to [v1.9.2](https://github.com/hashicorp/packer/releases/tag/v1.9.2).

Which issue(s) this PR fixes:

N/A

**Additional context**

v1.9.2 is the last Packer release under the Mozilla Public License. See the [HashiCorp Licensing FAQ](https://www.hashicorp.com/license-faq#What-did-[HashiCorp](https://www.hashicorp.com/license-faq#What-did-HashiCorp-announce-today-(Aug-10))-announce-today-(Aug-10)) for more info.