### PR TITLE
Ensure directories for network-dispatcher exist

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -48,6 +48,19 @@
     enabled: false
   when: ansible_os_family == "Debian"
 
+- name: Ensure networkd-dispatcher folders exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  loop:
+    - /etc/networkd-dispatcher/routable.d
+    - /etc/networkd-dispatcher/off.d
+    - /etc/networkd-dispatcher/no-carrier.d
+    
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   template:
     src: "{{ item.src }}"


### PR DESCRIPTION
What this PR does / why we need it:

Add directories under `/etc/network-dispatcher` if they do not exist.

https://github.com/kubernetes-sigs/image-builder/pull/1225 Introduced a task which adds chrony support.  This appears to be causing image builds in Flatcar on Openstack to fail:

```
    openstack.flatcar: TASK [providers : Copy networkd-dispatcher scripts to add DHCP provided NTP servers] ***                                                                                           
    openstack.flatcar: Sunday 13 August 2023  17:47:20 +1200 (0:00:00.015)       0:00:35.037 *********                                                                                                    
    openstack.flatcar: failed: [default] (item={'src': 'files/etc/networkd-dispatcher/routable.d/20-chrony.j2', 'dest': '/etc/networkd-dispatcher/routable.d/20-chrony'}) => {"ansible_loop_var": "item", 
"changed": false, "checksum": "30a51e04a079692488b0ff9a8110f944edc4ccd0", "item": {"dest": "/etc/networkd-dispatcher/routable.d/20-chrony", "src": "files/etc/networkd-dispatcher/routable.d/20-chrony.j2"
}, "msg": "Destination directory /etc/networkd-dispatcher/routable.d does not exist"}                                                                                                                     
    openstack.flatcar: failed: [default] (item={'src': 'files/etc/networkd-dispatcher/off.d/20-chrony.j2', 'dest': '/etc/networkd-dispatcher/off.d/20-chrony'}) => {"ansible_loop_var": "item", "changed":
 false, "checksum": "166b935120885092c7ac9c5e8dc2512ffceeb470", "item": {"dest": "/etc/networkd-dispatcher/off.d/20-chrony", "src": "files/etc/networkd-dispatcher/off.d/20-chrony.j2"}, "msg": "Destinati
on directory /etc/networkd-dispatcher/off.d does not exist"}                                                                                                                                              
    openstack.flatcar: failed: [default] (item={'src': 'files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2', 'dest': '/etc/networkd-dispatcher/no-carrier.d/20-chrony'}) => {"ansible_loop_var": "ite
m", "changed": false, "checksum": "2274084fa730b0f786991695f08c82cd49516376", "item": {"dest": "/etc/networkd-dispatcher/no-carrier.d/20-chrony", "src": "files/etc/networkd-dispatcher/no-carrier.d/20-ch
rony.j2"}, "msg": "Destination directory /etc/networkd-dispatcher/no-carrier.d does not exist"} 
```

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

I have not seen any issues raised about this yet.

**Additional context**
Add any other context for the reviewers