### PR TITLE
CAPC: Remove ConfigDrive from cloud-init datasource_list in cloudstack images

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/cloudstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/cloudstack.yml
@@ -16,7 +16,7 @@
   copy:
     dest: /etc/cloud/cloud.cfg.d/cloudstack.cfg
     content: |-
-      datasource_list: ['CloudStack', 'ConfigDrive']
+      datasource_list: ['CloudStack']
       datasource:
         CloudStack:
           max_wait: 120


### PR DESCRIPTION
What this PR does / why we need it:

This reverts commit d2956b387f0b1e0cf0d3061901085568c17e1934 (see #1202).

We'v found that the new images for CAPC do not work on VMware and Xen, which is caused by an issue fixed by https://github.com/canonical/cloud-init/pull/4281 (it works fine on KVM)

We need to revert the changes and reapply it after intensive testing. sorry for it.


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers