### PR TITLE
use "github.com/hashicorp/azure" version "<2.0.0"

### DIFF
--- a/images/capi/packer/azure/config.pkr.hcl
+++ b/images/capi/packer/azure/config.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     azure = {
-      version = ">= 1.4.3"
+      version = "< 2.0.0"
       source  = "github.com/hashicorp/azure"
     }
   }


### PR DESCRIPTION
What this PR does / why we need it:

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
- The OS DISK URI seemed to have changed with the `github.com/hashicorp/azure` version `>=2.0.0`.
	- We expect to see the URI like `**/Images/cluster-api-vhds/capi-xyz-osDisk.**`
	- Instead we see `**/Images/images/packer-osDisk.xyz.vhd`
	- Notice the change in the URI
- Moreover, with the plugin `github.com/hashicorp/azure` version `>=2.0.0`, we do not see `TemplateUriReadOnlySas` in the output of `Building VHD` stage of `build_vhd` of creating reference images for CAPZ. 
- This PR uses the "github.com/hashicorp/azure" version "<2.0.0" in the reference image jobs.


**Additional context**
Add any other context for the reviewers