### PR TITLE
Pin Nutanix version to pre 0.8.0

### DIFF
--- a/images/capi/packer/nutanix/config.pkr.hcl
+++ b/images/capi/packer/nutanix/config.pkr.hcl
@@ -1,7 +1,7 @@
 packer {
   required_plugins {
     nutanix = {
-      version = ">= 0.7.0"
+      version = ">= 0.7.0, < 0.8.0"
       source = "github.com/nutanix-cloud-native/nutanix"
     }
   }


### PR DESCRIPTION
What this PR does / why we need it:

Pins the Nutanix plugin version to the 0.7.x versions that don't include the additional checks for missing configuration.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1254

**Additional context**

/cc @mboersma 
