### PR TITLE
Load external packer plugins via config files

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -105,6 +105,7 @@ deps-ova: deps-common
 	hack/ensure-goss.sh
 	hack/ensure-ovftool.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) init packer/ova/config.pkr.hcl
 
 .PHONY: deps-openstack
 deps-openstack: ## Installs/checks dependencies for OpenStack builds

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -140,6 +140,7 @@ deps-vbox: deps-common
 	hack/ensure-ansible-windows.sh
 	hack/ensure-goss.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) init packer/vbox/config.pkr.hcl
 
 .PHONY: deps-powervs
 deps-powervs: ## Installs/checks dependencies for PowerVS builds

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -96,6 +96,7 @@ deps-gce: ## Installs/checks dependencies for GCE builds
 deps-gce: deps-common
 	hack/ensure-goss.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) init packer/gce/config.pkr.hcl
 
 .PHONY: deps-ova
 deps-ova: ## Installs/checks dependencies for OVA builds

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -119,6 +119,7 @@ deps-qemu: ## Installs/checks dependencies for QEMU builds
 deps-qemu: deps-common
 	hack/ensure-goss.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) init packer/qemu/config.pkr.hcl
 
 .PHONY: deps-raw
 deps-raw: ## Installs/checks dependencies for RAW builds

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -66,6 +66,7 @@ deps-ami: deps-common
 	hack/ensure-ansible-windows.sh
 	hack/ensure-goss.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) init packer/ami/config.pkr.hcl
 
 .PHONY: deps-azure
 deps-azure: ## Installs/checks dependencies for Azure builds

--- a/images/capi/packer/ami/config.pkr.hcl
+++ b/images/capi/packer/ami/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.6, < 1.3"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}

--- a/images/capi/packer/gce/config.pkr.hcl
+++ b/images/capi/packer/gce/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 1.1.1, < 1.2"
+      source  = "github.com/hashicorp/googlecompute"
+    }
+  }
+}

--- a/images/capi/packer/ova/config.pkr.hcl
+++ b/images/capi/packer/ova/config.pkr.hcl
@@ -1,0 +1,13 @@
+packer {
+  required_version = ">= 1.7.0"
+  required_plugins {
+    vmware = {
+      version = ">= 1.0.8, < 1.1"
+      source  = "github.com/hashicorp/vmware"
+    }
+    vsphere = {
+      version = ">= 1.2.1, < 1.3"
+      source  = "github.com/hashicorp/vsphere"
+    }
+  }
+}

--- a/images/capi/packer/qemu/config.pkr.hcl
+++ b/images/capi/packer/qemu/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = ">= 1.0.9, < 1.1"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}

--- a/images/capi/packer/vbox/config.pkr.hcl
+++ b/images/capi/packer/vbox/config.pkr.hcl
@@ -1,0 +1,12 @@
+packer {
+  required_plugins {
+    vagrant = {
+      version = ">= 1.0.3, < 1.1"
+      source  = "github.com/hashicorp/vagrant"
+    }
+    virtualbox = {
+      version = ">= 1.0.5, < 1.1"
+      source  = "github.com/hashicorp/virtualbox"
+    }
+  }
+}


### PR DESCRIPTION
What this PR does / why we need it:

Silences the warnings that `packer` v1.9.2 emits now for using deprecated, bundled plugins:

```shell
/Users/matt/projects/image-builder/images/capi/.local/bin/packer validate -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/kubernetes.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/windows/kubernetes.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/containerd.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/windows/containerd.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/windows/docker.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/windows/ansible-args-windows.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/common.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/windows/common.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/windows/cloudbase-init.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/goss-args.json"  -var-file="/Users/matt/projects/image-builder/images/capi/packer/config/additional_components.json"   -var-file="packer/ova/packer-common.json" -var-file="/Users/matt/projects/image-builder/images/capi/packer/ova/windows-2022.json" -except=vsphere -only=vmware-iso  packer/ova/packer-windows.json
Warning: Bundled plugins used

This template relies on the use of plugins bundled into the Packer binary.
The practice of bundling external plugins into Packer will be removed in an
upcoming version.

To remove this warning and ensure builds keep working you can install these
external plugins with the 'packer plugins install' command

* packer plugins install github.com/hashicorp/vmware
* packer plugins install github.com/hashicorp/vsphere

Alternatively, if you upgrade your templates to HCL2, you can use 'packer init'
with a 'required_plugins' block to automatically install external plugins.
```

Also pins each plugin within a "known-working" range by sticking to the current minor release for each. This will require maintainers to update plugins explicitly, which is probably what we want.

Which issue(s) this PR fixes:

Fixes #

**Additional context**

I've tested this with the `validate-` targets locally. 

It seems possible that this will be more likely to trigger #1258.