### PR TITLE
Bump ansible to v2.15.3

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.11.5"
+_version="2.13.11"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

The version of [ansible](https://github.com/ansible/ansible/releases/tag/v2.15.3) in image-builder hasn't been updated [since 2021](https://github.com/kubernetes-sigs/image-builder/pull/706), and only newer versions are tested with the [community.windows](https://github.com/ansible-collections/community.windows) extension.

Which issue(s) this PR fixes:

Fixes #1266

**Additional context**

This is a pretty big jump in versions. 🤞🏻 