### PR TITLE
Bump Packer to v1.9.4

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,8 +20,8 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-# **DO NOT** change the Packer version: v1.9.2 is the last release under the MPL v2.0 license.
-_version="1.9.2"
+# **DO NOT** change the Packer version unless it is available under MPL v2.0.
+_version="1.9.4"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates the version of Packer to [v1.9.4](https://github.com/hashicorp/packer/releases/tag/v1.9.4).

Which issue(s) this PR fixes:

N/A

**Additional context**

v1.9.x is the last Packer release series under the Mozilla Public License. See the [HashiCorp Licensing FAQ](https://www.hashicorp.com/license-faq#What-did-[HashiCorp](https://www.hashicorp.com/license-faq#What-did-HashiCorp-announce-today-(Aug-10))-announce-today-(Aug-10)) for more info.

I think I misread this notice previously:
https://www.hashicorp.com/license-faq#products-covered-by-bsl

I thought v1.9.2 was the last MPL release for Packer, but re-reading it I think BUSL will arrive with a Packer 2.0 release. In practice both the [v1.9.3](https://github.com/hashicorp/packer/blob/v1.9.3/LICENSE) and [v1.9.4](https://github.com/hashicorp/packer/blob/v1.9.4/LICENSE) releases retain the MPL 2.0 license.