### PR TITLE
Update docker image base to Ubuntu jammy

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -193,7 +193,7 @@ IMAGE_NAME ?= cluster-node-image-builder
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
 ARCH ?= amd64
-BASE_IMAGE ?= docker.io/library/ubuntu:focal
+BASE_IMAGE ?= docker.io/library/ubuntu:jammy
 
 ## --------------------------------------
 ## Packer flags


### PR DESCRIPTION
What this PR does / why we need it:

Updates the Docker base image to use Ubuntu 22.04 LTS (jammy) instead of 20.04. This brings with it Python 3.10 instead of 3.8.

Which issue(s) this PR fixes:

Refs https://github.com/kubernetes-sigs/image-builder/pull/1268#pullrequestreview-1589893068
