### PR TITLE
Clean up more references to Ubuntu 18.04

### DIFF
--- a/docs/book/src/capi/providers/openstack.md
+++ b/docs/book/src/capi/providers/openstack.md
@@ -43,12 +43,12 @@ make deps-qemu
 
 ### Building QCOW2 Image
 
-From the `images/capi` directory, run `make build-qemu-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `1804` or `2004` depending on the version you want to build the image for.
+From the `images/capi` directory, run `make build-qemu-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `2004` or `2204` depending on the version you want to build the image for.
 
-For building a ubuntu-2004 based CAPI image, run the following commands -
+To build a Ubuntu 22.04-based CAPI image, run the following commands -
 
 ```bash
 $ git clone https://github.com/kubernetes-sigs/image-builder.git
 $ cd image-builder/images/capi/
-$ make build-qemu-ubuntu-2004
+$ make build-qemu-ubuntu-2204
 ```

--- a/docs/book/src/capi/providers/raw.md
+++ b/docs/book/src/capi/providers/raw.md
@@ -43,9 +43,9 @@ make deps-raw
 
 ### Building QCOW2 Image
 
-From the `images/capi` directory, run `make build-raw-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `1804` or `2004` depending on the version you want to build the image for.
+From the `images/capi` directory, run `make build-raw-ubuntu-xxxx`. The image is built and located in images/capi/output/BUILD_NAME+kube-KUBERNETES_VERSION. Please replace xxxx with `2004` or `2004-efi` depending on the version you want to build the image for.
 
-For building a ubuntu-2004 based CAPI image, run the following commands -
+To build a Ubuntu 20.04-based CAPI image, run the following commands -
 
 ```bash
 $ git clone https://github.com/kubernetes-sigs/image-builder.git


### PR DESCRIPTION
What this PR does / why we need it:

Removes some more end-of-life Ubuntu 18.04 references in documentation.

Which issue(s) this PR fixes:

Refs #1232