### PR TITLE
update windows reference template

### DIFF
--- a/images/capi/packer/azure/scripts/test-templates/windows/kustomization.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/windows/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.6.0/cluster-template-windows.yaml
+  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.10.2/cluster-template-windows.yaml
 patchesStrategicMerge:
 - ../patches/azuremachinetemplate-windows.yaml
 - ../patches/kubeadmcontrolplane-windows.yaml


### PR DESCRIPTION
What this PR does / why we need it:

- This PR updates the `cluster-template-windows.yaml` for windows, essentially unblocking Azure DevOps building windows VHDs.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers