### PR TITLE
Bump ansible to v2.15.3

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.13.11"
+_version="2.15.3"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates ansible to the latest release [v2.15.3](https://github.com/ansible/ansible/releases/tag/v2.15.3).

Which issue(s) this PR fixes:

Refs #1268
