### PR TITLE
Remove inline provisioner for GCE Ubuntu

### DIFF
--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -24,17 +24,6 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [
-        "BUILD_NAME={{user `build_name`}}"
-      ],
-      "inline": [
-        "if [ $BUILD_NAME != \"ubuntu-2004\" ]; then exit 0; fi",
-        "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done",
-        "sudo apt-get -qq update && sudo DEBIAN_FRONTEND=noninteractive apt-get -qqy install python python-pip"
-      ],
-      "type": "shell"
-    },
-    {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'"
       ],


### PR DESCRIPTION
What this PR does / why we need it:

The CAPG tests are currently failing - see https://kubernetes.slack.com/archives/C8TSNPY4T/p1692992049432829

Turns out this block of code never did anything due to previously having:
```
"if [ $BUILD_NAME != \"ubuntu-1804\" ] || [ $BUILD_NAME != \"ubuntu-2004\" ]; then exit 0; fi",
```
Which always matched regardless of what the build name was. 

As it was never actually used I've removed it completely.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers