### PR TITLE
Azure: Remove quotes from tags in test VHD script

### DIFF
--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -53,7 +53,8 @@ jobs:
       AZURE_LOCATION=$(az storage account show --name "${STORAGE_ACCOUNT_NAME}" --query '[location]' -o tsv)
 
       # Create the resource group
-      az group create --name "${RESOURCE_GROUP}" --location "${AZURE_LOCATION}" --tags "${TAGS}"
+      # Note: the tags parameter is not surrounded by quotes for the Azure CLI to parse it correctly.
+      az group create --name "${RESOURCE_GROUP}" --location "${AZURE_LOCATION}" --tags ${TAGS}
 
       # Create a managed image from the VHD blob
       OS_TYPE="Linux"


### PR DESCRIPTION
What this PR does / why we need it:
This PR removes quotes when referencing `$TAGS` which caused tags to be incorrectly formatted for the az cli.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers