### PR TITLE
Remove kops-maintainers group from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -74,15 +74,3 @@ aliases:
     - tuxtof
   cluster-api-nutanix-reviewers:
     - tuxtof
-  kops-maintainers:
-    - hakman
-    - justinsb
-    - rifelpet
-    # kOps maintainers, but members of kubernetes, not of kubernetes-sigs:
-    # - geojaz
-    # - johngmyers
-    # - kashifsaadat
-    # - mikesplain
-    # - olemarkus
-    # - rdrgmnzs
-    # - zetaab


### PR DESCRIPTION
What this PR does / why we need it:

Removes the obsolete `kops-maintainers` section from the `OWNERS_ALIASES` file. It's not referenced anywhere else in the project.

Which issue(s) this PR fixes:

Refs: #1143