### PR TITLE
CAPI/OVA: set resource_pool for jobs and improve cleanup

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -171,6 +171,7 @@
         }
       ],
       "password": "{{user `password`}}",
+      "resource_pool": "{{user `resource_pool`}}",
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c '{{user `shutdown_command`}}'",
       "ssh_clear_authorized_keys": "false",
       "ssh_password": "{{user `ssh_password`}}",
@@ -233,6 +234,7 @@
         }
       ],
       "password": "{{user `password`}}",
+      "resource_pool": "{{user `resource_pool`}}",
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
@@ -273,6 +275,7 @@
       "name": "vsphere-clone",
       "network": "{{user `network`}}",
       "password": "{{user `password`}}",
+      "resource_pool": "{{user `resource_pool`}}",
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "4h",
@@ -502,6 +505,7 @@
     "kubernetes_source_type": null,
     "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}",
     "output_dir": "./output/{{user `build_version`}}",
+    "resource_pool": "",
     "username": "",
     "vcenter_server": "",
     "vsphere_guest_os_type": null

--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -41,8 +41,9 @@ cleanup_build_vm() {
 
   for target in ${TARGETS[@]};
   do
+    # Adding || true to both commands so it does not exit after not being able to cleanup one target.
     govc vm.power -off -force -wait /${GOVC_DATACENTER}/vm/${FOLDER}/capv-ci-${target}-${TIMESTAMP} || true
-    govc object.destroy /${GOVC_DATACENTER}/vm/${FOLDER}/capv-ci-${target}-${TIMESTAMP}
+    govc object.destroy /${GOVC_DATACENTER}/vm/${FOLDER}/capv-ci-${target}-${TIMESTAMP} || true
   done
 
 }
@@ -57,6 +58,8 @@ export GOVC_DATACENTER="SDDC-Datacenter"
 export GOVC_INSECURE=true
 export FOLDER="Workloads/ci/imagebuilder"
 
+echo "Running build with timestamp ${TIMESTAMP}"
+
 cat << EOF > packer/ova/vsphere.json
 {
     "vcenter_server":"${GOVC_URL}",
@@ -65,6 +68,7 @@ cat << EOF > packer/ova/vsphere.json
     "password":"${GOVC_PASSWORD}",
     "datastore":"WorkloadDatastore",
     "datacenter":"${GOVC_DATACENTER}",
+    "resource_pool": "Compute-ResourcePool/ci-image-builder",
     "cluster": "Cluster-1",
     "network": "sddc-cgw-network-8",
     "folder": "${FOLDER}"


### PR DESCRIPTION
CAPV Maintainer here. We're currently taking a look at the CI infrastructure and are doing some cleanups there.

What this PR does / why we need it:

* Improves the cleanup logic to not exit if a target fails to get cleaned up
* Creates the VMs in a resource pool so they do not get created directly on the Cluster level

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers