### PR TITLE
Add dracut cmd to generate initramfs with drivers for RHEL raw

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/raw.yml
+++ b/images/capi/ansible/roles/providers/tasks/raw.yml
@@ -35,6 +35,10 @@
     - cloud-utils-growpart
   when: ansible_os_family == "RedHat"
 
+- name: Run dracut cmd to regenerate initramfs with all drivers - needed when converting to different hypervisor templates
+  shell: dracut --force --no-hostonly
+  when: ansible_os_family == "RedHat"
+
 #- name: Unlock password
 #  replace:
 #    path: /etc/cloud/cloud.cfg

--- a/images/capi/packer/raw/raw-rhel-8.json
+++ b/images/capi/packer/raw/raw-rhel-8.json
@@ -2,6 +2,7 @@
   "boot_command_prefix": "<tab> text inst.ks=",
   "boot_command_suffix": "/8/ks.cfg<enter><wait>",
   "build_name": "rhel-8",
+  "build_target": "raw",
   "distro_name": "rhel",
   "distro_version": "8",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",


### PR DESCRIPTION
What this PR does / why we need it:
Raw builds are run on KVM vms. RHEL 8.x ships with dracut that builds initramfs with default `host-only` mode set to true. This causes the initramfs to only include drivers that are required to run kvm infrastructure. When the disks are exported and booted on a metal server, the OS fails to boot up due to this missing drivers. 

This change runs dracut with `--no-hostonly` to rebuild initramfs to include all drivers

This PR also fixes another issue that bubbled up during testing the dracut changes. The `build_type` was not set to `raw` in the rhel json file, causing providers role to run qemu tasks as opposed to raw tasks.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1287 

**Additional context**
Add any other context for the reviewers