### PR TITLE
GCE: Fix k8s deb/rpm image versions revision part based on OBS format

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
@@ -1,7 +1,7 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.24.15-00",
-  "kubernetes_rpm_version": "1.24.15-0",
+  "kubernetes_deb_version": "1.24.15-1.1",
+  "kubernetes_rpm_version": "1.24.15",
   "kubernetes_semver": "v1.24.15",
   "kubernetes_series": "v1.24",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
@@ -1,7 +1,7 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.25.11-00",
-  "kubernetes_rpm_version": "1.25.11-0",
+  "kubernetes_deb_version": "1.25.11-1.1",
+  "kubernetes_rpm_version": "1.25.11",
   "kubernetes_semver": "v1.25.11",
   "kubernetes_series": "v1.25",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-26.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-26.json
@@ -1,7 +1,7 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.26.6-00",
-  "kubernetes_rpm_version": "1.26.6-0",
+  "kubernetes_deb_version": "1.26.6-1.1",
+  "kubernetes_rpm_version": "1.26.6",
   "kubernetes_semver": "v1.26.6",
   "kubernetes_series": "v1.26",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
@@ -1,7 +1,7 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.27.3-00",
-  "kubernetes_rpm_version": "1.27.3-0",
+  "kubernetes_deb_version": "1.27.3-1.1",
+  "kubernetes_rpm_version": "1.27.3",
   "kubernetes_semver": "v1.27.3",
   "kubernetes_series": "v1.27",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"


### PR DESCRIPTION
What this PR does / why we need it:
Change the format of k8s deb/rpm image versions revision part based on the new OBS format. 
More info on: https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1017

**Additional context**
Add any other context for the reviewers