### PR TITLE
Update gce nightly images

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-24.json
@@ -1,8 +1,0 @@
-{
-  "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.24.15-1.1",
-  "kubernetes_rpm_version": "1.24.15",
-  "kubernetes_semver": "v1.24.15",
-  "kubernetes_series": "v1.24",
-  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
-}

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-25.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.25.11-1.1",
-  "kubernetes_rpm_version": "1.25.11",
-  "kubernetes_semver": "v1.25.11",
+  "kubernetes_deb_version": "1.25.14-1.1",
+  "kubernetes_rpm_version": "1.25.14",
+  "kubernetes_semver": "v1.25.14",
   "kubernetes_series": "v1.25",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-26.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-26.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.26.6-1.1",
-  "kubernetes_rpm_version": "1.26.6",
-  "kubernetes_semver": "v1.26.6",
+  "kubernetes_deb_version": "1.26.9-1.1",
+  "kubernetes_rpm_version": "1.26.9",
+  "kubernetes_semver": "v1.26.9",
   "kubernetes_series": "v1.26",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.27.3-1.1",
-  "kubernetes_rpm_version": "1.27.3",
-  "kubernetes_semver": "v1.27.3",
+  "kubernetes_deb_version": "1.27.6-1.1",
+  "kubernetes_rpm_version": "1.27.6",
+  "kubernetes_semver": "v1.27.6",
   "kubernetes_series": "v1.27",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-28.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-28.json
@@ -1,0 +1,8 @@
+{
+  "build_timestamp": "nightly",
+  "kubernetes_deb_version": "1.28.2-1.1",
+  "kubernetes_rpm_version": "1.28.2",
+  "kubernetes_semver": "v1.28.2",
+  "kubernetes_series": "v1.28",
+  "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
What this PR does / why we need it:

- drop 1.24 build
- update 1.25/1.26/1.27 to latest release and add 1.28 release

/assign @richardcase 