### PR TITLE
capi: move CI to new resource pool and folder in VMC

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -56,7 +56,7 @@ export GC_KIND="false"
 export TIMESTAMP="$(date -u '+%Y%m%dT%H%M%S')"
 export GOVC_DATACENTER="SDDC-Datacenter"
 export GOVC_INSECURE=true
-export FOLDER="Workloads/ci/imagebuilder"
+export FOLDER="Workloads/image-builder"
 
 echo "Running build with timestamp ${TIMESTAMP}"
 
@@ -68,7 +68,7 @@ cat << EOF > packer/ova/vsphere.json
     "password":"${GOVC_PASSWORD}",
     "datastore":"WorkloadDatastore",
     "datacenter":"${GOVC_DATACENTER}",
-    "resource_pool": "Compute-ResourcePool/ci-image-builder",
+    "resource_pool": "Compute-ResourcePool/image-builder",
     "cluster": "Cluster-1",
     "network": "sddc-cgw-network-8",
     "folder": "${FOLDER}"


### PR DESCRIPTION
What this PR does / why we need it:

Moves the resources created inside CI to a new location.
We currently cleanup the environment and change some structure.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers