### PR TITLE
Bump ansible to 2.15.4

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.15.3"
+_version="2.15.4"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates `ansible` to the latest patch release. See https://github.com/ansible/ansible/blob/v2.15.4/changelogs/CHANGELOG-v2.15.rst#v2-15-4

Which issue(s) this PR fixes: 

N/A

**Additional context**
