### PR TITLE
Bump containerd to 1.7.6

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -1,7 +1,7 @@
 {
   "containerd_additional_settings": null,
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
-  "containerd_sha256": "e32e31fdc4a66e2490d056d12fc10b6b0c6301cf3350b08c7ea96dccea4f8258",
-  "containerd_sha256_windows": "2072317fbef14a4133168e2d58c060458ffbecfcb6ba79a7436147844209ac47",
-  "containerd_version": "1.6.23"
+  "containerd_sha256": "20da1f2252d2033594b06e1eb68dd4906ff439f83f1003b7ebacdffcb4b95bdc",
+  "containerd_sha256_windows": "76595c69bfb21871de3c6537c7bf85a7e494bd13310e3ecb991a176c87d6ce2f",
+  "containerd_version": "1.7.6"
 }

--- a/images/capi/packer/config/ppc64le/containerd.json
+++ b/images/capi/packer/config/ppc64le/containerd.json
@@ -1,5 +1,5 @@
 {
-  "containerd_sha256": "5c0b4456e4b4a17a28ec676e6265b5a33fe1c0549999e6b5ad9c1f42503a3809",
+  "containerd_sha256": "66993b13221e1ecab8e8e799025320fe74d9741ae4a99a74bd45dbd081c30a98",
   "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-ppc64le.tar.gz",
-  "containerd_version": "1.6.19"
+  "containerd_version": "1.7.6"
 }


### PR DESCRIPTION
What this PR does / why we need it:

Updates containerd to the latest [v1.7.6 release](https://github.com/containerd/containerd/releases/tag/v1.7.6).

Which issue(s) this PR fixes:

Fixes #1244

**Additional context**

For future reference, the SHAs are taken from these packages:

- For Linux, it's the sha256 sum for the cri-containerd-cni-\<version\>-linux-arm64.tar.gz package: https://github.com/containerd/containerd/releases/download/v1.7.6/cri-containerd-cni-1.7.6-linux-amd64.tar.gz.sha256sum
- For Windows, it's the sha256 sum for the containerd-\<version\>-windows-arm64.tar.gz package: https://github.com/containerd/containerd/releases/download/v1.7.6/containerd-1.7.6-windows-amd64.tar.gz.sha256sum
- For Linux PPC, it's the sha256 sum for the cri-containerd-cni-\<version\>-linux-ppc64le.tar.gz package: https://github.com/containerd/containerd/releases/download/v1.7.6/cri-containerd-cni-1.7.6-linux-ppc64le.tar.gz.sha256sum

/cc @hrak