### PR TITLE
Disable colour output with ansible-lint

### DIFF
--- a/images/capi/scripts/ci-lint.sh
+++ b/images/capi/scripts/ci-lint.sh
@@ -28,4 +28,4 @@ cd "${CAPI_ROOT}" || exit 1
 export PATH=${PWD}/.local/bin:$PATH
 export PATH=${PYTHON_BIN_DIR:-"${HOME}/.local/bin"}:$PATH
 
-make lint
+NO_COLOR=1 make lint


### PR DESCRIPTION
What this PR does / why we need it:

The output with colour doesn't look great in the prow logs (see https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_image-builder/934/pull-lint/1705217812173164544) so we would be better disabling them and just having the plain output.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers