### PR TITLE
Ensure Windows and common deps are installed before ansible-lint

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -181,6 +181,8 @@ deps-proxmox: deps-common
 
 .PHONY: deps-lint
 deps-lint: ## Installs/checks dependencies for image-builder code linting
+deps-lint: deps-common
+	hack/ensure-ansible-windows.sh
 	hack/ensure-ansible-lint.sh
 
 ## --------------------------------------

--- a/images/capi/ansible/python.yml
+++ b/images/capi/ansible/python.yml
@@ -14,7 +14,7 @@
 ---
 - hosts: all
   # Gathering facts requires Python to be available, so it's a chicken and egg
-  # problem as this playbook installs Python.
+  # problem since this playbook installs Python.
   gather_facts: false
   become: true
 


### PR DESCRIPTION
What this PR does / why we need it:

Fixes a missed dependency for the `make lint` target that prevented it from running cleanly in CI.

Which issue(s) this PR fixes: 

N/A

**Additional context**

I also made a trivial change in the /ansible directory to trigger the linter prow job.