### PR TITLE
Update containerd_wasm_shims to v0.9.1

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -31,12 +31,15 @@
     mode: "0600"
 
 - name: Download containerd-wasm-shims
+  vars:
+    sha256sums: "{{ containerd_wasm_shims_sha256 | from_json }}"
   get_url:
-    url: "{{ containerd_wasm_shims_url }}"
-    checksum: "sha256:{{ containerd_wasm_shims_sha256 }}"
-    dest: /tmp/containerd_wasm_shims.tar.gz
+    url: "{{ containerd_wasm_shims_url | replace('<SHIM>', item) }}"
+    checksum: "sha256:{{ sha256sums[item] }}"
+    dest: "/tmp/{{ item }}_wasm_shim.tar.gz"
     mode: "0600"
   when: containerd_wasm_shims_runtimes | length > 0
+  loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"
 
 - name: Create a directory if it does not exist
   file:
@@ -55,16 +58,16 @@
       - --no-overwrite-dir
   when: ansible_os_family != "Flatcar"
 
-# install containerd Wasm shims when the runtimes are not empty -- current known runtimes are 'slight', 'spin', and 'wws'
-# see: https://github.com/kubernetes-sigs/image-builder/pull/1037
+# Install containerd Wasm shims specified in a comma-separated string. Known runtimes are 'lunatic', 'slight', 'spin', and 'wws'.
 - name: Unpack containerd-wasm-shims
   unarchive:
     remote_src: true
-    src: /tmp/containerd_wasm_shims.tar.gz
+    src: "/tmp/{{ item }}_wasm_shim.tar.gz"
     dest: "{{ sysusr_prefix }}/bin"
     extra_opts:
       - --no-overwrite-dir
   when: ansible_os_family != "Flatcar" and (containerd_wasm_shims_runtimes | length > 0)
+  loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"
 
 - name: Unpack containerd for Flatcar to /opt/bin
   unarchive:
@@ -81,16 +84,16 @@
       - 's@opt/local@opt@'
   when: ansible_os_family == "Flatcar"
 
-# install containerd Wasm shims when the runtimes are not empty -- current known runtimes are 'slight', 'spin', and 'wws'
-# see: https://github.com/kubernetes-sigs/image-builder/pull/1037
+# Install containerd Wasm shims specified in a comma-separated string. Known runtimes are 'lunatic', 'slight', 'spin', and 'wws'.
 - name: Unpack containerd-wasm-shims for Flatcar to /opt/bin
   unarchive:
     remote_src: true
-    src: /tmp/containerd_wasm_shims.tar.gz
+    src: "/tmp/{{ item }}_wasm_shim.tar.gz"
     dest: "{{ sysusr_prefix }}/bin"
     extra_opts:
       - --no-overwrite-dir
   when: ansible_os_family == "Flatcar" and (containerd_wasm_shims_runtimes | length > 0)
+  loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"
 
 # Remove /opt/cni directory, as we will install cni later
 - name: Delete /opt/cni directory

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -16,13 +16,17 @@ imports = ["/etc/containerd/conf.d/*.toml"]
     runtime_type = "io.containerd.runc.v2"
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
     SystemdCgroup = true
-{% if 'spin' in containerd_wasm_shims_runtimes %}
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin]
-    runtime_type = "io.containerd.spin.v1"
+{% if 'lunatic' in containerd_wasm_shims_runtimes %}
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.lunatic]
+    runtime_type = "io.containerd.lunatic.v1"
 {% endif %}
 {% if 'slight' in containerd_wasm_shims_runtimes %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.slight]
     runtime_type = "io.containerd.slight.v1"
+{% endif %}
+{% if 'spin' in containerd_wasm_shims_runtimes %}
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin]
+    runtime_type = "io.containerd.spin.v1"
 {% endif %}
 {% if 'wws' in containerd_wasm_shims_runtimes %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.wws]

--- a/images/capi/packer/azure/azure-config.json
+++ b/images/capi/packer/azure/azure-config.json
@@ -2,7 +2,7 @@
   "azure_location": "{{env `AZURE_LOCATION`}}",
   "client_id": "{{env `AZURE_CLIENT_ID`}}",
   "client_secret": "{{env `AZURE_CLIENT_SECRET`}}",
-  "containerd_wasm_shims_runtimes": "spin,slight,wws",
+  "containerd_wasm_shims_runtimes": "lunatic,slight,spin,wws",
   "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
   "vm_size": "Standard_B2ms"
 }

--- a/images/capi/packer/config/wasm-shims.json
+++ b/images/capi/packer/config/wasm-shims.json
@@ -1,6 +1,6 @@
 {
   "containerd_wasm_shims_runtimes": "",
-  "containerd_wasm_shims_sha256": "26bb6bd99947a7a45bd4d4ae4f94dd130677da5530bba08ffec8160ff6997313",
-  "containerd_wasm_shims_url": "https://github.com/deislabs/containerd-wasm-shims/releases/download/{{user `containerd_wasm_shims_version`}}/containerd-wasm-shims-v1-linux-x86_64.tar.gz",
-  "containerd_wasm_shims_version": "v0.8.0"
+  "containerd_wasm_shims_sha256": "{\"lunatic\":\"2927411e8cf892ade6a970055b4f77e332cd3ec1c43e2d09872c825212d35ade\",\"slight\":\"8aac701e20bbf7f3cf046d4676ebe869a1e20f89ce8a565e4b9a3e23be327932\",\"spin\":\"2f7be169f28434df0d2c1cddd189e06486d9de8c29e84f720cbfa2573518bddf\",\"wws\":\"58a357845eaa251993427721c1fa9ecadc6c2cc81bc900d1c4913638df91a661\"}",
+  "containerd_wasm_shims_url": "https://github.com/deislabs/containerd-wasm-shims/releases/download/{{ user `containerd_wasm_shims_version` }}/containerd-wasm-shims-v1-<SHIM>-linux-x86_64.tar.gz",
+  "containerd_wasm_shims_version": "v0.9.1"
 }

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -11,6 +11,11 @@ command:
     stderr: []
     timeout: 0
 {{if ne .Vars.containerd_wasm_shims_runtimes ""}}
+  containerd-shim-lunatic-v1:
+    exit-status: 1
+    stdout: [ ]
+    stderr: ["io.containerd.lunatic.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
+    timeout: 0
   containerd-shim-slight-v1:
     exit-status: 1
     stdout: [ ]
@@ -26,7 +31,7 @@ command:
     stdout: [ ]
     stderr: ["io.containerd.wws.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
     timeout: 0
-  grep -E 'io\.containerd\.(slight|spin|wws)\.v1' /etc/containerd/config.toml:
+  grep -E 'io\.containerd\.(lunatic|slight|spin|wws)\.v1' /etc/containerd/config.toml:
     exit-status: 0
     stdout: [ ]
     stderr: [ ]


### PR DESCRIPTION
What this PR does / why we need it:

Updates the containerd-wasm-shims to the latest pre-release [v0.9.1](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.1), which adds a new Wasm runtime. Also handles the new packaging where each shim is in its own archive.

Which issue(s) this PR fixes: 

Fixes #

**Additional context**

I've tested locally with Ubuntu 22.04 images built from this PR and everything seems to work. (I'm hitting the local ClusterIP service endpoints because of security restrictions on Azure dev accounts.)

```shell
$ sudo KUBECONFIG=/etc/kubernetes/admin.conf kubectl get svc
NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)   AGE
kubernetes     ClusterIP   10.96.0.1        <none>        443/TCP   9m14s
wasm-lunatic   ClusterIP   10.106.103.176   <none>        80/TCP    9s
wasm-slight    ClusterIP   10.97.72.208     <none>        80/TCP    9s
wasm-spin      ClusterIP   10.98.26.207     <none>        80/TCP    9s
wasm-wws       ClusterIP   10.109.105.219   <none>        80/TCP    9s
$ curl http://10.106.103.176/hello  # lunatic
Hello :)
$ curl http://10.97.72.208/hello  # slight
hello world!
$ curl http://10.98.26.207/hello  # spin
Hello world from Spin!
$ curl http://10.109.105.219/hello  # wws
<!DOCTYPE html>
<head>
  <title>Wasm Workers Server</title>
  <meta name="viewport" content="width=device-width,initial-scale=1">
  <meta charset="UTF-8">
  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
  <style>
    body { max-width: 1000px; }
    main { margin: 5rem 0; }
    h1, p { text-align: center; }
    h1 { margin-bottom: 2rem; }
    pre { font-size: .9rem; }
    pre > code { padding: 2rem; }
    p { margin-top: 2rem; }
  </style>
</head>
<body>
  <main>
    <h1>Hello from Wasm Workers Server </h1>
    <pre><code>Replying to /hello
Method: GET
User Agent: curl/7.81.0
Payload: -</code></pre>
    <p>
      This page was generated by a JavaScript file running in WebAssembly.
    </p>
  </main>
</body>
$ 
```

I also tested with containerd 1.6.23 and 1.7.6 to make sure the shim configuration is valid in both versions.

cc: @ogghead 