### PR TITLE
[Photon]Disable tdnf cache timer

### DIFF
--- a/images/capi/ansible/roles/node/tasks/photon.yml
+++ b/images/capi/ansible/roles/node/tasks/photon.yml
@@ -51,3 +51,9 @@
     backrefs: true
     regexp: "^(?!.*apparmor=0)(photon_cmdline.*)"
     line: '\1 apparmor=0'
+
+- name: Disable tdnf cache timer
+  systemd:
+    name: tdnf-cache-updateinfo.timer
+    enabled: false
+    state: stopped


### PR DESCRIPTION
What this PR does / why we need it:
[Photon]Disable tdnf cache timer
on Photon appliance where ram size is small, tdnf cache cause OOM outages. 

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1310 

**Additional context**
Add any other context for the reviewers