### PR TITLE
Expose ssh_proxy variables for vSphere builder

### DIFF
--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -23,6 +23,8 @@
   "remote_username": "",
   "skip_compaction": "false",
   "ssh_password": "builder",
+  "ssh_proxy_host": "",
+  "ssh_proxy_port": "",
   "ssh_timeout": "60m",
   "ssh_username": "builder",
   "vmx_version": "15",

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -237,6 +237,8 @@
       "resource_pool": "{{user `resource_pool`}}",
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
+      "ssh_proxy_host":  "{{user `ssh_proxy_host`}}",
+      "ssh_proxy_port":  "{{user `ssh_proxy_port`}}",
       "ssh_timeout": "4h",
       "ssh_username": "{{user `ssh_username`}}",
       "storage": [

--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -237,8 +237,8 @@
       "resource_pool": "{{user `resource_pool`}}",
       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
-      "ssh_proxy_host":  "{{user `ssh_proxy_host`}}",
-      "ssh_proxy_port":  "{{user `ssh_proxy_port`}}",
+      "ssh_proxy_host": "{{user `ssh_proxy_host`}}",
+      "ssh_proxy_port": "{{user `ssh_proxy_port`}}",
       "ssh_timeout": "4h",
       "ssh_username": "{{user `ssh_username`}}",
       "storage": [


### PR DESCRIPTION
**What this PR does / why we need it:**

In my environment, vSphere API is accessible only via proxy. It is not enough to set classic proxy variables (e.g. https_proxy, no_proxy etc.). Packer's ssh communicator only supports SOCKS proxy and it is configuration is separate. See https://developer.hashicorp.com/packer/docs/communicators/ssh

I couldn't find another way to set `ssh_proxy_host` and `ssh_proxy_port` without exposing them in builder's configuration as I do in this PR. 

**Open Points:**
1. Is there a way to set these variables without any change in the code?
2. Is there a standard across builders in the whole repo? Should I add this change to every builder? 