### PR TITLE
Fix path issues in post-processor of vsphere

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -322,8 +322,7 @@
         "vsphere-iso-base"
       ],
       "inline": [
-        "cd {{user `output_dir`}}",
-        "../../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../../hack/ovf_eula.txt --ovf_template ../../hack/ovf_template.xml --vmdk_file {{user `build_version`}}-disk-0.vmdk"
+        "./hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt --ovf_template ./hack/ovf_template.xml --vmdk_file {{user `build_version`}}-disk-0.vmdk {{user `output_dir`}}"
       ],
       "name": "vsphere",
       "type": "shell-local"


### PR DESCRIPTION
**What this PR does / why we need it:**
 
The current code mainly works but there is a failing scenario. When `./output` directory is a symbolic link, `../..` refers to the original path instead of `images/capi` path and post-processing fails.
 
The other uses of this script (`image-build-ova.py`) and other scripts used in post-processors are already called as `./hack/<script>`. See https://github.com/kubernetes-sigs/image-builder/pull/1315/files#diff-e5a52b8d4ed5f9c2b3af687e2e7ca510249ead5a7071b3827c698e46da551461R335

