### PR TITLE
Bump ansible-lint to v6.20.3

### DIFF
--- a/images/capi/hack/ensure-ansible-lint.sh
+++ b/images/capi/hack/ensure-ansible-lint.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="6.20.0"
+_version="6.20.3"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates the `ansible-lint` tool to the latest patch [v6.20.3](https://github.com/ansible/ansible-lint/releases/tag/v6.20.3).

Which issue(s) this PR fixes: 

Refs #1312, #1313

**Additional context**
