### PR TITLE
Update pip install to handle "error: externally-managed-environment"

### DIFF
--- a/images/capi/hack/ensure-ansible-lint.sh
+++ b/images/capi/hack/ensure-ansible-lint.sh
@@ -32,7 +32,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 if ! command -v ansible-lint >/dev/null 2>&1; then
-    ensure_py3
-    pip3 install --user "ansible-lint==${_version}"
+    pip3_install "ansible-lint==${_version}"
     ensure_py3_bin ansible-lint
 fi

--- a/images/capi/hack/ensure-ansible-windows.sh
+++ b/images/capi/hack/ensure-ansible-windows.sh
@@ -40,6 +40,5 @@ export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 if pip3 show pywinrm >/dev/null 2>&1; then exit 0; fi
 
-ensure_py3
-pip3 install --user "pywinrm==${_version}"
+pip3_install "pywinrm==${_version}"
 if ! pip3 show pywinrm ; then exit 1; fi

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -32,8 +32,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 if ! command -v ansible >/dev/null 2>&1; then
-    ensure_py3
-    pip3 install --user "ansible-core==${_version}"
+    pip3_install "ansible-core==${_version}"
     ensure_py3_bin ansible
     ensure_py3_bin ansible-playbook
 fi

--- a/images/capi/hack/ensure-azure-cli.sh
+++ b/images/capi/hack/ensure-azure-cli.sh
@@ -32,6 +32,5 @@ if command -v az >/dev/null 2>&1; then exit 0; fi
 export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 ensure_py3
-pip install -U pip setuptools
-pip3 install --user azure-cli
+pip3_install azure-cli
 ensure_py3_bin az azure-cli

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -100,6 +100,19 @@ ensure_py3() {
   fi
 }
 
+pip3_install() {
+  ensure_py3
+  if output=$(pip3 install --disable-pip-version-check --user "${@}" 2>&1); then
+    echo "$output"
+  elif [[ $output == *"error: externally-managed-environment"* ]]; then
+    >&2 echo "warning: externally-managed-environment, retrying pip3 install with --break-system-packages"
+    pip3 install --disable-pip-version-check --user --break-system-packages "${@}"
+  else
+    >&2 echo "$output"
+    exit 1
+  fi
+}
+
 hostarch_without_darwin_arm64() {
   if [ "${HOSTOS}" == "darwin" ] && [ "${HOSTARCH}" == "arm64" ]; then
     echo "amd64"


### PR DESCRIPTION
What this PR does / why we need it:

Adds a new `pip3_install` bash function that will retry installation if a certain error is raised.

Recently the e2e build environment was updated such that [PEP 668](https://peps.python.org/pep-0668/) became implemented. This means that `pip3 install <package>` raises an error telling the user to do `apt-get install python-<package>` instead. [Here](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_image-builder/1319/pull-azure-vhds/1711845171575918592) is one example of that failure.

This makes sense for distro vendors, but image-builder doesn't control the distro and has specific requirements for some tools (Packer, ansible, ansible-lint).

Which issue(s) this PR fixes:

Fixes #

**Additional context**

I looked at the recommended approach–using a Python virtualenv–but it's not a great fit with our set of scripts and would require more significant refactoring.