### PR TITLE
Check ansible version when installing dependencies

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -37,6 +37,19 @@ if ! command -v ansible >/dev/null 2>&1; then
     ensure_py3_bin ansible-playbook
 fi
 
+ansible_version=""
+IFS=" " read -ra ansible_version <<< "$(ansible --version)"
+if [[ "${_version}" != $(echo -e "${_version}\n${ansible_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${ansible_version[2]}" != "devel" ]]; then
+  cat <<EOF
+Detected ansible version: ${ansible_version[*]}.
+Image builder requires ${_version} or greater.
+Please install ${_version} or later.
+EOF
+  exit 2
+fi
+
+echo ${ansible_version[*]}
+
 ansible-galaxy collection install \
   community.general \
   ansible.posix \


### PR DESCRIPTION
What this PR does / why we need it:

Updates the `ensure-ansible.sh` script to check against image-builder's required version, and to exit with a message if `ansible` is too old.

Which issue(s) this PR fixes:

Fixes #1323

**Additional context**:

```shell
% make -C images/capi deps-common                                   
hack/ensure-python.sh
Checking if python is available
Python 3.11.6
hack/ensure-ansible.sh
Detected ansible version: ansible [core 2.15.2].
Image builder requires 2.15.4 or greater.
Please install 2.15.4 or later.
make: *** [deps-common] Error 2
```
