### PR TITLE
QEMU RockyLinux 9 and Ubuntu 23.04

### DIFF
--- a/images/capi/.ansible-lint-ignore
+++ b/images/capi/.ansible-lint-ignore
@@ -153,6 +153,8 @@ ansible/roles/setup/tasks/redhat.yml fqcn[action-core]
 ansible/roles/setup/tasks/redhat.yml fqcn[action]
 ansible/roles/setup/tasks/redhat.yml name[missing]
 ansible/roles/setup/tasks/redhat.yml package-latest
+ansible/roles/setup/tasks/redhat.yml command-instead-of-module
+ansible/roles/setup/tasks/redhat.yml no-changed-when
 ansible/roles/setup/tasks/rpm_repos.yml fqcn[action-core]
 ansible/roles/setup/tasks/rpm_repos.yml no-changed-when
 ansible/roles/sysprep/defaults/main.yml var-naming[no-role-prefix]

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -368,7 +368,7 @@ OPENSTACK_BUILD_NAMES	?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-f
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2204-efi qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2304 qemu-ubuntu-2204-efi qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-rockylinux-9 qemu-flatcar
 
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
@@ -765,9 +765,11 @@ build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-ubuntu-2004-efi: ## Builds Ubuntu 20.04 QEMU image that EFI boots
 build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
 build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
+build-qemu-ubuntu-2304: ## Builds Ubuntu 23.04 QEMU image
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
+build-qemu-rockylinux-9: ## Builds Rocky 9 QEMU image
 build-qemu-all: $(QEMU_BUILD_TARGETS) ## Builds all Qemu images
 
 build-raw-flatcar: ## Builds Flatcar RAW image
@@ -901,9 +903,11 @@ validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-ubuntu-2004-efi: ## Validates Ubuntu 20.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
 validate-qemu-ubuntu-2204-efi: ## Validates Ubuntu 22.04 QEMU EFI image packer config
+validate-qemu-ubuntu-2304: ## Validates Ubuntu 23.04 QEMU image packer config
 validate-qemu-centos-7: ## Validates CentOS 7 QEMU image packer config
 validate-qemu-rhel-8: ## Validates RHEL 8 QEMU image
 validate-qemu-rockylinux-8: ## Validates Rocky Linux 8 QEMU image packer config
+validate-qemu-rockylinux-9: ## Validates Rocky Linux 9 QEMU image packer config
 validate-qemu-all: $(QEMU_VALIDATE_TARGETS) ## Validates all Qemu Packer config
 
 validate-raw-flatcar: ## Validates Flatcar RAW image packer config

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -40,7 +40,7 @@ rh7_rpms:
   - python-netifaces
   - python-requests
 
-# Used for RedHat based distributions ==  8 (ex. RHEL-8, RockyLinux-8 etc.)
+# Used for RedHat based distributions =!  7 (ex. RHEL-8, RockyLinux-8, RockyLinux-9 etc.)
 rh8_rpms:
   - nftables
   - python3-netifaces

--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -23,6 +23,9 @@
     - lookup('env', 'RHSM_USER') | length > 0
     - lookup('env', 'RHSM_PASS') | length > 0
 
+- name: Perform dnf clean
+  command: /usr/bin/yum -y clean all
+
 - name: Import epel gpg key
   rpm_key:
     state: present

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -98,6 +98,23 @@
     - /var/log/cloud-init-output.log
     - /var/run/cloud-init
 
+- name: Reset cloud-init
+  shell:
+    cmd: |
+      cloud-init clean --machine-id
+  when: ansible_os_family == "Debian"
+
+- name: Reset cloud-init
+  shell:
+    cmd: |
+      cloud-init clean
+  when: ansible_os_family == "RedHat"
+
+- name: Remove cloud-init.disabled
+  file:
+    state: absent
+    path: /etc/cloud/cloud-init.disabled
+
 # A shallow search in /tmp and /var/tmp is used to declare which files or
 # directories will be removed as part of resetting temp space. The reason
 # a state absent->directory task isn't used is because Ansible's own data

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -75,7 +75,11 @@
 
 - name: Reset network interface IDs
   shell: sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
-  when: packer_builder_type != "googlecompute"
+  when: packer_builder_type != "googlecompute" and ansible_distribution_major_version|int != 9
+
+- name: Reset network interface IDs
+  shell: sed -i '/^\(uuid\)=/d' /etc/NetworkManager/system-connections/*.nmconnection
+  when: packer_builder_type != "googlecompute" and ansible_distribution_major_version|int == 9
 
 - name: Remove the kickstart log
   file:

--- a/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg
+++ b/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg
@@ -1,0 +1,96 @@
+# Use CDROM installation media
+repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/"
+cdrom
+
+# Use text install
+text
+
+# Don't run the Setup Agent on first boot
+firstboot --disabled
+eula --agreed
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+
+# System language
+lang en_US.UTF-8
+
+# Network information
+network --bootproto=dhcp --onboot=on --ipv6=auto --activate --hostname=capv.vm
+
+# Lock Root account
+rootpw --lock
+
+# Create builder user
+user --name=builder --groups=wheel --password=builder --plaintext --shell=/bin/bash
+
+# System services
+selinux --permissive
+firewall --disabled
+services --enabled="NetworkManager,sshd,chronyd"
+
+# System timezone
+timezone UTC
+
+# System booloader configuration
+bootloader --location=mbr --boot-drive=sda
+zerombr
+clearpart --all --initlabel --drives=sda
+part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+
+skipx
+
+%packages --ignoremissing --excludedocs
+openssh-server
+open-vm-tools
+sudo
+sed
+python3
+
+# unnecessary firmware
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl*-firmware
+-libertas-usb8388-firmware
+-ql*-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+-cockpit
+-quota
+-alsa-*
+-fprintd-pam
+-intltool
+-microcode_ctl
+%end
+
+%addon com_redhat_kdump --disable
+%end
+
+reboot
+
+%post
+
+echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+chmod 440 /etc/sudoers.d/builder
+
+# Remove the package cache
+yum -y clean all
+
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+systemctl enable vmtoolsd
+systemctl start vmtoolsd
+
+# Ensure on next boot that network devices get assigned unique IDs.
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/qemu/linux/ubuntu/http/23.04/user-data
+++ b/images/capi/packer/qemu/linux/ubuntu/http/23.04/user-data
@@ -1,0 +1,93 @@
+#cloud-config
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# For more information on how autoinstall is configured, please refer to
+# https://ubuntu.com/server/docs/install/autoinstall-reference
+autoinstall:
+  version: 1
+  # Disable ssh server during installation, otherwise packer tries to connect and exceed max attempts
+  early-commands:
+    - systemctl stop ssh
+  # Configure the locale
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  apt:
+    mirror-selection:
+      primary:
+          - uri: http://archive.ubuntu.com/ubuntu
+  # Create a single-partition with no swap space. Kubernetes
+  # really dislikes the idea of anyone else managing memory.
+  # For more information on how partitioning is configured,
+  # please refer to https://curtin.readthedocs.io/en/latest/topics/storage.html.
+  storage:
+    grub:
+      replace_linux_default: false
+    config:
+      - type: disk
+        id: disk-0
+        size: largest
+        grub_device: true
+        preserve: false
+        ptable: msdos
+        wipe: superblock
+      - type: partition
+        id: partition-0
+        device: disk-0
+        size: -1
+        number: 1
+        preserve: false
+        flag: boot
+      - type: format
+        id: format-0
+        volume: partition-0
+        fstype: ext4
+        preserve: false
+      - type: mount
+        id: mount-0
+        device: format-0
+        path: /
+  updates: 'all'
+  ssh:
+    install-server: true
+    allow-pw: true
+  # Customize the list of packages installed.
+  packages:
+    - open-vm-tools
+  # Create the default user.
+  # Ensures the "builder" user doesn't require a password to use sudo.
+  user-data:
+    users:
+      - name: builder
+        # openssl passwd -6 -stdin <<< builder
+        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
+        groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+        lock-passwd: false
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+
+  # This command runs after all other steps; it:
+  # 1. Disables swapfiles
+  # 2. Removes the existing swapfile
+  # 3. Removes the swapfile entry from /etc/fstab
+  # 4. Cleans up any packages that are no longer required
+  # 5. Removes the cached list of packages
+  late-commands:
+    - swapoff -a
+    - rm -f /swapfile
+    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - apt-get purge --auto-remove -y
+    - rm -rf /var/lib/apt/lists/*

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -8,6 +8,7 @@
         "{{user `boot_command_suffix`}}"
       ],
       "boot_wait": "{{user `boot_wait`}}",
+      "cpu_model": "host",
       "cpus": "{{user `cpus`}}",
       "disk_compression": "{{ user `disk_compression`}}",
       "disk_discard": "{{user `disk_discard`}}",

--- a/images/capi/packer/qemu/qemu-rockylinux-9.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-9.json
@@ -1,0 +1,17 @@
+{
+  "boot_command_prefix": "<up><tab> text inst.ks=",
+  "boot_command_suffix": "/9/ks.cfg<enter><wait><enter>",
+  "build_name": "rockylinux-9",
+  "distribution_version": "9",
+  "distro_arch": "amd64",
+  "distro_name": "rockylinux",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "guest_os_type": "centos9-64",
+  "iso_checksum": "06505828e8d5d052b477af5ce62e50b938021f5c28142a327d4d5c075f0670dc",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.2-x86_64-minimal.iso",
+  "os_display_name": "RockyLinux 9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "/sbin/halt -h -p"
+}

--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
@@ -1,5 +1,5 @@
 {
-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait><wait><wait>boot<enter>",
   "build_name": "ubuntu-2204",
   "distribution_version": "2204",
   "distro_name": "ubuntu",

--- a/images/capi/packer/qemu/qemu-ubuntu-2304.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2304.json
@@ -1,0 +1,13 @@
+{
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/23.04/'<enter><wait><wait><wait><wait>initrd /casper/initrd<wait><wait><enter><wait>boot<enter>",
+  "build_name": "ubuntu-2304",
+  "distribution_version": "2304",
+  "distro_name": "ubuntu",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "c7cda48494a6d7d9665964388a3fc9c824b3bef0c9ea3818a1be982bc80d346b",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://releases.ubuntu.com/23.04/ubuntu-23.04-live-server-amd64.iso",
+  "os_display_name": "Ubuntu 23.04",
+  "shutdown_command": "shutdown -P now",
+  "unmount_iso": "true"
+}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds RockyLinux 9 as well as Ubuntu 23.04 LTS support for QEMU.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
This PR adds support for Rocky Linux 9.2 and Ubuntu 23.04 LTS for QEMU CAPI.
@AverageMarcus F.Y.I.