### PR TITLE
Set Flatcar OS_TYPE as  other4xLinux64Guest

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -114,7 +114,7 @@ def main():
                  "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64Guest"},
                  "rockylinux-64": {"id": "80", "version": "", "type": "rockylinux_64Guest"},
                  "ubuntu-64": {"id": "94", "version": "", "type": "ubuntu64Guest"},
-                 "flatcar-64": {"id": "100", "version": "", "type": "other3xLinux64Guest"},
+                 "flatcar-64": {"id": "100", "version": "", "type": "other4xLinux64Guest"},
                  "Windows2019Server-64": {"id": "112", "version": "", "type": "windows2019srv_64Guest"}}
 
     # Create the OVF file.

--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -114,7 +114,7 @@ def main():
                  "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64Guest"},
                  "rockylinux-64": {"id": "80", "version": "", "type": "rockylinux_64Guest"},
                  "ubuntu-64": {"id": "94", "version": "", "type": "ubuntu64Guest"},
-                 "flatcar-64": {"id": "100", "version": "", "type": "otherLinux64Guest"},
+                 "flatcar-64": {"id": "100", "version": "", "type": "other3xLinux64Guest"},
                  "Windows2019Server-64": {"id": "112", "version": "", "type": "windows2019srv_64Guest"}}
 
     # Create the OVF file.

--- a/images/capi/packer/ova/flatcar.json
+++ b/images/capi/packer/ova/flatcar.json
@@ -21,5 +21,5 @@
   "systemd_prefix": "/etc/systemd",
   "sysusr_prefix": "/opt",
   "sysusrlocal_prefix": "/opt",
-  "vsphere_guest_os_type": "other3xLinux64Guest"
+  "vsphere_guest_os_type": "other4xLinux64Guest"
 }


### PR DESCRIPTION
vSphere gives an error while importing OVA file because of the template. I started a thread in the Kubernetes' Slack about this issue https://kubernetes.slack.com/archives/C01E0Q35A8J/p1698754064351559

~My understanding is the value should be `other3xLinux64Guest`.  I changed the OVF file of the image manually and tested importing. It worked. The value in upstream Flatcar repo is also `other3xLinux64Guest`. See https://github.com/flatcar/scripts/blob/main/build_library/template_vmware.ovf#L138~

See the discussions below.