### PR TITLE
Bump ansible-lint to v6.21.1

### DIFF
--- a/images/capi/.ansible-lint-ignore
+++ b/images/capi/.ansible-lint-ignore
@@ -15,7 +15,6 @@ ansible/roles/containerd/tasks/main.yml risky-file-permissions
 ansible/roles/containerd/tasks/photon.yml fqcn[action-core]
 ansible/roles/containerd/tasks/photon.yml no-changed-when
 ansible/roles/containerd/tasks/redhat.yml fqcn[action-core]
-ansible/roles/firstboot/meta/main.yml yaml[line-length]
 ansible/roles/firstboot/tasks/main.yaml fqcn[action-core]
 ansible/roles/firstboot/tasks/main.yaml name[missing]
 ansible/roles/firstboot/tasks/photon.yml fqcn[action-core]
@@ -38,7 +37,6 @@ ansible/roles/kubernetes/tasks/mariner.yml fqcn[action-core]
 ansible/roles/kubernetes/tasks/mariner.yml no-changed-when
 ansible/roles/kubernetes/tasks/photon.yml fqcn[action-core]
 ansible/roles/kubernetes/tasks/photon.yml no-changed-when
-ansible/roles/kubernetes/tasks/photon.yml yaml[line-length]
 ansible/roles/kubernetes/tasks/redhat.yml fqcn[action-core]
 ansible/roles/kubernetes/tasks/url.yml command-instead-of-shell
 ansible/roles/kubernetes/tasks/url.yml fqcn[action-core]
@@ -55,7 +53,6 @@ ansible/roles/load_additional_components/tasks/url.yml fqcn[action-core]
 ansible/roles/load_additional_components/tasks/url.yml no-changed-when
 ansible/roles/load_additional_components/tasks/url.yml risky-file-permissions
 ansible/roles/node/defaults/main.yml var-naming[no-role-prefix]
-ansible/roles/node/meta/main.yml yaml[line-length]
 ansible/roles/node/tasks/amazonLinux2.yml fqcn[action-core]
 ansible/roles/node/tasks/main.yml command-instead-of-module
 ansible/roles/node/tasks/main.yml fqcn[action-core]
@@ -126,7 +123,6 @@ ansible/roles/providers/tasks/vmware.yml name[missing]
 ansible/roles/python/defaults/main.yml var-naming[no-role-prefix]
 ansible/roles/python/tasks/flatcar.yml fqcn[action-core]
 ansible/roles/python/tasks/flatcar.yml no-changed-when
-ansible/roles/python/tasks/flatcar.yml yaml[line-length]
 ansible/roles/python/tasks/main.yml fqcn[action-core]
 ansible/roles/python/tasks/main.yml name[missing]
 ansible/roles/python/tasks/main.yml no-changed-when

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -181,11 +181,11 @@
 - name: Download runsc for gvisor
   ansible.builtin.get_url:
     dest: "{{ sysusr_prefix }}/bin/{{ item }}"
-    url: "https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_architecture }}/{{ item }}"
+    url: https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_architecture }}/{{ item }}
     mode: "0755"
     owner: root
     group: root
-    checksum: "sha512:https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_architecture }}/{{ item }}.sha512"
+    checksum: sha512:https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_architecture }}/{{ item }}.sha512
   loop:
     - runsc
     - containerd-shim-runsc-v1

--- a/images/capi/ansible/roles/firstboot/meta/main.yml
+++ b/images/capi/ansible/roles/firstboot/meta/main.yml
@@ -21,6 +21,9 @@ dependencies:
 
   - role: setup
     vars:
-      rpms: "{{ ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
+      rpms: >-
+        {{ ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') )
+          if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7')
+          else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
     when: packer_builder_type is search('qemu')

--- a/images/capi/ansible/roles/kubernetes/tasks/photon.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/photon.yml
@@ -21,4 +21,8 @@
 - name: Install Kubernetes
   command: tdnf install {{ packages }} --nogpgcheck -y
   vars:
-    packages: kubelet-{{ kubernetes_rpm_version }} kubeadm-{{ kubernetes_rpm_version }} kubectl-{{ kubernetes_rpm_version }} kubernetes-cni-{{ kubernetes_cni_rpm_version }}
+    packages: >-
+      kubelet-{{ kubernetes_rpm_version }}
+      kubeadm-{{ kubernetes_rpm_version }}
+      kubectl-{{ kubernetes_rpm_version }}
+      kubernetes-cni-{{ kubernetes_cni_rpm_version }}

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -115,8 +115,9 @@ common_raw_debs:
 common_raw_photon_rpms: []
 # photon and flatcar do not have backward compatibility for legacy distro behavior for sysctl.conf by default
 # as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.
-sysctl_conf_file: "{{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family in ['Common Base Linux Mariner', 'Flatcar', 'VMware Photon OS']
-  else '/etc/sysctl.conf' }}"
+sysctl_conf_file: >-
+  {{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family in ['Common Base Linux Mariner', 'Flatcar', 'VMware Photon OS']
+    else '/etc/sysctl.conf' }}
 
 pause_image: registry.k8s.io/pause:3.9
 containerd_additional_settings:

--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -27,16 +27,22 @@ dependencies:
 
   - role: setup
     vars:
-      rpms: "{{ (common_photon_rpms + lookup('vars', 'photon_' + ansible_distribution_major_version + '_rpms' ) + lookup('vars', 'common_' + build_target + '_photon_rpms')) }}"
+      rpms: >-
+        {{ (common_photon_rpms + lookup('vars', 'photon_' + ansible_distribution_major_version + '_rpms' )
+          + lookup('vars', 'common_' + build_target + '_photon_rpms')) }}
     when: ansible_distribution == "VMware Photon OS"
 
   - role: setup
     vars:
-      rpms: "{{ ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7') else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}"
+      rpms: >-
+        {{ ( ( common_rpms + rh7_rpms + lookup('vars', 'common_' + build_target + '_rpms') )
+          if (ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7')
+          else ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) ) }}
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
-    when: ansible_distribution not in ["VMware Photon OS", "Amazon"]
-      and not (packer_builder_type == "oracle-oci" and ansible_architecture == "aarch64")
-      and not packer_builder_type is search('qemu')
+    when: >
+      ansible_distribution not in ["VMware Photon OS", "Amazon"]
+        and not (packer_builder_type == "oracle-oci" and ansible_architecture == "aarch64")
+        and not packer_builder_type is search('qemu')
 
   - role: setup
     vars:

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -127,8 +127,7 @@
     state: started
     daemon_reload: true
     name: chronyd
-  when: (packer_builder_type.startswith('amazon')
-      or packer_builder_type.startswith('azure')
-      or packer_builder_type is search('vmware')
-      or packer_builder_type is search('vsphere'))
-    and ansible_os_family != "Flatcar"
+  when: >
+    (packer_builder_type.startswith('amazon') or packer_builder_type.startswith('azure')
+      or packer_builder_type is search('vmware') or packer_builder_type is search('vsphere'))
+      and ansible_os_family != "Flatcar"

--- a/images/capi/ansible/roles/python/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/python/tasks/flatcar.yml
@@ -19,9 +19,12 @@
 - name: Install pypy
   when:
     - pypy_installed.stdout_lines[0] == "false"
+  vars:
+    pypy_url_base: https://github.com/squeaky-pl/portable-pypy/releases/download/pypy{{ pypy_python_version }}-{{ pypy_version }}
+    pypy_url_path: pypy{{ pypy_python_version }}-{{ pypy_version }}-linux_x86_64-portable.tar.bz2
   block:
     - name: Download pypy archive
-      raw: curl https://github.com/squeaky-pl/portable-pypy/releases/download/pypy{{ pypy_python_version }}-{{ pypy_version }}/pypy{{ pypy_python_version }}-{{ pypy_version }}-linux_x86_64-portable.tar.bz2 -L --output {{ pypy_download_path }}
+      raw: curl {{ pypy_url_base }}/{{ pypy_url_path }} -L --output {{ pypy_download_path }}
     - name: Extract archive
       raw: tar -xjf {{ pypy_download_path }} -C {{ pypy_install_path }}
     - name: Rename pypy folder

--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -130,7 +130,7 @@
     path: HKLM:\SYSTEM\CurrentControlSet\Services\hns\State
     state: present
     name: HNSControlFlag
-    data: 0x50
+    data: 80
     type: dword
   when: distribution_version == "2019"
 

--- a/images/capi/hack/ensure-ansible-lint.sh
+++ b/images/capi/hack/ensure-ansible-lint.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="6.20.3"
+_version="6.21.1"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates ansible-lint to v6.21.1 and fixes some basic formatting issues so that `make lint-fix` is a no-op.

Which issue(s) this PR fixes:

Refs #1312

**Additional context**
