### PR TITLE
Add Goss output files to .gitignore

### DIFF
--- a/images/capi/.gitignore
+++ b/images/capi/.gitignore
@@ -7,3 +7,7 @@
 /.local/bin/
 manifest.json
 **.DS_Store
+
+# Goss test droppings
+debug-goss-spec.yaml
+goss-spec.yaml


### PR DESCRIPTION
What this PR does / why we need it:

Answers the question "How many times will you mistakenly check these log files in to version control before you add them to .gitignore?" 7. About seven is the answer.

Which issue(s) this PR fixes:

Fixes #

**Additional context**
