### PR TITLE
`make lint` runs shellcheck on shell scripts as well

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -184,6 +184,7 @@ deps-lint: ## Installs/checks dependencies for image-builder code linting
 deps-lint: deps-common
 	hack/ensure-ansible-windows.sh
 	hack/ensure-ansible-lint.sh
+	hack/ensure-shellcheck.sh
 
 ## --------------------------------------
 ## Container variables
@@ -967,8 +968,11 @@ validate-all: ## Validates the Packer config for all build targets
 
 .PHONY: lint
 lint: ## Runs linters on image-builder code
+sh_files = $(shell find . -type f -name "*.sh")
 lint: deps-lint
 	ansible-lint ansible/
+# ignore error code since shellcheck exits with Error 1 if problems are found despite running properly
+	-@for f in $(sh_files); do (shellcheck -x $$f); done
 
 .PHONY: lint-fix
 lint-fix: ## Runs linters on image-builder code and fixes issues

--- a/images/capi/hack/ensure-shellcheck.sh
+++ b/images/capi/hack/ensure-shellcheck.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+scversion="stable"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    operatingsystem="darwin.x86_64"
+else
+    operatingsystem="linux.x86_64"
+fi
+
+if command -v shellcheck >/dev/null 2>&1; then exit 0; fi
+
+wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.${operatingsystem?}.tar.xz" | tar -xJv
+cp "shellcheck-${scversion}/shellcheck" ~/.local/bin/
+rm -rf "./shellcheck-${scversion}"
+shellcheck --version


### PR DESCRIPTION
What this PR does / why we need it: This PR lets `make lint` run shellcheck on all shell scripts found recursively under images/capi, and adds an `ensure-shellcheck.sh` as well to automatically install the latest stable version of shellcheck.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1327

**Additional context**
First PR to this repo! Sorry for the wait on this.

I've implemented the solution as the issue specified. Unfortunately, shellcheck has no fixing mode, so yet another library such as [shfmt](https://github.com/mvdan/sh) may be called for in order to implement corresponding functionality for `make lint-fix`. If called for, I could implement that as a part of this PR, but I just wanted to get a version out with the requested solution first. (it was also after I implemented the shellcheck solution that I realized that shfmt has a mode to print out formatting errors it detects as well—perhaps fully using that is the way to go?)