### PR TITLE
Restore /etc/resolv.conf symlink on Flatcar CAPI Azure images

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -192,7 +192,7 @@
       ],
       "inline": [
         "if [[ $BUILD_NAME != \"flatcar\"* ]]; then exit 0; fi",
-        "sudo bash -c \"/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent -force -deprovision+user && sync\""
+        "sudo bash -c \"/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent -force -deprovision+user && ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf && sync\""
       ],
       "inline_shebang": "/bin/bash -x",
       "remote_folder": "{{user `provisioner_remote_folder`}}",


### PR DESCRIPTION
What this PR does / why we need it:

Restore `/etc/resolv.conf` symlink after waagent deprovisioning on Flatcar so built images have proper DNS resolution until https://github.com/flatcar/Flatcar/issues/1265 is addressed.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 
Closes #1346
