### PR TITLE
Install linux-modules-extra-azure to work around CIFS bug

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -79,3 +79,15 @@
     group: root
     mode: "0644"
   when: ansible_os_family == "Debian"
+
+# Temporary workaround for a kernel bug that stopped CIFS from working.
+# See https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/2042092.
+- name: Install linux-modules-extra-azure
+  apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: true
+  vars:
+    packages:
+      - linux-modules-extra-azure
+  when: ansible_os_family == "Debian"


### PR DESCRIPTION
What this PR does / why we need it:

A recent Ubuntu upgrade broke the expected path configuration for CIFS, causing problems downstream for azure-file-* projects that use CAPZ in testing. This works around the issue for now by installing the `linux-modules-extra-azure` package which provides the kernel module in a supported configuration.

See https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/2042092 for details.

This should be reverted when the 6.2.0-1017-azure kernel is distributed (probably second week of December).

Which issue(s) this PR fixes:

N/A

**Additional context**
