### PR TITLE
Update containerd to 1.7.10

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -3,7 +3,7 @@
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
   "containerd_gvisor_runtime": "false",
   "containerd_gvisor_version": "latest",
-  "containerd_sha256": "20da1f2252d2033594b06e1eb68dd4906ff439f83f1003b7ebacdffcb4b95bdc",
-  "containerd_sha256_windows": "76595c69bfb21871de3c6537c7bf85a7e494bd13310e3ecb991a176c87d6ce2f",
-  "containerd_version": "1.7.6"
+  "containerd_sha256": "38fce887eafe047571d9cdd0f1cc768315af5a68ab2d1726ab3cd0d43dd77377",
+  "containerd_sha256_windows": "a334db85f8a8d54441c38087ecbfe9b62db54cbf2cb8b43276682923976202bb",
+  "containerd_version": "1.7.10"
 }

--- a/images/capi/packer/config/ppc64le/containerd.json
+++ b/images/capi/packer/config/ppc64le/containerd.json
@@ -1,5 +1,5 @@
 {
-  "containerd_sha256": "66993b13221e1ecab8e8e799025320fe74d9741ae4a99a74bd45dbd081c30a98",
+  "containerd_sha256": "d4947b6d33c720db924fb49f8ec5022e7dbcff9d04d3bea6ebd1310e7706fa2b",
   "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-ppc64le.tar.gz",
-  "containerd_version": "1.7.6"
+  "containerd_version": "1.7.10"
 }


### PR DESCRIPTION
What this PR does / why we need it:

This PR updates containerd to 1.7.10

Release notes: https://github.com/containerd/containerd/releases/tag/v1.7.10

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers