### PR TITLE
Revert "Install linux-modules-extra-azure to work around CIFS bug"

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -79,15 +79,3 @@
     group: root
     mode: "0644"
   when: ansible_os_family == "Debian"
-
-# Temporary workaround for a kernel bug that stopped CIFS from working.
-# See https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/2042092.
-- name: Install linux-modules-extra-azure
-  apt:
-    name: "{{ packages }}"
-    state: present
-    force_apt_get: true
-  vars:
-    packages:
-      - linux-modules-extra-azure
-  when: ansible_os_family == "Debian"


### PR DESCRIPTION
What this PR does / why we need it:

This reverts commit 456428ea49cdc13e535fefc3753bb781e7400f1c.

The workaround implemented in #1348 is no longer needed since a newer kernel has proper paths and packaging for the CIFS module.

Which issue(s) this PR fixes: 

N/A

**Additional context**

See https://bugs.launchpad.net/ubuntu/+source/linux-azure/+bug/2042092 for details.