### PR TITLE
Bump ansible-core to v2.16.1

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.15.4"
+_version="2.16.1"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates the `ansible-core` package to [v2.16.1](https://github.com/ansible/ansible/releases/tag/v2.16.1).

I looked through the v2.16.0 and v2.16.1 release notes and didn't see anything that looks breaking, but please do double-check me. I've also built some images with this and didn't see any problems.

Which issue(s) this PR fixes:

N/A
