### PR TITLE
Bump packer to v1.9.5

### DIFF
--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -21,7 +21,7 @@ set -o pipefail
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
 # **DO NOT** change the Packer version unless it is available under MPL v2.0.
-_version="1.9.4"
+_version="1.9.5"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates packer to the latest [v1.9.5 release](https://github.com/hashicorp/packer/releases/tag/v1.9.5).


Which issue(s) this PR fixes:

Refs #1246

**Additional context**

This packer release is still using the Mozilla license, but [v1.10.0 is not](https://github.com/hashicorp/packer/blob/v1.10.0/LICENSE).
