### PR TITLE
Bump ansible-core to v2.15.8

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,7 +22,8 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="2.16.1"
+# Note: ansible-core v2.16.x requires Python >= 3.10.
+_version="2.15.8"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates / downgrades `ansible-core` to version [v2.15.8](https://github.com/ansible/ansible/releases/tag/v2.15.8), to maintain compatibility with python 3.9.

Which issue(s) this PR fixes:

See #1357

**Additional context**

Apologies for the whiplash: I hadn't noticed that ansible 2.16.x requires Python 3.10, but image-builder's `ensure-python.sh` script requires only 3.9. Since we tripped up some users by requiring a newer python previously, let's stick with the more backward-compatible release for now.