### PR TITLE
Add QEMU Support for CentOS 9 Stream

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -368,7 +368,7 @@ OPENSTACK_BUILD_NAMES	?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-f
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2304 qemu-ubuntu-2204-efi qemu-centos-7 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-rockylinux-9 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2304 qemu-ubuntu-2204-efi qemu-centos-7 qemu-centos-9 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rockylinux-8 qemu-rockylinux-9 qemu-flatcar
 
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
@@ -768,6 +768,7 @@ build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
 build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
 build-qemu-ubuntu-2304: ## Builds Ubuntu 23.04 QEMU image
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
+build-qemu-centos-9: ## Builds CentOS 9 Stream QEMU image
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
 build-qemu-rockylinux-9: ## Builds Rocky 9 QEMU image

--- a/images/capi/packer/qemu/linux/centos/http/9/ks.cfg
+++ b/images/capi/packer/qemu/linux/centos/http/9/ks.cfg
@@ -1,0 +1,73 @@
+# version=RHEL9
+# Install OS instead of upgrade
+cdrom
+authselect --enableshadow --passalgo=sha512 --kickstart
+# License agreement
+eula --agreed
+# Use text mode install
+text
+# Disable Initial Setup on first boot
+firstboot --disable
+# Keyboard layout
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network --bootproto=dhcp --device=link --activate
+network --hostname=centos9
+firewall --disabled
+# Root password
+rootpw builder --plaintext
+# SELinux configuration
+selinux --permissive
+# Do not configure the X Window System
+skipx
+# System timezone
+timezone UTC
+# Add a user named builder
+user --groups=wheel --name=builder --password=builder --plaintext --gecos="builder"
+
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=sda
+# Clear the Master Boot Record
+zerombr
+clearpart --all --initlabel --drives=sda
+part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+
+# Reboot after successful installation
+reboot
+
+%packages --ignoremissing --excludedocs
+# dnf group info minimal-environment
+@^minimal-environment
+@core
+openssh-server
+sed
+sudo
+python3
+
+# Exclude unnecessary firmwares
+-iwl*firmware
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+%post --nochroot --logfile=/mnt/sysimage/root/ks-post.log
+# Disable quiet boot and splash screen
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/etc/default/grub
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/boot/grub2/grubenv
+
+# Passwordless sudo for the user 'builder'
+echo "builder ALL=(ALL) NOPASSWD: ALL" >> /mnt/sysimage/etc/sudoers.d/builder
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/qemu/qemu-centos-9.json
+++ b/images/capi/packer/qemu/qemu-centos-9.json
@@ -1,0 +1,19 @@
+{
+  "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python extra_arguments =vvvv",
+  "boot_command_prefix": "<tab> text inst.ks=",
+  "boot_command_suffix": "/9/ks.cfg<enter><wait><enter>",
+  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+  "build_name": "centos-9",
+  "distribution_version": "9",
+  "distro_arch": "amd64",
+  "distro_name": "centos",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "guest_os_type": "centos9-64",
+  "iso_checksum": "2080b8ff7b4bd06982323a8bf3d1c030678b48656e5c6d12e79c22a838e2490e",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20231211.0-x86_64-dvd1.iso",
+  "os_display_name": "CentOS 9 Stream",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "/sbin/halt -h -p"
+}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds Centos 9 Stream support for QEMU.

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

Additional context
This PR adds support for Centos 9 Stream for QEMU CAPI.