### PR TITLE
Simplify installation of az CLI on Windows

### DIFF
--- a/images/capi/ansible/windows/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/azure.yml
@@ -46,17 +46,7 @@
   vars:
     users: "{{ wire_server_users.split(',') if (wire_server_users is defined) and (wire_server_users | length > 0) else [] }}"
 
-- name: Download Azure CLI MSI installer
-  ansible.windows.win_get_url:
-    url: https://aka.ms/installazurecliwindowsx64
-    dest: C:\azure-cli.msi
-
 - name: Install Azure CLI
   ansible.windows.win_package:
-    path: C:\azure-cli.msi
+    path: https://aka.ms/installazurecliwindowsx64
     state: present
-
-- name: Clean up Azure CLI Installer file
-  ansible.windows.win_file:
-    path: C:\azure-cli.msi
-    state: absent


### PR DESCRIPTION
What this PR does / why we need it:

Simplifies installation of the `az` CLI on Windows, which after initial testing seems to be more reliable than the download -> install -> delete approach image-builder currently uses.

Which issue(s) this PR fixes:
Fixes #1355

**Additional context**
Add any other context for the reviewers