### PR TITLE
Delete all rotated logs

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -198,10 +198,10 @@
       find /var/log -type f -iname '*.log' | xargs truncate -s 0
   when: ansible_os_family != "Flatcar"
 
-- name: Delete all logrotated log zips
+- name: Delete all logrotated logs
   shell:
     cmd: |
-      find /var/log -type f -name '*.gz' -exec rm {} +
+      find /var/log -type f -regex '.*[0-9z]$' -exec rm {} +
   when: ansible_os_family != "Flatcar"
 
 - name: Remove swapfile


### PR DESCRIPTION
What this PR does / why we need it:

This regex matches the folllowing patterns found in ubuntu, centos, rhel

```bash
messages-20231224
cloud-init.log.gz.2
dnf.log.1
script_exporter_setup.log-20231215.xz
client.log-20231119.gz
```


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Fixes #381 

**Additional context**

Find uses by default `Emacs Regular Expressions` [docs](https://man7.org/linux/man-pages/man1/find.1.html) to to avoid use complex cases like `([0-9]$|gz$)` I went with a more minimalist approach. 

* https://www.gnu.org/software/emacs/manual/html_node/emacs/Regexps.html