### PR TITLE
Rockylinux image download fix

### DIFF
--- a/images/capi/packer/qemu/qemu-rockylinux-8.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-8.json
@@ -8,9 +8,9 @@
   "distro_version": "8",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
   "guest_os_type": "centos8-64",
-  "iso_checksum": "4ce0948699a26f66dffd705c0459d428439cef02d5db43d36a6ae62ba494fe9e",
+  "iso_checksum": "06019fd7c4f956b2b0ed37393e81c577885e4ebd518add249769846711a09dc4",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.8-x86_64-minimal.iso",
+  "iso_url": "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.9-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 8",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"

--- a/images/capi/packer/qemu/qemu-rockylinux-9.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-9.json
@@ -8,9 +8,9 @@
   "distro_version": "9",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
   "guest_os_type": "centos9-64",
-  "iso_checksum": "06505828e8d5d052b477af5ce62e50b938021f5c28142a327d4d5c075f0670dc",
+  "iso_checksum": "eef8d26018f4fcc0dc101c468f65cbf588f2184900c556f243802e9698e56729",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.2-x86_64-minimal.iso",
+  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.3-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 9",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"


### PR DESCRIPTION
This PR fixes the rockylinux image download links.

The versions 9.2 and 8.8 have been replaced by 9.3 and 8.9 in stable releases.

https://download.rockylinux.org/pub/rocky/8/isos/x86_64/
https://download.rockylinux.org/pub/rocky/9/isos/x86_64/