### PR TITLE
Fix: Correctly parse Ansible version in ensure-ansible.sh

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -38,18 +38,24 @@ if ! command -v ansible >/dev/null 2>&1; then
     ensure_py3_bin ansible-playbook
 fi
 
-ansible_version=""
-IFS=" " read -ra ansible_version <<< "$(ansible --version)"
-if [[ "${_version}" != $(echo -e "${_version}\n${ansible_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${ansible_version[2]}" != "devel" ]]; then
+# Get Ansible version
+ansible_version_line=$(ansible --version | head -n1)
+IFS=" " read -ra ansible_version <<< "$ansible_version_line"
+
+# Extract just the version number (e.g., "2.10.8")
+version_number=${ansible_version[1]}
+
+# Your existing version comparison logic, with "version_number" instead of "ansible_version[2]"
+if [[ "${_version}" != $(echo -e "${_version}\n${version_number}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${version_number}" != "devel" ]]; then
   cat <<EOF
-Detected ansible version: ${ansible_version[*]}.
+Detected ansible version: ${version_number}.
 Image builder requires ${_version} or greater.
 Please install ${_version} or later.
 EOF
   exit 2
 fi
 
-echo ${ansible_version[*]}
+echo ${version_number}
 
 ansible-galaxy collection install \
   community.general \


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR corrects the Ansible version parsing in the `ensure-ansible.sh` script. Previously, the script erroneously identified the version as the third word in `ansible --version` output, causing 'unbound variable' errors. Now, it accurately captures the version as the second element, ensuring compatibility across various output formats and preventing errors.

**Before:**
```
make build-qemu-ubuntu-2204
hack/ensure-python.sh
Checking if python is available
Python 3.10.12
hack/ensure-ansible.sh
hack/ensure-ansible.sh: line 43: ansible_version[2]: unbound variable
hack/ensure-ansible.sh: line 43: ansible_version[2]: unbound variable
make: *** [Makefile:60: deps-common] Error 1
```

**After:**
```
make build-qemu-ubuntu-2204
hack/ensure-python.sh
Checking if python is available
Python 3.10.12
hack/ensure-ansible.sh
Detected ansible version: 2.10.8.
Image builder requires 2.15.8 or greater.
Please install 2.15.8 or later.
make: *** [Makefile:60: deps-common] Error 2
```

**Additional context:**
The issue was notably persistent across environments with different Ansible output formats. This adjustment standardizes version detection, improving script functionality and reliability for a broader user base.