### PR TITLE
Update docs after v0.1.22 release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,11 @@
 # Image Builder Releases
 
-The current release of Image Builder is [v0.1.21][] (November 16, 2023). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21`.
+The current release of Image Builder is [v0.1.22][] (January 15, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22`.
 
 ## Release Process
 
 For more detail about image-builder project releases, see the [Image Builder Book][].
 
 
-[v0.1.21]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.21
+[v0.1.22]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.22
 [Image Builder Book]: https://image-builder.sigs.k8s.io/capi/releasing.html

--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -18,7 +18,7 @@ Run the docker build target of Makefile
 The latest image-builder container image release is available here:
 
 ```commandline
-docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21
+docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22
 ```
 
 ### Examples
@@ -27,7 +27,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     - If the AWS CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials.
 
     ```commandline
-    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21 build-ami-ubuntu-2004
+    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-ami-ubuntu-2004
     ```
     - Another alternative is to use an `aws-creds.env` file to load the credentials and pass it during docker run.
 
@@ -38,7 +38,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```
 
     ```commandline
-        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21 build-ami-ubuntu-2004
+        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-ami-ubuntu-2004
     ```
 
 - AZURE
@@ -53,7 +53,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```
 
     ```commandline
-    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21 build-azure-sig-ubuntu-2004
+    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-azure-sig-ubuntu-2004
     ```
 
 - vSphere OVA
@@ -62,7 +62,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the Docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
 
     ```commandline
-    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21 build-node-ova-vsphere-ubuntu-2004
+    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-node-ova-vsphere-ubuntu-2004
     ```
 
 In addition to this, further customizations can be done as discussed [here](./capi.md#customization).

--- a/docs/book/src/capi/releasing.md
+++ b/docs/book/src/capi/releasing.md
@@ -1,6 +1,6 @@
 # Image Builder Releases
 
-The current release of Image Builder is [v0.1.21][] (November 16, 2023). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.21`.
+The current release of Image Builder is [v0.1.22][] (Januarty 15, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22`.
 
 ## Release Process
 
@@ -78,7 +78,7 @@ Image-builder v0.1.22 is now available: https://github.com/kubernetes-sigs/image
 Thanks to all contributors!
 ```
 
-[v0.1.21]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.21
+[v0.1.22]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.22
 [#image-builder channel]: https://kubernetes.slack.com/archives/C01E0Q35A8J
 [Personal access tokens]: https://github.com/settings/tokens
 [pr-container-image-build]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-builder#pr-container-image-build


### PR DESCRIPTION
What this PR does / why we need it:

Updates the docs with the latest release versions bumped, as described in the [release documentation](https://image-builder.sigs.k8s.io/capi/releasing.html#update-documentation).

Which issue(s) this PR fixes:

N/A