### PR TITLE
CAPI: Add kubeadm KUBECONFIG and k8s bash completion

### DIFF
--- a/images/capi/ansible/roles/kubernetes/files/etc/profile.d/kubernetes.sh
+++ b/images/capi/ansible/roles/kubernetes/files/etc/profile.d/kubernetes.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=sh disable=SC2166,SC2157,SC3044
+
+# Check for interactive bash
+if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" ]; then
+  ADMIN_CONF=/etc/kubernetes/admin.conf
+  SUPER_ADMIN_CONF=/etc/kubernetes/super-admin.conf
+
+  if [ -r "${SUPER_ADMIN_CONF}" ]; then
+    export KUBECONFIG="${SUPER_ADMIN_CONF}"
+  elif [ -r "${ADMIN_CONF}" ]; then
+    export KUBECONFIG="${ADMIN_CONF}"
+  fi
+
+  alias k=kubectl
+  __load_completion kubectl >/dev/null 2>&1 || true
+  complete -F __start_kubectl k 2>/dev/null || true
+fi

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -92,6 +92,32 @@
     mode: "0644"
   when: kubernetes_enable_automatic_resource_sizing
 
+- name: Generate kubectl bash completion
+  shell:
+    cmd: "{{ sysusr_prefix }}/bin/kubectl completion bash > {{ sysusr_prefix }}/share/bash-completion/completions/kubectl"
+    creates: "{{ sysusr_prefix }}/share/bash-completion/completions/kubectl"
+  when: ansible_os_family != "Flatcar"
+
+- name: Generate kubeadm bash completion
+  shell:
+    cmd: "{{ sysusr_prefix }}/bin/kubeadm completion bash > {{ sysusr_prefix }}/share/bash-completion/completions/kubeadm"
+    creates: "{{ sysusr_prefix }}/share/bash-completion/completions/kubeadm"
+  when: ansible_os_family != "Flatcar"
+
+- name: Generate crictl bash completion
+  shell:
+    cmd: "{{ sysusr_prefix }}/bin/crictl completion bash > {{ sysusr_prefix }}/share/bash-completion/completions/crictl"
+    creates: "{{ sysusr_prefix }}/share/bash-completion/completions/crictl"
+  when: ansible_os_family != "Flatcar"
+
+- name: Set KUBECONFIG variable and alias
+  copy:
+    dest: /etc/profile.d/kubernetes.sh
+    src: etc/profile.d/kubernetes.sh
+    owner: root
+    group: root
+    mode: "0644"
+
 # TODO: This section will be deprecated once https://github.com/containerd/cri/issues/1131 is fixed. It is used to support ECR with containerd.
 - name: Check if Kubernetes container registry is using Amazon ECR
   set_fact:


### PR DESCRIPTION
What this PR does / why we need it:

Just a little quality of life improvement...

Add bash completion for kubectl, kubeadm and crictl.

If an interactive shell is detected and the kubeadm
admin confs are accessible, sets up the KUBECONFIG env
var.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers