### PR TITLE
Use openvpn from community-owned registry

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -84,7 +84,7 @@ cat packer/ova/packer-node.json | jq  'del(."post-processors"[])' > packer/ova/p
 # Run the vpn client in container
 docker run --rm -d --name vpn -v "${HOME}/.openvpn/:${HOME}/.openvpn/" \
   -w "${HOME}/.openvpn/" --cap-add=NET_ADMIN --net=host --device=/dev/net/tun \
-  gcr.io/cluster-api-provider-vsphere/extra/openvpn:latest
+  gcr.io/k8s-staging-capi-vsphere/extra/openvpn:latest
 
 # Tail the vpn logs
 docker logs vpn


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

What this PR does / why we need it:
The previous image was hosted on a registry owned by VMware. I moved the image to a community-owned registry

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

**Additional context**
Add any other context for the reviewers