### PR TITLE
Set root make targets to default to images/capi/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Display this help and the help for images/capi/Makefile
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-35s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@echo
+	@echo Targets handled by images/capi/Makefile:
+	@$(MAKE) -C images/capi help
+
 .PHONY: build-book
-build-book:
+build-book: ## Build the image-builder book
 	docs/book/build.sh
 
 .PHONY: serve-book
-serve-book: ## Build and serve the book with live-reloading enabled
+serve-book: ## Build and serve the image-builder book with live-reloading enabled
 	$(MAKE) -C docs/book serve
+
+.DEFAULT:
+	$(MAKE) -C images/capi $@


### PR DESCRIPTION
What this PR does / why we need it:

If a `make` command doesn't match a target in the root `Makefile`, pass it off to `images/capi/Makefile` where the real project contents are.

Basically I got tired of typing `make -C images/capi blahblah` all the time, so I wanted to revisit the idea of "proxying" commands to the "real" `Makefile` without having to restructure the project.

Which issue(s) this PR fixes:

N/A

**Additional context**
