### PR TITLE
Use specific CNI package only if defined

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/debian.yml
@@ -33,4 +33,4 @@
       - kubelet={{ kubernetes_deb_version }}
       - kubeadm={{ kubernetes_deb_version }}
       - kubectl={{ kubernetes_deb_version }}
-      - kubernetes-cni={{ kubernetes_cni_deb_version }}
+      - kubernetes-cni{{ '='+kubernetes_cni_deb_version if kubernetes_cni_deb_version else '' }}

--- a/images/capi/ansible/roles/kubernetes/tasks/mariner.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/mariner.yml
@@ -31,7 +31,7 @@
       - kubelet-{{ kubernetes_rpm_version }}
       - kubeadm-{{ kubernetes_rpm_version }}
       - kubectl-{{ kubernetes_rpm_version }}
-      - kubernetes-cni-{{ kubernetes_cni_rpm_version }}
+      - kubernetes-cni{{ '-'+kubernetes_cni_rpm_version if kubernetes_cni_rpm_version else '' }}
 
 - name: Allow Kubernetes API server through iptables
   iptables:

--- a/images/capi/ansible/roles/kubernetes/tasks/photon.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/photon.yml
@@ -25,4 +25,4 @@
       kubelet-{{ kubernetes_rpm_version }}
       kubeadm-{{ kubernetes_rpm_version }}
       kubectl-{{ kubernetes_rpm_version }}
-      kubernetes-cni-{{ kubernetes_cni_rpm_version }}
+      kubernetes-cni{{ '-'+kubernetes_cni_rpm_version if kubernetes_cni_rpm_version else '' }}

--- a/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
@@ -31,4 +31,4 @@
       - kubelet-{{ kubernetes_rpm_version }}
       - kubeadm-{{ kubernetes_rpm_version }}
       - kubectl-{{ kubernetes_rpm_version }}
-      - kubernetes-cni-{{ kubernetes_cni_rpm_version }}
+      - kubernetes-cni{{ '-'+kubernetes_cni_rpm_version if kubernetes_cni_rpm_version else '' }}

--- a/images/capi/hack/generate-goss-specs.py
+++ b/images/capi/hack/generate-goss-specs.py
@@ -103,7 +103,7 @@ def main():
     cni = read_json_file(os.path.join(root_path, 'packer', 'config', 'cni.json'))
     versions['cni'] = cni['kubernetes_cni_semver'].lstrip('v')
     versions['cni_deb'] = cni['kubernetes_cni_deb_version']
-    versions['cni_rpm'] = cni['kubernetes_cni_rpm_version'].split('-')[0]
+    versions['cni_rpm'] = cni['kubernetes_cni_rpm_version'].split('-')[0] if cni['kubernetes_cni_rpm_version'] else None
 
     k8s = read_json_file(os.path.join(root_path, 'packer', 'config', 'kubernetes.json'))
     versions['k8s'] = k8s['kubernetes_semver'].lstrip('v')
@@ -144,14 +144,14 @@ def main():
             elif system == 'photon':
                 runtimes = ["containerd"]
                 os_versions = ["3", "4", "5"]
-            else: 
+            else:
                 runtimes = ["containerd"]
                 os_versions = [""]
             for runtime in runtimes:
                 for version in os_versions:
                     versions["os"] = version
                     generate_goss(provider, system, versions, runtime, args.dry_run, args.write)
-            
+
 
 if __name__ == '__main__':
     main()

--- a/images/capi/packer/config/cni.json
+++ b/images/capi/packer/config/cni.json
@@ -1,9 +1,9 @@
 {
-  "kubernetes_cni_deb_version": "1.2.0-2.1",
-  "kubernetes_cni_http_checksum": "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-{{user `kubernetes_cni_http_checksum_arch`}}-v1.2.0.tgz.sha256",
+  "kubernetes_cni_deb_version": null,
+  "kubernetes_cni_http_checksum": "sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/{{ user `kubernetes_cni_semver` }}/cni-plugins-linux-{{ user `kubernetes_cni_http_checksum_arch` }}-{{ user `kubernetes_cni_semver` }}.tgz.sha256",
   "kubernetes_cni_http_checksum_arch": "amd64",
   "kubernetes_cni_http_source": "https://github.com/containernetworking/plugins/releases/download",
-  "kubernetes_cni_rpm_version": "1.2.0",
+  "kubernetes_cni_rpm_version": null,
   "kubernetes_cni_semver": "v1.2.0",
   "kubernetes_cni_source_type": "pkg"
 }

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -9,11 +9,13 @@ kubernetes_version: &kubernetes_version
 
 kubernetes_cni_version: &kubernetes_cni_version
   versions:
+{{ if or .Vars.kubernetes_cni_deb_version .Vars.kubernetes_cni_rpm_version }}
     or:
       - contain-element:
           match-regexp: "^\\Q{{ .Vars.kubernetes_cni_deb_version }}\\E$"
       - contain-element:
           match-regexp: "^\\Q{{ .Vars.kubernetes_cni_rpm_version }}\\E$"
+{{ end }}
 
 package:
 # Flatcar uses Ignition instead of cloud-init


### PR DESCRIPTION
What this PR does / why we need it:

For RPM- and deb-based distros, fixes the "which version of CNI goes with this version of Kubernetes?" problem by removing the specific cni version package by default, allowing the package manager to choose a compatible version.

This *should* be backward-compatible in that it will continue to request a specific CNI package version if that variable is specified by the user.

Which issue(s) this PR fixes:

Fixes #1363
Fixes #1196

**Additional context**

I'm not sure `null`-ing out these two variables and adding a bit of conditional python is the cleanest way to handle this: ideas welcome! I guess one alternative would be to remove these two variables entirely.

Make targets that build kubernetes from source should be able to override several variables to achieve v1.29+ builds, but will need to have knowledge already about which CNI version matches up.

I have tried this successfully with k8s v1.26.7 and v1.29.1.

See also https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#what-are-significant-differences-between-the-google-hosted-and-kubernetes-package-repositories