### PR TITLE
Rocky LInux 9 OVA

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -319,7 +319,7 @@ CENTOS_VERSIONS			:=	centos-7
 FLATCAR_VERSIONS		:=	flatcar
 PHOTON_VERSIONS			:=	photon-3 photon-4 photon-5
 RHEL_VERSIONS			:=	rhel-7 rhel-8
-ROCKYLINUX_VERSIONS     :=  rockylinux-8
+ROCKYLINUX_VERSIONS		:=  rockylinux-8 rockylinux-9
 UBUNTU_VERSIONS			:=	ubuntu-2004 ubuntu-2004-efi ubuntu-2204 ubuntu-2204-efi
 WINDOWS_VERSIONS		:=	windows-2019 windows-2022
 
@@ -692,6 +692,7 @@ build-node-ova-local-photon-5: ## Builds Photon 5 Node OVA w local hypervisor
 build-node-ova-local-rhel-7: ## Builds RHEL 7 Node OVA w local hypervisor
 build-node-ova-local-rhel-8: ## Builds RHEL 8 Node OVA w local hypervisor
 build-node-ova-local-rockylinux-8: ## Builds RockyLinux 8 Node OVA w local hypervisor
+build-node-ova-local-rockylinux-9: ## Builds RockyLinux 9 Node OVA w local hypervisor
 build-node-ova-local-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA w local hypervisor
 build-node-ova-local-windows-2019: ## Builds for Windows Server 2019 Node OVA w local hypervisor
 build-node-ova-local-all: $(NODE_OVA_LOCAL_BUILD_TARGETS) ## Builds all Node OVAs w local hypervisor
@@ -704,6 +705,7 @@ build-node-ova-vsphere-photon-5: ## Builds Photon 5 Node OVA and template on vSp
 build-node-ova-vsphere-rhel-7: ## Builds RHEL 7 Node OVA and template on vSphere
 build-node-ova-vsphere-rhel-8: ## Builds RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
+build-node-ova-vsphere-rockylinux-9: ## Builds RockyLinux 9 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
 build-node-ova-vsphere-ubuntu-2004-efi: ## Builds Ubuntu 20.04 Node OVA and template on vSphere that EFI boots
 build-node-ova-vsphere-ubuntu-2204: ## Builds Ubuntu 22.04 Node OVA and template on vSphere
@@ -719,6 +721,7 @@ build-node-ova-vsphere-clone-photon-5: ## Builds Photon 5 Node OVA and template 
 build-node-ova-vsphere-clone-rhel-7: ## Builds RHEL 7 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-rhel-8: ## Builds RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-rockylinux-8: ## Builds RockyLinux 8 Node OVA and template on vSphere
+build-node-ova-vsphere-clone-rockylinux-9: ## Builds RockyLinux 9 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2204: ## Builds Ubuntu 22.04 Node OVA and template on vSphere
 build-node-ova-vsphere-clone-ubuntu-2204-efi: ## ## Builds Ubuntu 22.04 Node OVA and template on vSphere that EFI boots
@@ -731,6 +734,7 @@ build-node-ova-vsphere-base-photon-5: ## Builds base Photon 5 Node OVA and templ
 build-node-ova-vsphere-base-rhel-7: ## Builds base RHEL 7 Node OVA and template on vSphere
 build-node-ova-vsphere-base-rhel-8: ## Builds base RHEL 8 Node OVA and template on vSphere
 build-node-ova-vsphere-base-rockylinux-8: ## Builds base RockyLinux 8 Node OVA and template on vSphere
+build-node-ova-vsphere-base-rockylinux-9: ## Builds base RockyLinux 9 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2004: ## Builds base Ubuntu 20.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2204: ## Builds base Ubuntu 22.04 Node OVA and template on vSphere
 build-node-ova-vsphere-base-ubuntu-2204-efi: ## Builds Ubuntu 22.04 Node OVA and template on vSphere that EFI boots
@@ -743,6 +747,7 @@ build-node-ova-local-vmx-centos-7: ## Builds Centos 7 Node OVA from VMX file w l
 build-node-ova-local-vmx-rhel-7: ## Builds RHEL 7 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-rhel-8: ## Builds RHEL 8 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-rockylinux-8: ## Builds RockyLinux 8 Node OVA from VMX file w local hypervisor
+build-node-ova-local-vmx-rockylinux-9: ## Builds RockyLinux 9 Node OVA from VMX file w local hypervisor
 build-node-ova-local-vmx-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA from VMX file w local hypervisor
 
 build-node-ova-local-base-photon-3: ## Builds Photon 3 Base Node OVA w local hypervisor
@@ -752,6 +757,7 @@ build-node-ova-local-base-centos-7: ## Builds Centos 7 Base Node OVA w local hyp
 build-node-ova-local-base-rhel-7: ## Builds RHEL 7 Base Node OVA w local hypervisor
 build-node-ova-local-base-rhel-8: ## Builds RHEL 8 Base Node OVA w local hypervisor
 build-node-ova-local-base-rockylinux-8: ## Builds RockyLinux 8 Base Node OVA w local hypervisor
+build-node-ova-local-base-rockylinux-9: ## Builds RockyLinux 9 Base Node OVA w local hypervisor
 build-node-ova-local-base-ubuntu-2004: ## Builds Ubuntu 20.04 Base Node OVA w local hypervisor
 
 build-openstack-ubuntu-2004: ## Builds Ubuntu 20.04 OpenStack image
@@ -872,6 +878,7 @@ validate-node-ova-local-photon-5: ## Validates Photon 5 Node OVA Packer config w
 validate-node-ova-local-rhel-7: ## Validates RHEL 7 Node OVA Packer config w local hypervisor
 validate-node-ova-local-rhel-8: ## Validates RHEL 8 Node OVA Packer config w local hypervisor
 validate-node-ova-local-rockylinux-8: ## Validates RockyLinux 8 Node OVA Packer config w local hypervisor
+validate-node-ova-local-rockylinux-9: ## Validates RockyLinux 9 Node OVA Packer config w local hypervisor
 validate-node-ova-local-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA Packer config w local hypervisor
 validate-node-ova-local-ubuntu-2204: ## Validates Ubuntu 22.04 Node OVA Packer config w local hypervisor
 validate-node-ova-local-windows-2019: ## Validates Windows Server 2019 Node OVA Packer config w local hypervisor
@@ -885,6 +892,7 @@ validate-node-ova-local-vmx-centos-7: ## Validates Centos 7 Node OVA from VMX fi
 validate-node-ova-local-vmx-rhel-7: ## Validates RHEL 7 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-rhel-8: ## Validates RHEL 8 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-rockylinux-8: ## Validates RockyLinux 8 Node OVA from VMX file w local hypervisor
+validate-node-ova-local-vmx-rockylinux-9: ## Validates RockyLinux 9 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-ubuntu-2004: ## Validates Ubuntu 20.04 Node OVA from VMX file w local hypervisor
 validate-node-ova-local-vmx-ubuntu-2204: ## Validates Ubuntu 22.04 Node OVA from VMX file w local hypervisor
 
@@ -895,6 +903,7 @@ validate-node-ova-local-base-centos-7: ## Validates Centos 7 Base Node OVA w loc
 validate-node-ova-local-base-rhel-7: ## Validates RHEL 7 Base Node OVA w local hypervisor
 validate-node-ova-local-base-rhel-8: ## Validates RHEL 8 Base Node OVA w local hypervisor
 validate-node-ova-local-base-rockylinux-8: ## Validates RockyLinux 8 Base Node OVA w local hypervisor
+validate-node-ova-local-base-rockylinux-9: ## Validates RockyLinux 9 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-2004: ## Validates Ubuntu 20.04 Base Node OVA w local hypervisor
 validate-node-ova-local-base-ubuntu-2204: ## Validates Ubuntu 22.04 Base Node OVA w local hypervisor
 

--- a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
@@ -21,7 +21,15 @@
     packages:
       - cloud-init
       - cloud-utils-growpart
+
+- name: Install python2 pip
+  yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
       - python2-pip
+  when: ansible_distribution_major_version|int <= 8
 
 # pip on CentOS needs to be upgraded, but since it's still
 # Python 2.7, need < 21.0

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -28,6 +28,11 @@ rh8_rpms: &rh8_rpms
   python3-netifaces:
   python3-requests:
 
+rh9_rpms: &rh9_rpms
+  nftables:
+  python3-netifaces:
+  python3-requests:
+
 common_debs: &common_debs
   auditd:
   apt-transport-https:
@@ -255,8 +260,18 @@ rockylinux:
   ova:
     package:
       open-vm-tools:
-      python2-pip:
-      <<: *rh8_rpms
+    os_version:
+    - distro_version: "7"
+      package:
+        python2-pip:
+        <<: *rh7_rpms
+    - distro_version: "8"
+      package:
+        python2-pip:
+        <<: *rh8_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
   qemu:
     package:
       open-vm-tools:

--- a/images/capi/packer/ova/linux/rockylinux/http/9/ks.cfg
+++ b/images/capi/packer/ova/linux/rockylinux/http/9/ks.cfg
@@ -1,0 +1,96 @@
+# Use CDROM installation media
+repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/"
+cdrom
+
+# Use text install
+text
+
+# Don't run the Setup Agent on first boot
+firstboot --disabled
+eula --agreed
+
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+
+# System language
+lang en_US.UTF-8
+
+# Network information
+network --bootproto=dhcp --onboot=on --ipv6=auto --activate --hostname=capv.vm
+
+# Lock Root account
+rootpw --lock
+
+# Create builder user
+user --name=builder --groups=wheel --password=builder --plaintext --shell=/bin/bash
+
+# System services
+selinux --permissive
+firewall --disabled
+services --enabled="NetworkManager,sshd,chronyd"
+
+# System timezone
+timezone UTC
+
+# System booloader configuration
+bootloader --location=mbr --boot-drive=sda
+zerombr
+clearpart --all --initlabel --drives=sda
+autopart --nohome --noswap --nolvm
+
+skipx
+
+%packages --ignoremissing --excludedocs
+openssh-server
+open-vm-tools
+sudo
+sed
+python3
+
+# unnecessary firmware
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl*-firmware
+-libertas-usb8388-firmware
+-ql*-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+-cockpit
+-quota
+-alsa-*
+-fprintd-pam
+-intltool
+-microcode_ctl
+%end
+
+%addon com_redhat_kdump --disable
+%end
+
+reboot
+
+%post
+
+echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+chmod 440 /etc/sudoers.d/builder
+
+# Remove the package cache
+yum -y clean all
+
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+systemctl enable vmtoolsd
+systemctl start vmtoolsd
+
+# Ensure on next boot that network devices get assigned unique IDs.
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/ova/rockylinux-9.json
+++ b/images/capi/packer/ova/rockylinux-9.json
@@ -1,0 +1,19 @@
+{
+  "boot_command_prefix": "<up>e<down><down><end><bs><bs><bs><bs><bs>text inst.ks=",
+  "boot_command_suffix": "/9/ks.cfg<leftCtrlOn>x<leftCtrlOff>",
+  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+  "build_name": "rockylinux-9",
+  "distro_arch": "amd64",
+  "distro_name": "rockylinux",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "firmware": "efi",
+  "guest_os_type": "rockylinux-64",
+  "iso_checksum": "eef8d26018f4fcc0dc101c468f65cbf588f2184900c556f243802e9698e56729",
+  "iso_checksum_type": "sha256",
+  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.3-x86_64-minimal.iso",
+  "os_display_name": "RockyLinux 9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "/sbin/halt -h -p",
+  "vsphere_guest_os_type": "rockylinux_64Guest"
+}


### PR DESCRIPTION
What this PR does / why we need it:
Adds Rocky Linux 9 for vSphere OVA.

**Additional context**
Defaulted firmware to EFI for users with large GPUs or multiple vGPUs.