### PR TITLE
Add timeout to Goss test for Windows AZ CLI

### DIFF
--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -240,6 +240,7 @@ command:
   Check Azure CLI is installed via alias:
     exec: powershell -command "az"
     exit-status: 0
+    timeout: 30000
 {{end}}
 
 {{ if ne .Vars.ssh_source_url "" }}


### PR DESCRIPTION
What this PR does / why we need it:

Adds `timeout: 30000` to the "Check Azure CLI is installed via alias" spec in Goss. Most other Windows Goss specs have this.

Which issue(s) this PR fixes:

Fixes #1355

**Additional context**
