### PR TITLE
patch: qemu efi fixes

### DIFF
--- a/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi.qemu/user-data
+++ b/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi.qemu/user-data
@@ -52,7 +52,7 @@ autoinstall:
         type: format
         id: format-0
       - device: disk-sda
-        size: 8023703552
+        size: -1
         wipe: superblock
         number: 2
         preserve: false
@@ -100,7 +100,7 @@ autoinstall:
   # 7. Removes the cached list of packages
   late-commands:
     - apt install -y efibootmgr
-    - efibootmgr -o 0006,0001,0000,0002,0003,0004,0005
+    - efibootmgr -o $(efibootmgr | grep -oP 'Boot[0-9]+[*]\s+ubuntu' | grep -oP '000[0-9]+' | head -n 1)
     - swapoff -a
     - rm -f /swapfile
     - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab


### PR DESCRIPTION
# What this PR does / why we need it:

* Set partition size for root to be -1 to prevent issues with disk sizes when someone wants to use the "disk_size" parameter in packer.
* Set the efibootmgr to look for the correct boot entry instead of hard coding it. This prevents random failures when the installer is run again on installation completion and reboot. The qemu method (or Ubuntu) sometimes fails to eject the "CDROM" and as a result, boot from disk fails if the boot order is not correct. This would cause the build to hang on "Waiting for SSH to become available..." indefinitely.


### Testing
After changing these two values I've ran multiple, consistent builds where the disk size matches a values passed in via `disk_size` and I never get a hanging "Waiting for SSH to become available..." anymore.

