### PR TITLE
Update CAPZ test templates used in pipeline

### DIFF
--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -110,7 +110,7 @@ jobs:
       # Install required binaries
       mkdir ~/test-binaries
       export PATH=${PATH}:~/test-binaries
-      az capi install -a -ip ~/test-binaries
+      az capi install -a -p ~/test-binaries
 
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: Install and configure az capi extension

--- a/images/capi/packer/azure/scripts/test-templates/linux/kustomization.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/linux/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.6.0/cluster-template.yaml
-patchesStrategicMerge:
-- ../patches/azuremachinetemplate-controlplane.yaml
-- ../patches/azuremachinetemplate-workload.yaml
+- https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.13.0/cluster-template.yaml
+patches:
+- path: ../patches/azuremachinetemplate-controlplane.yaml
+- path: ../patches/azuremachinetemplate-workload.yaml

--- a/images/capi/packer/azure/scripts/test-templates/windows/kustomization.yaml
+++ b/images/capi/packer/azure/scripts/test-templates/windows/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.10.2/cluster-template-windows.yaml
-patchesStrategicMerge:
-- ../patches/azuremachinetemplate-windows.yaml
-- ../patches/kubeadmcontrolplane-windows.yaml
-- ../patches/machinedeployment-windows.yaml
+- https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/download/v1.13.0/cluster-template-windows.yaml
+patches:
+- path: ../patches/azuremachinetemplate-windows.yaml
+- path: ../patches/kubeadmcontrolplane-windows.yaml
+- path: ../patches/machinedeployment-windows.yaml


### PR DESCRIPTION
What this PR does / why we need it:

Updates the cluster templates used in the ADO pipeline test phase by `az capi` to current release versions, and updates some `kustomize` syntax. This is necessary to support external cloud-provider and Kubernetes v1.29.x.

Which issue(s) this PR fixes:

N/A

**Additional context**
