### PR TITLE
Support Azure OOT credential provider

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -79,3 +79,21 @@
     group: root
     mode: "0644"
   when: ansible_os_family == "Debian"
+
+- name: Create the credential provider path
+  file:
+    path: /var/lib/kubelet/credential-provider
+    state: directory
+    mode: "0755"
+
+- name: Download OOT credential provider
+  get_url:
+    url: https://github.com/kubernetes-sigs/cloud-provider-azure/releases/latest/download/azure-acr-credential-provider-linux-amd64
+    dest: /var/lib/kubelet/credential-provider/acr-credential-provider
+    mode: "0755"
+
+- name: Download OOT credential provider config file
+  get_url:
+    url: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/examples/out-of-tree/credential-provider-config.yaml
+    dest: /var/lib/kubelet/credential-provider-config.yaml
+    mode: "0644"

--- a/images/capi/ansible/windows/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/azure.yml
@@ -60,3 +60,24 @@
   ansible.windows.win_file:
     path: C:\azure-cli.msi
     state: absent
+
+- name: Create the credential provider path
+  win_file:
+    path: C:\var\lib\kubelet\credential-provider
+    state: directory
+
+- name: Download OOT credential provider
+  win_get_url:
+    url: https://github.com/kubernetes-sigs/cloud-provider-azure/releases/latest/download/azure-acr-credential-provider-windows-amd64.exe
+    dest: C:\var\lib\kubelet\credential-provider\acr-credential-provider.exe
+
+# It is a workaround for K8s < 1.30.
+# Detail: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/4533
+- name: Copy OOT credential provider binary
+  when: kubernetes_semver is version('v1.30.0', '<')
+  win_shell: copy C:\var\lib\kubelet\credential-provider\acr-credential-provider.exe C:\var\lib\kubelet\credential-provider\acr-credential-provider
+
+- name: Download OOT credential provider config file
+  win_get_url:
+    url: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/examples/out-of-tree/credential-provider-config-win.yaml
+    dest: C:\var\lib\kubelet\credential-provider-config.yaml


### PR DESCRIPTION
For Linux and Windows, OOT credential provider and its config will be downloaded.

What this PR does / why we need it:
Support Azure OOT credential provider

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #
https://github.com/kubernetes-sigs/cloud-provider-azure/issues/5231
**Additional context**
Add any other context for the reviewers