### PR TITLE
Bump containerd to 1.7.13

### DIFF
--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -3,7 +3,7 @@
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
   "containerd_gvisor_runtime": "false",
   "containerd_gvisor_version": "latest",
-  "containerd_sha256": "38fce887eafe047571d9cdd0f1cc768315af5a68ab2d1726ab3cd0d43dd77377",
-  "containerd_sha256_windows": "a334db85f8a8d54441c38087ecbfe9b62db54cbf2cb8b43276682923976202bb",
-  "containerd_version": "1.7.10"
+  "containerd_sha256": "9be621c0206b5c20a1dea05fae12fc698e5083cc81f65c9d918c644090696d19",
+  "containerd_sha256_windows": "a576160771eba9b3e0d85a841fa4f6dba60a14c5c4f45e34f2148e2fe138ebb7",
+  "containerd_version": "1.7.13"
 }

--- a/images/capi/packer/config/ppc64le/containerd.json
+++ b/images/capi/packer/config/ppc64le/containerd.json
@@ -1,5 +1,5 @@
 {
-  "containerd_sha256": "d4947b6d33c720db924fb49f8ec5022e7dbcff9d04d3bea6ebd1310e7706fa2b",
+  "containerd_sha256": "4cebd6cbaf24b6dcaabcadd93cfe81441eb7cec6bdc9e431cf7777fee4842ff0",
   "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-ppc64le.tar.gz",
-  "containerd_version": "1.7.10"
+  "containerd_version": "1.7.13"
 }


### PR DESCRIPTION


What this PR does / why we need it:

Update containerd version to address container breakout vulnerability in runsc.


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #

Haven't seen an issue yet.

**Additional context**
Add any other context for the reviewers

See  [CVE-2024-21626](https://github.com/advisories/GHSA-xr7r-f8xq-vfvv) and [containerd release 1.7.13](https://github.com/containerd/containerd/releases/tag/v1.7.13) 