### PR TITLE
Update docs for release v0.1.23

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,11 @@
 # Image Builder Releases
 
-The current release of Image Builder is [v0.1.22][] (January 15, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22`.
+The current release of Image Builder is [v0.1.23][] (February 7, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23`.
 
 ## Release Process
 
 For more detail about image-builder project releases, see the [Image Builder Book][].
 
 
-[v0.1.22]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.22
+[v0.1.23]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.23
 [Image Builder Book]: https://image-builder.sigs.k8s.io/capi/releasing.html

--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -18,7 +18,7 @@ Run the docker build target of Makefile
 The latest image-builder container image release is available here:
 
 ```commandline
-docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22
+docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23
 ```
 
 ### Examples
@@ -27,7 +27,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     - If the AWS CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials.
 
     ```commandline
-    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-ami-ubuntu-2004
+    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23 build-ami-ubuntu-2004
     ```
     - Another alternative is to use an `aws-creds.env` file to load the credentials and pass it during docker run.
 
@@ -38,7 +38,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```
 
     ```commandline
-        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-ami-ubuntu-2004
+        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23 build-ami-ubuntu-2004
     ```
 
 - AZURE
@@ -53,7 +53,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```
 
     ```commandline
-    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-azure-sig-ubuntu-2004
+    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23 build-azure-sig-ubuntu-2004
     ```
 
 - vSphere OVA
@@ -62,7 +62,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the Docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
 
     ```commandline
-    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22 build-node-ova-vsphere-ubuntu-2004
+    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23 build-node-ova-vsphere-ubuntu-2004
     ```
 
 In addition to this, further customizations can be done as discussed [here](./capi.md#customization).

--- a/docs/book/src/capi/releasing.md
+++ b/docs/book/src/capi/releasing.md
@@ -1,6 +1,6 @@
 # Image Builder Releases
 
-The current release of Image Builder is [v0.1.22][] (Januarty 15, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.22`.
+The current release of Image Builder is [v0.1.23][] (February 7, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.23`.
 
 ## Release Process
 
@@ -22,7 +22,7 @@ Releases in image-builder follow [semantic versioning][semver] conventions. Curr
     - *If signing tags with GPG, makes your key available to the `git tag` command.*
 - Create a new tag:
   - `export IB_VERSION=v0.1.x`
-    - *Replace `x` with the next patch version. For example: `v0.1.22`.*
+    - *Replace `x` with the next patch version. For example: `v0.1.23`.*
   - `git tag -s -m "Image Builder ${IB_VERSION}" ${IB_VERSION}`
   - `git push upstream ${IB_VERSION}`
 
@@ -30,8 +30,8 @@ Releases in image-builder follow [semantic versioning][semver] conventions. Curr
 
 Pushing the tag in the previous step triggered a job to build the container image and publish it to the staging registry.
 
-- Images are built by the [pr-container-image-build][] job. This will push the image to a [staging repository][].
-- Wait for the above pr-container-image-build job to complete and for the tagged image to exist in the staging directory.
+- Images are built by the [post-image-builder-push-images][] job. This will push the image to a [staging repository][].
+- Wait for the above post-image-builder-push-images job to complete and for the tagged image to exist in the staging directory.
 - If you don't have a GitHub token, create one via [Personal access tokens][]. Make sure you give the token the `repo` scope.
 - Create a GitHub pull request to promote the image:
   - `export GITHUB_TOKEN=<your GH token>`
@@ -65,7 +65,7 @@ While waiting for the above PR to merge, create a GitHub draft release for the t
 
 ### Update Documentation
 
-There are several files in image-builder itself that refer to the latest release (including this one). Create a pull request that updates these to the newly published version.
+There are several files in image-builder itself that refer to the latest release (including this one). Create a pull request that updates these to the newly published version. ([Example PR](https://github.com/kubernetes-sigs/image-builder/pull/1375))
 
 Wait for this PR to merge before communicating the release to users, so image-builder documentation is consistent.
 
@@ -74,14 +74,14 @@ Wait for this PR to merge before communicating the release to users, so image-bu
 In the [#image-builder channel][] on the Kubernetes Slack, post a message announcing the new release. Include a link to the GitHub release and a thanks to the contributors:
 
 ```
-Image-builder v0.1.22 is now available: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.22
+Image-builder v0.1.23 is now available: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.23
 Thanks to all contributors!
 ```
 
-[v0.1.22]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.22
+[v0.1.23]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.23
 [#image-builder channel]: https://kubernetes.slack.com/archives/C01E0Q35A8J
 [Personal access tokens]: https://github.com/settings/tokens
-[pr-container-image-build]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-builder#pr-container-image-build
+[post-image-builder-push-images]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-image-builder-push-images
 [releases page]: https://github.com/kubernetes-sigs/image-builder/releases
 [semver]: https://semver.org/#semantic-versioning-200
 [staging repository]: https://console.cloud.google.com/gcr/images/k8s-staging-scl-image-builder/GLOBAL/cluster-node-image-builder-amd64


### PR DESCRIPTION
What this PR does / why we need it:

Updates the docs with reference to the v0.1.23 release.

I also fixed the link to the testgrid job so it points at the correct one for building a tag image (previously it was pointing to the one for PRs) and I added a link to an example docs update PR.

Blocked until https://github.com/kubernetes/k8s.io/pull/6392 is merged and the image is available

/hold