### PR TITLE
[WIP] Fix flatcar python error

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -192,6 +192,8 @@
       ],
       "inline": [
         "if [[ $BUILD_NAME != \"flatcar\"* ]]; then exit 0; fi",
+        "which python || echo 'python not found'",
+        "which python3 || echo 'python3 not found'",
         "sudo bash -c \"/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent -force -deprovision+user && ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf && sync\""
       ],
       "inline_shebang": "/bin/bash -x",


### PR DESCRIPTION
What this PR does / why we need it:

Fixes a problem with flatcar builds not finding python in the `pull-azure-sigs` prow e2e job.

Which issue(s) this PR fixes:

Fixes #1395

**Additional context**
