### PR TITLE
Flatcar build fix

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -192,7 +192,7 @@
       ],
       "inline": [
         "if [[ $BUILD_NAME != \"flatcar\"* ]]; then exit 0; fi",
-        "sudo bash -c \"/usr/share/oem/python/bin/python /usr/share/oem/bin/waagent -force -deprovision+user && ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf && sync\""
+        "sudo PATH=\"$PATH:/usr/share/oem/python/bin:/usr/share/oem/bin\" bash -c \"waagent -force -deprovision+user && ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf && sync\""
       ],
       "inline_shebang": "/bin/bash -x",
       "remote_folder": "{{user `provisioner_remote_folder`}}",

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -192,7 +192,7 @@
       ],
       "inline": [
         "if [[ $BUILD_NAME != \"flatcar\"* ]]; then exit 0; fi",
-        "sudo PATH=\"$PATH:/usr/share/oem/python/bin:/usr/share/oem/bin\" bash -c \"waagent -force -deprovision+user && ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf && sync\""
+        "sudo PATH=\"$PATH:/usr/share/oem/python/bin:/usr/share/oem/bin\" bash -c \"waagent -force -deprovision && userdel -f -r $USER && ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf && sync\""
       ],
       "inline_shebang": "/bin/bash -x",
       "remote_folder": "{{user `provisioner_remote_folder`}}",


### PR DESCRIPTION
What this PR does / why we need it:
Flatcar made some changes to waagent/python handling that broke the image build. There is also a lingering bug and a compatibility issue with python3.11 so we need to add a temporary workaround for user deletion during deprovisioning.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): Fixes #1395

**Additional context**
Add any other context for the reviewers