### PR TITLE
Set HOME_MODE to 0700 in Flatcar images

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -133,3 +133,7 @@
     src: usr/local/bin/etcd-network-tuning.sh
     dest: "{{ external_binary_path }}/etcd-network-tuning.sh"
     mode: "0755"
+
+- name: Set default HOME_MODE in login.defs (Flatcar)
+  shell: sed -ri "/^#?HOME_MODE\>/s:.*:HOME_MODE 0700:" /etc/login.defs
+  when: ansible_os_family == "Flatcar"

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -135,5 +135,5 @@
     mode: "0755"
 
 - name: Set default HOME_MODE in login.defs (Flatcar)
-  shell: sed -ri "/^#?HOME_MODE\>/s:.*:HOME_MODE 0700:" /etc/login.defs
+  shell: sed -ri "s/^#?HOME_MODE\>.*/HOME_MODE 0700/" /etc/login.defs
   when: ansible_os_family == "Flatcar"


### PR DESCRIPTION
## What this PR does / why we need it:
This sets `HOME_MODE` to 0700 in /etc/login.defs.

Currently it is unset in Flatcar (coming from Gentoo that keeps the upstream setting).
When `HOME_MODE` is unset, useradd uses the default umask of 022 when creating home directories for users.
This causes home directories for all users created through ignition in Flatcar to be world readable.

Setting `HOME_MODE` to 0700 restrict home permissions to the owner, as is default in RHEL derived distros ([Ubuntu uses 0750](https://git.launchpad.net/ubuntu/+source/shadow/tree/debian/login.defs#n156)).
