### PR TITLE
patch: fix boolean condition for kubernetes_enable_automatic_resource_sizing

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -81,7 +81,7 @@
     owner: root
     group: root
     mode: "0755"
-  when: kubernetes_enable_automatic_resource_sizing
+  when: kubernetes_enable_automatic_resource_sizing | bool
 
 - name: Drop kubelet resource sizing systemd unit file
   template:
@@ -90,7 +90,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: kubernetes_enable_automatic_resource_sizing
+  when: kubernetes_enable_automatic_resource_sizing | bool
 
 - name: Generate kubectl bash completion
   shell:


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
- Fix a bug where kubernetes_enable_automatic_resource_sizing is set to "false" by default but it is interpreted as non-falsey String


## Related issues
- https://github.com/kubernetes-sigs/image-builder/pull/1373

## Additional context
- Duirng our cluster upgrade (only two patch versions), we discovered `/run/kubelet/extra-args.env` (content: `KUBELET_EXTRA_ARGS= --system-reserved=cpu=230m,memory=5052Mi`) is added which cause node to have way less allocatable memory. We've patched it internally and verified the fix works.
- Ref: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_conditionals.html#conditionals-based-on-variables

