### PR TITLE
Remove unneeded pip and package upgrade

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/debian.yml
+++ b/images/capi/ansible/roles/providers/tasks/debian.yml
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Upgrade pip to latest
-  pip:
-    name: pip
-    executable: pip3
-    state: latest
-
-- name: Upgrade pyOpenSSL and cryptography
-  pip:
-    name:
-      - pyOpenSSL==22.0.*
-      - cryptography==38.0.*
-    executable: pip3
-
 - name: Install Azure client
   pip:
     executable: pip3


### PR DESCRIPTION
## Change description

Removes a stanza we used to set things up for installing the Azure CLI without a `pip` error, but this workaround is ancient and doesn't seem to be needed now.

## Related issues

- Fixes #
