### PR TITLE
Update qemu ubuntu 22.04

### DIFF
--- a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
@@ -5,9 +5,9 @@
   "firmware": "OVMF.fd",
   "guest_os_type": "ubuntu-64",
   "http_directory": "./packer/qemu/linux/ubuntu/http/22.04.efi.qemu",
-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
+  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso",
+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.4-live-server-amd64.iso",
   "os_display_name": "Ubuntu 22.04",
   "shutdown_command": "shutdown -P now",
   "unmount_iso": "true"


### PR DESCRIPTION
Ubuntu has released newer version of ISO. Version in config is no longer available.

https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso?checksum=sha256%3Aa4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
