### PR TITLE
Upgrade Centos 9 Stream base image to newer version.

### DIFF
--- a/images/capi/packer/qemu/qemu-centos-9.json
+++ b/images/capi/packer/qemu/qemu-centos-9.json
@@ -10,9 +10,9 @@
   "distro_version": "9",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
   "guest_os_type": "centos9-64",
-  "iso_checksum": "2080b8ff7b4bd06982323a8bf3d1c030678b48656e5c6d12e79c22a838e2490e",
+  "iso_checksum": "97fe11f456329dcc84d100dbe2202e08b6af97c844564f714db1e4bb352207a9",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20231211.0-x86_64-dvd1.iso",
+  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20240212.0-x86_64-dvd1.iso",
   "os_display_name": "CentOS 9 Stream",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"


### PR DESCRIPTION
Old image from Centos9Stream is not available in the mirror anynmore.

## Change description
Upgrade Centos 9 Stream ISO as previous version left the mirror


## Related issues
No issues reported

## Additional context

