### PR TITLE
fix(outscale): Configure ec2 provider so VM userdata will work again

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/99_metadata.cfg
+++ b/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/99_metadata.cfg
@@ -1,2 +1,2 @@
 disable-ec2-metadata: false
-datasource_list: [ Outscale ] 
+datasource_list: [ Ec2 ] 


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
This is a followup of PR https://github.com/kubernetes-sigs/image-builder/pull/1409 that was breaking user-data so VM on Outscale was unable to install ssh public keys. 

It configure cloud-init provider to Ec2 because outscale is compatible with it. 

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1410



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
