### PR TITLE
Add raw image building support for rhel-9 and rhel-9 efi

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -372,7 +372,7 @@ QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2304 qemu-ub
 
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
-RAW_BUILD_NAMES				?=      raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar raw-rhel-8
+RAW_BUILD_NAMES				?=      raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar raw-rhel-8 raw-rhel-9 raw-rhel-9-efi
 VBOX_BUILD_NAMES			?=      vbox-windows-2019
 
 POWERVS_BUILD_NAMES         ?= powervs-centos-8
@@ -784,6 +784,8 @@ build-raw-flatcar: ## Builds Flatcar RAW image
 build-raw-ubuntu-2004: ## Builds Ubuntu 20.04 RAW image
 build-raw-ubuntu-2004-efi: ## Builds Ubuntu 20.04 RAW image that EFI boots
 build-raw-rhel-8: ## Builds RHEL 8 RAW image
+build-raw-rhel-9: ## Builds RHEL 9 RAW image
+build-raw-rhel-9-efi: ## Builds RHEL 9 RAW image that EFI boots
 build-raw-all: $(RAW_BUILD_TARGETS) ## Builds all RAW images
 
 build-oci-ubuntu-2004: ## Builds the OCI ubuntu-2004 image

--- a/images/capi/packer/raw/linux/rhel
+++ b/images/capi/packer/raw/linux/rhel
@@ -1,1 +1,0 @@
-../../ova/linux/centos

--- a/images/capi/packer/raw/linux/rhel/7/ks.cfg
+++ b/images/capi/packer/raw/linux/rhel/7/ks.cfg
@@ -1,0 +1,92 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Perform a fresh install, not an upgrade
+install
+cdrom
+
+# Perform a text installation
+text
+
+# Do not install an X server
+skipx
+
+# Configure the locale/keyboard
+lang en_US.UTF-8
+keyboard us
+
+# Configure networking
+network --onboot yes --bootproto dhcp --hostname capv.vm
+firewall --disabled
+selinux --permissive
+timezone UTC
+
+# Don't flip out if unsupported hardware is detected
+unsupported_hardware
+
+# Configure the user(s)
+auth --enableshadow --passalgo=sha512 --kickstart
+user --name=builder --plaintext --password builder --groups=builder,wheel
+
+# Disable general install minutia
+firstboot --disabled
+eula --agreed
+
+# Create a single partition with no swap space
+bootloader --location=mbr
+zerombr
+clearpart --all --initlabel
+part / --grow --asprimary --fstype=ext4 --label=slash
+
+%packages --ignoremissing --excludedocs
+openssh-server
+sed
+sudo
+
+# Remove unnecessary firmware
+-*-firmware
+
+# Remove other unnecessary packages
+-postfix
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+# Perform a reboot once the installation has completed
+reboot
+
+# The %post section is essentially a shell script
+%post --erroronfail
+
+# Update the root certificates
+update-ca-trust force-enable
+
+# Ensure that the "builder" user doesn't require a password to use sudo,
+# or else Ansible will fail
+echo 'builder ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/builder
+chmod 440 /etc/sudoers.d/builder
+
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+# Ensure on next boot that network devices get assigned unique IDs.
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/raw/linux/rhel/8/ks.cfg
+++ b/images/capi/packer/raw/linux/rhel/8/ks.cfg
@@ -1,0 +1,74 @@
+# version=RHEL8
+# Install OS instead of upgrade
+install
+cdrom
+auth --enableshadow --passalgo=sha512 --kickstart
+# License agreement
+eula --agreed
+# Use text mode install
+text
+# Disable Initial Setup on first boot
+firstboot --disable
+# Keyboard layout
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network --bootproto=dhcp --device=link --activate
+network --hostname=rhel8
+firewall --disabled
+# Root password
+rootpw builder --plaintext
+# SELinux configuration
+selinux --permissive
+# Do not configure the X Window System
+skipx
+# System timezone
+timezone UTC
+# Add a user named builder
+user --groups=wheel --name=builder --password=builder --plaintext --gecos="builder"
+
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=sda
+# Clear the Master Boot Record
+zerombr
+clearpart --all --initlabel --drives=sda
+part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+
+# Reboot after successful installation
+reboot
+
+%packages --ignoremissing --excludedocs
+# dnf group info minimal-environment
+@^minimal-environment
+@core
+openssh-server
+sed
+sudo
+python3
+
+# Exclude unnecessary firmwares
+-iwl*firmware
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+%post --nochroot --logfile=/mnt/sysimage/root/ks-post.log
+# Disable quiet boot and splash screen
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/etc/default/grub
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/boot/grub2/grubenv
+
+# Passwordless sudo for the user 'builder'
+echo "builder ALL=(ALL) NOPASSWD: ALL" >> /mnt/sysimage/etc/sudoers.d/builder
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/raw/linux/rhel/9/ks-efi.cfg
+++ b/images/capi/packer/raw/linux/rhel/9/ks-efi.cfg
@@ -1,0 +1,76 @@
+# version=RHEL9
+# Install OS instead of upgrade
+cdrom
+authselect --enableshadow --passalgo=sha512 --kickstart
+# License agreement
+eula --agreed
+# Use text mode install
+text
+# Disable Initial Setup on first boot
+firstboot --disable
+# Keyboard layout
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network --bootproto=dhcp --device=link --activate
+network --hostname=centos9
+firewall --disabled
+# Root password
+rootpw builder --plaintext
+# SELinux configuration
+selinux --permissive
+# Do not configure the X Window System
+skipx
+# System timezone
+timezone UTC
+# Add a user named builder
+user --groups=wheel --name=builder --password=builder --plaintext --gecos="builder"
+
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=sda
+# Clear the Master Boot Record
+zerombr
+clearpart --all --initlabel --drives=sda
+part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+part /boot/efi --fstype="efi" --ondisk=sda --size=200 --fsoptions="umask=0077,shortname=winnt"
+part swap --fstype="swap" --ondisk=sda --size=100
+part /boot --fstype="ext4" --ondisk=sda --size=1024
+
+# Reboot after successful installation
+reboot
+
+%packages --ignoremissing --excludedocs
+# dnf group info minimal-environment
+@^minimal-environment
+@core
+openssh-server
+sed
+sudo
+python3
+
+# Exclude unnecessary firmwares
+-iwl*firmware
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+%post --nochroot --logfile=/mnt/sysimage/root/ks-post.log
+# Disable quiet boot and splash screen
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/etc/default/grub
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/boot/grub2/grubenv
+
+# Passwordless sudo for the user 'builder'
+echo "builder ALL=(ALL) NOPASSWD: ALL" >> /mnt/sysimage/etc/sudoers.d/builder
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/raw/linux/rhel/9/ks.cfg
+++ b/images/capi/packer/raw/linux/rhel/9/ks.cfg
@@ -1,0 +1,73 @@
+# version=RHEL9
+# Install OS instead of upgrade
+cdrom
+authselect --enableshadow --passalgo=sha512 --kickstart
+# License agreement
+eula --agreed
+# Use text mode install
+text
+# Disable Initial Setup on first boot
+firstboot --disable
+# Keyboard layout
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network --bootproto=dhcp --device=link --activate
+network --hostname=centos9
+firewall --disabled
+# Root password
+rootpw builder --plaintext
+# SELinux configuration
+selinux --permissive
+# Do not configure the X Window System
+skipx
+# System timezone
+timezone UTC
+# Add a user named builder
+user --groups=wheel --name=builder --password=builder --plaintext --gecos="builder"
+
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=sda
+# Clear the Master Boot Record
+zerombr
+clearpart --all --initlabel --drives=sda
+part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+
+# Reboot after successful installation
+reboot
+
+%packages --ignoremissing --excludedocs
+# dnf group info minimal-environment
+@^minimal-environment
+@core
+openssh-server
+sed
+sudo
+python3
+
+# Exclude unnecessary firmwares
+-iwl*firmware
+%end
+
+# Enable/disable the following services
+services --enabled=sshd
+
+%post --nochroot --logfile=/mnt/sysimage/root/ks-post.log
+# Disable quiet boot and splash screen
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/etc/default/grub
+sed --follow-symlinks -i "s/ rhgb quiet//" /mnt/sysimage/boot/grub2/grubenv
+
+# Passwordless sudo for the user 'builder'
+echo "builder ALL=(ALL) NOPASSWD: ALL" >> /mnt/sysimage/etc/sudoers.d/builder
+# Remove the package cache
+yum -y clean all
+
+# Disable swap
+swapoff -a
+rm -f /swapfile
+sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+
+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
+
+%end

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -8,6 +8,7 @@
         "{{user `boot_command_suffix`}}"
       ],
       "boot_wait": "{{user `boot_wait`}}",
+      "cpu_model": "{{user `cpu_model`}}",
       "cpus": "{{user `cpus`}}",
       "disk_compression": "{{ user `disk_compression`}}",
       "disk_discard": "{{user `disk_discard`}}",

--- a/images/capi/packer/raw/raw-rhel-9-efi.json
+++ b/images/capi/packer/raw/raw-rhel-9-efi.json
@@ -1,0 +1,19 @@
+{
+  "boot_command_prefix": "<up>e <down><down><end><wait> text inst.ks=",
+  "boot_command_suffix": "/9/ks-efi.cfg<enter><wait><leftCtrlOn>x<leftCtrlOff>",
+  "build_name": "rhel-9",
+  "build_target": "raw",
+  "cpu_model": "host",
+  "distribution_version": "9",
+  "distro_name": "rhel",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "firmware": "OVMF.fd",
+  "guest_os_type": "RedHat_64",
+  "iso_checksum": "5c802147aa58429b21e223ee60e347e850d6b0d8680930c4ffb27340ffb687a8",
+  "iso_checksum_type": "sha256",
+  "iso_url": "rhel-9.3-x86_64-dvd.iso",
+  "os_display_name": "RHEL 9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "shutdown -P now"
+}

--- a/images/capi/packer/raw/raw-rhel-9.json
+++ b/images/capi/packer/raw/raw-rhel-9.json
@@ -1,0 +1,18 @@
+{
+  "boot_command_prefix": "<tab> text inst.ks=",
+  "boot_command_suffix": "/9/ks.cfg<enter><wait>",
+  "build_name": "rhel-9",
+  "build_target": "raw",
+  "cpu_model": "host",
+  "distribution_version": "9",
+  "distro_name": "rhel",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "guest_os_type": "RedHat_64",
+  "iso_checksum": "5c802147aa58429b21e223ee60e347e850d6b0d8680930c4ffb27340ffb687a8",
+  "iso_checksum_type": "sha256",
+  "iso_url": "rhel-9.3-x86_64-dvd.iso",
+  "os_display_name": "RHEL 9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Adding Image building support on Raw provider for RHEL-9 and RHEL-9 EFI. As part of the change, the kickstart files for RHEL raw are now symlinked to qemu's RHEL kickstart files as opposed ova's, since raw provider is much more closer to qemu than ova. 

CPU Model for raw is set to `host` as opposed to the default `qemu64`. While this is mainly required for RHEL 9 image building, this works well for other raw image builds as well.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Partially Fixes #1119 

