### PR TITLE
Add NIC exclusion to VMware tools conf in VMware Windows OVA

### DIFF
--- a/images/capi/ansible/windows/roles/providers/files/vmware/vmtools/tools.conf
+++ b/images/capi/ansible/windows/roles/providers/files/vmware/vmtools/tools.conf
@@ -1,0 +1,2 @@
+[guestinfo]
+exclude-nics=vEthernet*,antrea-*,cali*,cilium*,lxc*,ovs-system,flannel*,veth*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????

--- a/images/capi/ansible/windows/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/vmware.yml
@@ -1,3 +1,6 @@
+# Copyright 2024 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
@@ -9,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- ansible.builtin.include_tasks: azure.yml
-  when: packer_builder_type.startswith('azure')
-
-- ansible.builtin.include_tasks: vmware.yml
-  when: packer_builder_type is search('vmware') or packer_builder_type is search('vsphere')
+- name: Create provider vmtools config file
+  ansible.windows.win_copy:
+    src: vmware/vmtools/tools.conf
+    dest: 'C:\ProgramData\VMware\VMware Tools\tools.conf'


### PR DESCRIPTION
## Change description
Currently the node created from VMware Windows OVA could report multiple NIC addresses as CNI may create multiple NICs on nodes. This breaks the assumption from vSphere CPI which may result in wrong IP address to be set on Node.
This commit fixes the issue by setting exclude-nics for VMware tools.

- Fixes #1428 



## Additional context

