### PR TITLE
Revert updates to Ubuntu 2004 ISO URLs

### DIFF
--- a/images/capi/packer/qemu/qemu-ubuntu-2004-efi.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2004-efi.json
@@ -6,9 +6,9 @@
   "distro_name": "ubuntu",
   "firmware": "OVMF.fd",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://old-releases.ubuntu.com/releases/20.04/ubuntu-20.04.5-live-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
   "os_display_name": "Ubuntu 20.04",
   "shutdown_command": "shutdown -P now"
 }

--- a/images/capi/packer/qemu/qemu-ubuntu-2004.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2004.json
@@ -5,9 +5,9 @@
   "distribution_version": "2004",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://old-releases.ubuntu.com/releases/20.04/ubuntu-20.04.5-live-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
   "os_display_name": "Ubuntu 20.04",
   "shutdown_command": "shutdown -P now"
 }

--- a/images/capi/packer/raw/raw-ubuntu-2004-efi.json
+++ b/images/capi/packer/raw/raw-ubuntu-2004-efi.json
@@ -6,9 +6,9 @@
   "distro_name": "ubuntu",
   "firmware": "OVMF.fd",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://old-releases.ubuntu.com/releases/20.04/ubuntu-20.04.5-live-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
   "os_display_name": "Ubuntu 20.04",
   "shutdown_command": "shutdown -P now"
 }

--- a/images/capi/packer/raw/raw-ubuntu-2004.json
+++ b/images/capi/packer/raw/raw-ubuntu-2004.json
@@ -5,9 +5,9 @@
   "build_target": "raw",
   "distro_name": "ubuntu",
   "guest_os_type": "ubuntu-64",
-  "iso_checksum": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4",
+  "iso_checksum": "f11bda2f2caed8f420802b59f382c25160b114ccc665dbac9c5046e7fceaced2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://old-releases.ubuntu.com/releases/20.04/ubuntu-20.04.5-live-server-amd64.iso",
+  "iso_url": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso",
   "os_display_name": "Ubuntu 20.04",
   "shutdown_command": "shutdown -P now"
 }


### PR DESCRIPTION
This PR reverts updates to Ubuntu 20.04 URLs changed in #1420 since we need to figure out a way to migrate these to the subiquity installer from the debian-installer preseed approach before the URLs can be changed.