### PR TITLE
Bump ansible-core to v2.15.10

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -23,7 +23,7 @@ set -o pipefail
 source hack/utils.sh
 
 # Note: ansible-core v2.16.x requires Python >= 3.10.
-_version="2.15.9"
+_version="2.15.10"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
What this PR does / why we need it:

Updates `ansible-core` to version [v2.15.10](https://github.com/ansible/ansible/releases/tag/v2.15.10). Maintains compatibility with python 3.9.

Which issue(s) this PR fixes: 

N/A

**Additional context**
