### PR TITLE
update the way to install cloud-init

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/99_metadata.cfg
+++ b/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/99_metadata.cfg
@@ -1,2 +1,0 @@
-disable-ec2-metadata: false
-datasource_list: [ Ec2 ] 

--- a/images/capi/ansible/roles/providers/tasks/outscale.yml
+++ b/images/capi/ansible/roles/providers/tasks/outscale.yml
@@ -1,9 +1,12 @@
 ---
-- name: Change cloud-init metadata outscale config in Ubuntu
-  ansible.builtin.copy:
-    src: files/etc/cloud/cloud.cfg.d/99_metadata.cfg
-    dest: /etc/cloud/cloud.cfg.d/99_metadata.cfg
-    owner: root
-    group: root
-    mode: "0644"
-  when: ansible_distribution == "Ubuntu"
+- name: Install cloud-init packages
+  ansible.builtin.apt:
+    name: "{{ packages }}"
+    state: present
+    force_apt_get: true
+  vars:
+    packages:
+      - cloud-init
+      - cloud-guest-utils
+      - cloud-initramfs-copymods
+      - cloud-initramfs-dyn-netconf


### PR DESCRIPTION
  
## Change description
This PR solve the mismatch of cloud-init version and install the official version with ansible rather than passing by a packaged version 

  