### PR TITLE
photon: update photon-repos to download recent gpg keys

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -22,6 +22,11 @@
 
 - ansible.builtin.import_tasks: rpm_repos.yml
 
+- name: Update the repos package to import the recent gpg keys
+  ansible.builtin.command: tdnf update -y photon-repos --enablerepo=photon --refresh
+  register: distro
+  changed_when: '"Nothing to do" not in distro.stderr'
+
 - name: Perform a tdnf distro-sync
   ansible.builtin.command: tdnf distro-sync -y --refresh
   register: distro


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Adds a command to photon.yaml which ensures the latest gpg keys are present.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1441



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
