### PR TITLE
set python version to 3.9 minimum

### DIFF
--- a/images/capi/ansible/roles/python/defaults/main.yml
+++ b/images/capi/ansible/roles/python/defaults/main.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-pypy_python_version: "3.6"
+pypy_python_version: "3.9"
 pypy_version: 7.2.0
 pypy_download_path: /tmp/pypy.tar.bz2
 pypy_install_path: /opt


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->

- set python version to 3.9 minimum

getting this error when building `rhel-8` for capg 

```
Python 3.6.x is no longer officially supported by the Google Cloud CLI\nand may not function correctly. 
```

job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-image-builder-gcp-all-nightly/1781957253432086528


/assign @mboersma @dims 

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
