### PR TITLE
fix gce nightly

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-27.json
@@ -1,6 +1,6 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.27.13-1.1",
+  "kubernetes_deb_version": "1.27.13-2.1",
   "kubernetes_rpm_version": "1.27.13",
   "kubernetes_semver": "v1.27.13",
   "kubernetes_series": "v1.27",

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-28.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-28.json
@@ -1,6 +1,6 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.28.9-1.1",
+  "kubernetes_deb_version": "1.28.9-2.1",
   "kubernetes_rpm_version": "1.28.9",
   "kubernetes_semver": "v1.28.9",
   "kubernetes_series": "v1.28",

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-29.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-29.json
@@ -1,6 +1,6 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.29.4-1.1",
+  "kubernetes_deb_version": "1.29.4-2.1",
   "kubernetes_rpm_version": "1.29.4",
   "kubernetes_semver": "v1.29.4",
   "kubernetes_series": "v1.29",


### PR DESCRIPTION

## Change description

```
"msg": "no available installation candidate for kubelet=1.27.13-1.1"}
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-image-builder-gcp-all-nightly/1782682215004508160


/assign @dims @mboersma @richardcase 