### PR TITLE
add ubuntu 22.04 for digitalocean

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -362,7 +362,7 @@ AZURE_BUILD_SIG_CVM_NAMES ?= $(addsuffix -cvm,$(addprefix azure-sig-,$(SIG_CVM_T
 
 OCI_BUILD_NAMES				?= oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-oracle-linux-9 oci-windows-2019 oci-windows-2022
 
-DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004
+DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204
 
 OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-flatcar
 
@@ -676,6 +676,7 @@ build-azure-vhds: $(AZURE_BUILD_VHD_TARGETS) ## Builds all Azure VHDs
 build-azure-sigs: $(AZURE_BUILD_SIG_TARGETS) $(AZURE_BUILD_SIG_GEN2_TARGETS) $(AZURE_BUILD_SIG_CVM_TARGETS) ## Builds all Azure Shared Image Gallery images
 
 build-do-ubuntu-2004: ## Builds Ubuntu 20.04 DigitalOcean Snapshot
+build-do-ubuntu-2204: ## Builds Ubuntu 22.04 DigitalOcean Snapshot
 build-do-centos-7: ## Builds Centos 7 DigitalOcean Snapshot
 build-do-all: $(DO_BUILD_TARGETS) ## Builds all DigitalOcean Snapshot
 
@@ -862,6 +863,7 @@ validate-azure-sig-ubuntu-2204-cvm: ## Validates Ubuntu 22.04 CVM Azure managed 
 validate-azure-all: $(AZURE_VALIDATE_SIG_TARGETS) $(AZURE_VALIDATE_VHD_TARGETS) $(AZURE_VALIDATE_SIG_GEN2_TARGETS) $(AZURE_VALIDATE_SIG_CVM_TARGETS) ## Validates all images for Azure Packer config
 
 validate-do-ubuntu-2004: ## Validates Ubuntu 20.04 DigitalOcean Snapshot Packer config
+validate-do-ubuntu-2204: ## Validates Ubuntu 22.04 DigitalOcean Snapshot Packer config
 validate-do-centos-7: ## Validates Centos 7 DigitalOcean Snapshot Packer config
 validate-do-all: $(DO_VALIDATE_TARGETS) ## Validates all DigitalOcean Snapshot Packer config
 

--- a/images/capi/packer/digitalocean/ubuntu-2204.json
+++ b/images/capi/packer/digitalocean/ubuntu-2204.json
@@ -1,0 +1,5 @@
+{
+  "build_name": "ubuntu-2204",
+  "snapshot_name_suffix": "on Ubuntu 22.04",
+  "source_image": "ubuntu-22-04-x64"
+}


### PR DESCRIPTION
## Change description
- add ubuntu 22.04 for digitalocean

built the image

```
...
    digitalocean.ubuntu-2204:
==> digitalocean.ubuntu-2204: Gracefully shutting down droplet...
==> digitalocean.ubuntu-2204: Creating snapshot: Cluster API Kubernetes v1.30.0 on Ubuntu 22.04
==> digitalocean.ubuntu-2204: Waiting for snapshot to complete...
==> digitalocean.ubuntu-2204: Destroying droplet...
==> digitalocean.ubuntu-2204: Deleting temporary ssh key...
Build 'digitalocean.ubuntu-2204' finished after 13 minutes 45 seconds.

==> Wait completed after 13 minutes 45 seconds
```

![Screenshot 2024-04-23 at 15 07 43](https://github.com/kubernetes-sigs/image-builder/assets/4115580/44c5d3b3-5340-4941-9c41-2132cb309448)


/assign @timoreimann @gottwald 