### PR TITLE
Azure: Remove pipeline refs to CONTAINER_IMAGE

### DIFF
--- a/images/capi/packer/azure/.pipelines/build-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/build-vhd.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
 # - AZURE_TENANT_ID - tenant ID
 # - AZURE_CLIENT_ID - Service principal ID
 # - AZURE_CLIENT_SECRET - Service principal secret
@@ -11,7 +10,6 @@
 
 jobs:
 - job: build_vhd
-  container: $[ variables['CONTAINER_IMAGE'] ]
   timeoutInMinutes: 120
   strategy:
     maxParallel: 0
@@ -34,6 +32,7 @@ jobs:
     condition: and(eq(variables['PREFLIGHT_CHECKS'], 'true'), eq(variables['OS'], 'Windows'))
   - script: |
       set -o pipefail
+      export PATH=$PATH:$HOME/.local/bin LC_ALL=en_US.UTF-8
       make deps-azure
       os=$(echo "${OS}" | tr '[:upper:]' '[:lower:]')
       version=$(echo "${OS_VERSION}" | tr '[:upper:]' '[:lower:]' | tr -d .)

--- a/images/capi/packer/azure/.pipelines/cleanup.yaml
+++ b/images/capi/packer/azure/.pipelines/cleanup.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
 # - AZURE_CLIENT_ID_SKU - Service principal ID to PUT the SKU
 # - AZURE_CLIENT_SECRET_SKU - Service principal secret to PUT the SKU
 # - AZURE_TENANT_ID_SKU - tenant ID to PUT the SKU
@@ -27,7 +26,6 @@ stages:
   - stage: clean
     jobs:
     - job:
-      container: $[ variables['CONTAINER_IMAGE'] ]
       timeoutInMinutes: 120
       pool:
         name: $(BUILD_POOL)

--- a/images/capi/packer/azure/.pipelines/create-disk-version.yaml
+++ b/images/capi/packer/azure/.pipelines/create-disk-version.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
 # - AZURE_TENANT_ID - tenant ID
 # - AZURE_CLIENT_ID - Service principal ID
 # - AZURE_CLIENT_SECRET - Service principal secret
@@ -9,7 +8,6 @@
 
 jobs:
 - job: create_disk_version
-  container: $[ variables['CONTAINER_IMAGE'] ]
   timeoutInMinutes: 120
   strategy:
     maxParallel: 0

--- a/images/capi/packer/azure/.pipelines/create-sku.yaml
+++ b/images/capi/packer/azure/.pipelines/create-sku.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
 # - AZURE_CLIENT_ID - Service principal ID
 # - AZURE_CLIENT_SECRET - Service principal secret
 # - AZURE_TENANT_ID - tenant ID
@@ -14,7 +13,6 @@
 
 jobs:
 - job: create_sku
-  container: $[ variables['CONTAINER_IMAGE'] ]
   timeoutInMinutes: 120
   strategy:
     maxParallel: 0

--- a/images/capi/packer/azure/.pipelines/smoke-test.yaml
+++ b/images/capi/packer/azure/.pipelines/smoke-test.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
 # - AZURE_TENANT_ID_VHD - tenant ID to build the vhd
 # - AZURE_CLIENT_ID_VHD - Service principal ID to build the vhd
 # - AZURE_CLIENT_SECRET_VHD - Service principal secret to build the vhd
@@ -25,7 +24,6 @@ stages:
   - stage: vhd
     jobs:
     - job:
-      container: $[ variables['CONTAINER_IMAGE'] ]
       timeoutInMinutes: 120
       pool:
         name: $(BUILD_POOL)
@@ -33,6 +31,7 @@ stages:
       - template: k8s-config.yaml
       - script: |
           set -o pipefail
+          export PATH=$PATH:$HOME/.local/bin LC_ALL=en_US.UTF-8
           make deps-azure
           os=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
           version=$(echo "$OS_VERSION" | tr '[:upper:]' '[:lower:]' | tr -d .)

--- a/images/capi/packer/azure/.pipelines/stages.yaml
+++ b/images/capi/packer/azure/.pipelines/stages.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer and Ansible.
 # - AZURE_TENANT_ID_VHD - tenant ID to build the vhd
 # - AZURE_CLIENT_ID_VHD - Service principal ID to build the vhd
 # - AZURE_CLIENT_SECRET_VHD - Service principal secret to build the vhd

--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -1,6 +1,5 @@
 # Required pipeline variables:
 # - BUILD_POOL - Azure DevOps build pool to use
-# - CONTAINER_IMAGE - Dev container image URL to use. Should have Azure CLI, Packer, and Ansible.
 # - AZ_CAPI_EXTENSION_URL - URL to the Azure CAPI extension build.
 # - AZURE_TENANT_ID - tenant ID
 # - AZURE_CLIENT_ID - Service principal ID
@@ -12,7 +11,6 @@
 
 jobs:
 - job: test_vhd
-  container: $[ variables['CONTAINER_IMAGE'] ]
   timeoutInMinutes: 120
   strategy:
     maxParallel: 0
@@ -104,7 +102,6 @@ jobs:
       # Set up the Azure CLI Cluster API extension
       # https://github.com/Azure/azure-capi-cli-extension/releases/download/az-capi-nightly/capi-0.0.vnext-py2.py3-none-any.whl
       python3 -m pip install --upgrade pip
-      az upgrade --yes
       az extension add --yes --source "${AZ_CAPI_EXTENSION_URL}"
 
       # Install required binaries


### PR DESCRIPTION
## Change description

Removes references to `CONTAINER_IMAGE` in pipeline definitions, so image-builder will run natively on Azure DevOps agents.

The build container [deis/go-dev](https://github.com/deis/docker-go-dev/) is a maintenance burden and we'd like to stop using it. AFAICT this was the only remaining usage.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Closes #991

## Additional context

I've tested this change on the three (internal) CAPZ pipelines it touches, and they're working.

/cc @willie-yao @jackfrancis 