### PR TITLE
Adding optional security tools

### DIFF
--- a/images/capi/ansible/roles/security/README.md
+++ b/images/capi/ansible/roles/security/README.md
@@ -1,0 +1,14 @@
+# Security
+
+The security role enables the installation of Trivy and/or Falco to be installed directly into the image rather than
+having to run privileged pods.
+
+They can be individually enabled using the following `ansible_user_vars`. They are able to be installed in
+the `node_custom_roles_pre`, `node_custom_roles_post` or just as a role reference.
+
+```json
+{
+  "ansible_user_vars": "security_install_falco=true security_install_trivy=true",
+  "node_custom_roles_pre": "security"
+}
+```

--- a/images/capi/ansible/roles/security/defaults/main.yml
+++ b/images/capi/ansible/roles/security/defaults/main.yml
@@ -1,0 +1,17 @@
+# Copyright 2024 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+security_install_falco: ""
+security_install_trivy: ""

--- a/images/capi/ansible/roles/security/tasks/falco.yml
+++ b/images/capi/ansible/roles/security/tasks/falco.yml
@@ -1,0 +1,57 @@
+# Copyright 2024 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Add Falco package signing key
+  ansible.builtin.apt_key:
+    url: https://falco.org/repo/falcosecurity-packages.asc
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Add Falco apt repo
+  ansible.builtin.apt_repository:
+    repo: deb https://download.falco.org/packages/deb stable main
+    state: present
+    filename: falcosecurity
+  when: ansible_os_family == "Debian"
+
+- name: Install Falco requirements
+  ansible.builtin.apt:
+    pkg:
+      - dkms
+      - make
+      - "linux-headers-{{ ansible_kernel }}"
+      - clang
+      - llvm
+    update_cache: true
+    state: present
+  ignore_errors: true
+  register: pkg_result
+  until: pkg_result is success
+  when: ansible_os_family == "Debian"
+
+- name: Install Falco
+  ansible.builtin.apt:
+    name: falco
+    update_cache: true
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Enable Falco Modern eBPF
+  ansible.builtin.service:
+    name: falco-modern-bpf
+    state: started
+    enabled: true
+  when: ansible_os_family == "Debian"

--- a/images/capi/ansible/roles/security/tasks/main.yml
+++ b/images/capi/ansible/roles/security/tasks/main.yml
@@ -1,0 +1,23 @@
+# Copyright 2024 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install Falco
+  ansible.builtin.import_tasks: falco.yml
+  when: security_install_falco | bool
+
+- name: Install Trivy
+  ansible.builtin.import_tasks: trivy.yml
+  when: security_install_trivy | bool

--- a/images/capi/ansible/roles/security/tasks/trivy.yml
+++ b/images/capi/ansible/roles/security/tasks/trivy.yml
@@ -1,0 +1,40 @@
+# Copyright 2024 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Add Trivy package signing key
+  ansible.builtin.apt_key:
+    url: https://aquasecurity.github.io/trivy-repo/deb/public.key
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Add Trivy apt repo
+  ansible.builtin.apt_repository:
+    repo: "deb https://aquasecurity.github.io/trivy-repo/deb {{ansible_distribution_release}} main"
+    state: present
+    filename: trivy
+  when: ansible_os_family == "Debian"
+
+- name: Install Trivy
+  ansible.builtin.apt:
+    name: trivy
+    update_cache: true
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Update Trivy DB to ensure latest records are available as of now
+  ansible.builtin.command: trivy rootfs --download-db-only
+  args:
+    creates: ~/.cache/trivy/db/trivy.db


### PR DESCRIPTION
## Change description

This adds some optional security tooling to the image if users/orgs require it.
Some orgs may not allow privileged pods to run in their environments to run things like the trivy operator or falco. This PR allows the user to install the binaries for those tools directly into the image. 

This PR doesn't support the configuring of Falco via any configuration files as we shouldn't be telling people how to configure this. This should be done using another method, for example copying in files using a feature as requested in [this Issue](https://github.com/kubernetes-sigs/image-builder/issues/1422) once it has been worked on and completed (which I'll try and find the time for asap), or pulling them from an S3 endpoint etc.

I've been using this in my repo for near on a year now and have tested builds both with and without the tools installed so I don't expect any issues including this role as an optional addon.


I'm happy to wait until the next office hours to discuss this if needs be 😃 