### PR TITLE
add Ubuntu 24.04 LTS support for Nutanix

### DIFF
--- a/docs/book/src/capi/providers/nutanix.md
+++ b/docs/book/src/capi/providers/nutanix.md
@@ -46,7 +46,7 @@ Corresponding env variables
 | Variable              | Description                                                    | Default                             |
 |-----------------------|----------------------------------------------------------------|-------------------------------------|
 | `force_deregister`    | Allow output image override if already exists.                 | `false`                             |
-| `image_delete`        | Delete image once enitrebuild process is completed.            | `false`                             |
+| `image_delete`        | Delete image once entire build process is completed.           | `false`                             |
 | `image_export`        | Export raw image in the current folder.                        | `false`                             |
 | `image_name`          | Name of the output image.                                      | `BUILD_NAME-kube-KUBERNETES_SEMVER` |
 | `source_image_delete` | Delete source image once build process is completed            | `false`                             |

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -369,7 +369,7 @@ RAW_BUILD_NAMES				?=      raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar raw-r
 
 POWERVS_BUILD_NAMES         ?= powervs-centos-8
 
-NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2004 nutanix-ubuntu-2204 nutanix-rhel-8 nutanix-rhel-9 nutanix-rockylinux-8 nutanix-rockylinux-9 nutanix-flatcar nutanix-windows-2022
+NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2004 nutanix-ubuntu-2204 nutanix-ubuntu-2404 nutanix-rhel-8 nutanix-rhel-9 nutanix-rockylinux-8 nutanix-rockylinux-9 nutanix-flatcar nutanix-windows-2022
 
 HCLOUD_BUILD_NAMES ?= hcloud-ubuntu-2004 hcloud-ubuntu-2204 hcloud-centos-7 hcloud-rockylinux-8 hcloud-rockylinux-9 hcloud-flatcar
 
@@ -781,6 +781,7 @@ build-osc-all: $(OSC_BUILD_TARGETS) ## Builds all Outscale Snapshot
 
 build-nutanix-ubuntu-2004: ## Builds the Nutanix ubuntu-2004 image
 build-nutanix-ubuntu-2204: ## Builds the Nutanix ubuntu-2204 image
+build-nutanix-ubuntu-2404: ## Builds the Nutanix ubuntu-2404 image
 build-nutanix-rhel-8: ## Builds the Nutanix RedHat Enterprise Linux 8 image
 build-nutanix-rhel-9: ## Builds the Nutanix edHat Enterprise Linux 9 image
 build-nutanix-rockylinux-8: ## Builds the Nutanix Rocky Linux 8 image
@@ -924,6 +925,7 @@ validate-powervs-all: $(POWERVS_VALIDATE_TARGETS) ## Validates all PowerVS Packe
 
 validate-nutanix-ubuntu-2004: ## Validates Ubuntu 20.04 Nutanix Packer config
 validate-nutanix-ubuntu-2204: ## Validates Ubuntu 22.04 Nutanix Packer config
+validate-nutanix-ubuntu-2404: ## Validates Ubuntu 24.04 Nutanix Packer config
 validate-nutanix-rhel-8: ## Validates RedHat Enterprise Linux 8 Nutanix Packer config
 validate-nutanix-rhel-9: ## Validates RedHat Enterprise Linux 9 Nutanix Packer config
 validate-nutanix-rockylinux-8: ## Validates Rocky Linux 8 Nutanix Packer config
@@ -936,8 +938,8 @@ validate-hcloud-ubuntu-2004: ## Validates Ubuntu 20.04 Hetzner Cloud Packer conf
 validate-hcloud-ubuntu-2204: ## Validates Ubuntu 22.04 Hetzner Cloud Packer config
 validate-hcloud-centos-7: ## Validates CentOS 7 Hetzner Cloud Packer config
 validate-hcloud-rockylinux-8: ## Validates Rocky Linux 8 Hetzner Cloud Packer config
-validate-hcloud-rockylinux-9: ## Validates the Hetzner Cloud Rocky Linux 9 Nutanix Packer config
-validate-hcloud-flatcar: ## Validates the Hetzner Cloud Flatcar Nutanix Packer config
+validate-hcloud-rockylinux-9: ## Validates the Hetzner Cloud Rocky Linux 9 Packer config
+validate-hcloud-flatcar: ## Validates the Hetzner Cloud Flatcar Packer config
 validate-hcloud-all: $(HCLOUD_VALIDATE_TARGETS) ## Validates all Hetzner Cloud Packer config
 
 validate-proxmox-ubuntu-2204: ## Validates Ubuntu 22.04 Proxmox Packer config

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -58,7 +58,6 @@ common_debs:
   - libnetfilter-acct1
   - libnetfilter-cttimeout1
   - libnetfilter-log1
-  - python3-distutils
   - python3-netifaces
   - python3-pip
   - socat

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -45,7 +45,6 @@ common_debs: &common_debs
   libnetfilter-acct1:
   libnetfilter-cttimeout1:
   libnetfilter-log1:
-  python3-distutils:
   python3-netifaces:
   python3-pip:
   socat:

--- a/images/capi/packer/nutanix/ubuntu-2404.json
+++ b/images/capi/packer/nutanix/ubuntu-2404.json
@@ -1,0 +1,8 @@
+{
+  "build_name": "ubuntu-2404",
+  "distro_name": "ubuntu",
+  "guest_os_type": "Linux",
+  "image_url": "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img",
+  "shutdown_command": "shutdown -P now",
+  "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCiAgICBzaGVsbDogL2Jpbi9iYXNoCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQo="
+}


### PR DESCRIPTION
## Change description

This PR add the support of Ubuntu 24.04 LTS for the Nutanix plaform



## Additional context

one global deb dependency `python3-distutils` was removed because useless for old distri and no more exist in Ubuntu 24.04 LTS

## Related issues
 * Refs [Support Ubuntu 24.04 LTS (Noble Numbat) #1406](https://github.com/kubernetes-sigs/image-builder/issues/1406)
