### PR TITLE
Add instruction to build DHCP configured images

### DIFF
--- a/docs/book/src/capi/providers/ibmcloud.md
+++ b/docs/book/src/capi/providers/ibmcloud.md
@@ -39,21 +39,26 @@ In addition to the configuration found in `images/capi/packer/config`, the `powe
 
 This table lists several common options that a user may want to set via `PACKER_VAR_FILES` to customize their build behavior.
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `account_id` | IBM Cloud account id. | `""` |
-| `apikey` | IBM Cloud API key. | `""` |
-| `capture_cos_access_key` | The Cloud Object Storage access key. | `""` |
-| `capture_cos_bucket` | The Cloud Object Storage bucket to upload the image within. | `""` |
-| `capture_cos_region` | The Cloud Object Storage region to upload the image within. | `""` |
-| `capture_cos_secret_key` | The Cloud Object Storage secret key. | `""` |
-| `key_pair_name` | The name of the SSH key pair provided to the server for authenticating users (looked up in the tenant's list of keys). | `""` |
-| `region` | The PowerVS service instance region to build the image within. | `""` |
-| `service_instance_id` | The PowerVS service instance id to build the image within. | `""` |
-| `ssh_private_key_file` | The absolute path to the SSH key file. | `""` |
-| `zone` |  The PowerVS service instance zone to build the image within. | `""` |
+| Variable                 | Description                                                                                                            | Default |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------|---------|
+| `account_id`             | IBM Cloud account id.                                                                                                  | `""`    |
+| `apikey`                 | IBM Cloud API key.                                                                                                     | `""`    |
+| `capture_cos_access_key` | The Cloud Object Storage access key.                                                                                   | `""`    |
+| `capture_cos_bucket`     | The Cloud Object Storage bucket to upload the image within.                                                            | `""`    |
+| `capture_cos_region`     | The Cloud Object Storage region to upload the image within.                                                            | `""`    |
+| `capture_cos_secret_key` | The Cloud Object Storage secret key.                                                                                   | `""`    |
+| `key_pair_name`          | The name of the SSH key pair provided to the server for authenticating users (looked up in the tenant's list of keys). | `""`    |
+| `region`                 | The PowerVS service instance region to build the image within.                                                         | `""`    |
+| `service_instance_id`    | The PowerVS service instance id to build the image within.                                                             | `""`    |
+| `ssh_private_key_file`   | The absolute path to the SSH key file.                                                                                 | `""`    |
+| `zone`                   | The PowerVS service instance zone to build the image within.                                                           | `""`    |
+| `dhcp_network`           | The PowerVS image with DHCP support.                                                                                   | `false` |
 
 The parameters can be set via a variable file and passed via `PACKER_VAR_FILES`. See [Customization](../capi.md#customization) for examples.
+
+
+Note: When setting `dhcp_network: true`, make sure to customize the network settings while building OS using [pvsadm tool](https://github.com/ppc64le-cloud/pvsadm/blob/main/docs/Build%20DHCP%20enabled%20Centos%20Images.md).
+Also run the image-builder from system from where the DHCP private IP can be reached and SSH able.
 
 ## CAPIBM - VPC
 

--- a/images/capi/hack/ensure-powervs.sh
+++ b/images/capi/hack/ensure-powervs.sh
@@ -31,7 +31,7 @@ if ! (${SED} --version 2>&1 | grep -q GNU); then
   exit 1
 fi
 
-_version="0.2.1"
+_version="0.2.4"
 _chkfile="packer-plugin-powervs_v${_version}_SHA256SUMS"
 _chk_url="https://github.com/ppc64le-cloud/packer-plugin-powervs/releases/download/v${_version}/${_chkfile}"
 _bin_url="https://github.com/ppc64le-cloud/packer-plugin-powervs/releases/download/v${_version}/packer-plugin-powervs_v${_version}_x5.0_${HOSTOS}_${HOSTARCH}.zip"

--- a/images/capi/packer/powervs/packer.json
+++ b/images/capi/packer/powervs/packer.json
@@ -12,6 +12,7 @@
         },
         "name": "capibm-powervs-{{user `build_name`}}-{{user `kubernetes_rpm_version` | clean_resource_name}}-{{user `build_timestamp`}}"
       },
+      "dhcp_network": "{{user `dhcp_network`}}",
       "instance_name": "capibm-{{user `build_name`}}-{{user `build_timestamp`}}",
       "key_pair_name": "{{user `key_pair_name`}}",
       "region": "{{user `region`}}",
@@ -78,6 +79,7 @@
     "containerd_version": null,
     "crictl_url": null,
     "crictl_version": null,
+    "dhcp_network": "false",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "key_pair_name": "",
     "kubernetes_cni_deb_version": null,


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

packer-plugin-powervs now supports building DHCP enabled images. A new flag was [introduced](https://github.com/ppc64le-cloud/packer-plugin-powervs/pull/196) to facilitate this. 
This PR updates document to add the new flag and its usage.



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
