### PR TITLE
Add Ubuntu 24.04 LTS for DigitalOcean

### DIFF
--- a/docs/book/src/capi/providers/digitalocean.md
+++ b/docs/book/src/capi/providers/digitalocean.md
@@ -4,7 +4,7 @@
 
 - A DigitalOcean account
 - The DigitalOcean CLI ([doctl](https://github.com/digitalocean/doctl#installing-doctl)) installed and configured
-- Set environment variables for `DIGITALOCEAN_ACCESS_TOKEN`,
+- Set an environment variable for your `DIGITALOCEAN_ACCESS_TOKEN`
 
 ## Building Images
 
@@ -27,3 +27,5 @@ the different operating systems.
 |------|-------------|
 | `centos-7.json`    | The settings for the CentOS 7 image |
 | `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
+| `ubuntu-2204.json` | The settings for the Ubuntu 22.04 image |
+| `ubuntu-2404.json` | The settings for the Ubuntu 24.04 image |

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -355,7 +355,7 @@ AZURE_BUILD_SIG_CVM_NAMES ?= $(addsuffix -cvm,$(addprefix azure-sig-,$(SIG_CVM_T
 
 OCI_BUILD_NAMES				?= oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-oracle-linux-9 oci-windows-2019 oci-windows-2022
 
-DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204
+DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204 do-ubuntu-2404
 
 OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-flatcar
 
@@ -654,6 +654,7 @@ build-azure-sigs: $(AZURE_BUILD_SIG_TARGETS) $(AZURE_BUILD_SIG_GEN2_TARGETS) $(A
 
 build-do-ubuntu-2004: ## Builds Ubuntu 20.04 DigitalOcean Snapshot
 build-do-ubuntu-2204: ## Builds Ubuntu 22.04 DigitalOcean Snapshot
+build-do-ubuntu-2404: ## Builds Ubuntu 24.04 DigitalOcean Snapshot
 build-do-centos-7: ## Builds Centos 7 DigitalOcean Snapshot
 build-do-all: $(DO_BUILD_TARGETS) ## Builds all DigitalOcean Snapshot
 
@@ -839,6 +840,7 @@ validate-azure-all: $(AZURE_VALIDATE_SIG_TARGETS) $(AZURE_VALIDATE_VHD_TARGETS) 
 
 validate-do-ubuntu-2004: ## Validates Ubuntu 20.04 DigitalOcean Snapshot Packer config
 validate-do-ubuntu-2204: ## Validates Ubuntu 22.04 DigitalOcean Snapshot Packer config
+validate-do-ubuntu-2404: ## Validates Ubuntu 24.04 DigitalOcean Snapshot Packer config
 validate-do-centos-7: ## Validates Centos 7 DigitalOcean Snapshot Packer config
 validate-do-all: $(DO_VALIDATE_TARGETS) ## Validates all DigitalOcean Snapshot Packer config
 

--- a/images/capi/packer/digitalocean/ubuntu-2404.json
+++ b/images/capi/packer/digitalocean/ubuntu-2404.json
@@ -1,0 +1,5 @@
+{
+  "build_name": "ubuntu-2404",
+  "snapshot_name_suffix": "on Ubuntu 24.04",
+  "source_image": "ubuntu-24-04-x64"
+}


### PR DESCRIPTION
## Change description

Adds image-builder support for DigitalOcean snapshots for the new Ubuntu 24.04 LTS "Noble Numbat" release.

## Related issues

- Refs #1406 
- See also #1449 for prior art

## Additional context

I tested this on my DO account and it seems to be working:

```shell
% make build-do-ubuntu-2404
hack/ensure-python.sh
Checking if python is available
Python 3.12.3
...
==> digitalocean.ubuntu-2404: Gracefully shutting down droplet...
==> digitalocean.ubuntu-2404: Creating snapshot: Cluster API Kubernetes v1.28.9 on Ubuntu 24.04
==> digitalocean.ubuntu-2404: Waiting for snapshot to complete...
==> digitalocean.ubuntu-2404: Destroying droplet...
==> digitalocean.ubuntu-2404: Deleting temporary ssh key...
Build 'digitalocean.ubuntu-2404' finished after 9 minutes 45 seconds.

==> Wait completed after 9 minutes 45 seconds

==> Builds finished. The artifacts of successful builds are:
--> digitalocean.ubuntu-2404: A snapshot was created: 'Cluster API Kubernetes v1.28.9 on Ubuntu 24.04' (ID: 123456789) in regions 'nyc1'
```

![droplet](https://github.com/kubernetes-sigs/image-builder/assets/73019/c4f1fdfe-3099-4d3e-b791-fa0551be8364)

/cc @cpanato 