### PR TITLE
Add Ubuntu 24.04 LTS for AWS

### DIFF
--- a/docs/book/src/capi/providers/aws.md
+++ b/docs/book/src/capi/providers/aws.md
@@ -42,7 +42,14 @@ the different operating systems.
 |------|-------------|
 | `amazon-2.json` | The settings for the Amazon 2 Linux image |
 | `centos-7.json` | The settings for the CentOS 7 image |
-| `ubuntu-1804.json` | The settings for the Ubuntu 18.04 image |
+| `flatcar.json` | The settings for the Flatcar image |
+| `rhel-8.json` | The settings for the RHEL 8 image |
+| `rockylinux.json` | The settings for the Rocky Linux image |
+| `ubuntu-2004.json` | The settings for the Ubuntu 20.04 image |
+| `ubuntu-2204.json` | The settings for the Ubuntu 22.04 image |
+| `ubuntu-2404.json` | The settings for the Ubuntu 24.04 image |
+| `windows-2019.json` | The settings for the Windows 2019 image |
+
 
 #### Common AWS options
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -340,7 +340,7 @@ NODE_OVA_VSPHERE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-,$(PLATFORMS_AND_V
 NODE_OVA_VSPHERE_BASE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-base-,$(PLATFORMS_AND_VERSIONS))
 NODE_OVA_VSPHERE_CLONE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-clone-,$(PLATFORMS_AND_VERSIONS))
 
-AMI_BUILD_NAMES			   ?= ami-centos-7 ami-ubuntu-2004 ami-ubuntu-2204 ami-amazon-2 ami-flatcar ami-windows-2019 ami-rockylinux-8 ami-rhel-8
+AMI_BUILD_NAMES			   ?= ami-centos-7 ami-ubuntu-2004 ami-ubuntu-2204 ami-ubuntu-2404 ami-amazon-2 ami-flatcar ami-windows-2019 ami-rockylinux-8 ami-rhel-8
 GCE_BUILD_NAMES			   ?= gce-ubuntu-2004 gce-ubuntu-2204 gce-rhel-8
 
 # Make needs these lists to be space delimited, no quotes
@@ -618,6 +618,7 @@ build-ami-amazon-2: ## Builds Amazon-2 Linux AMI
 build-ami-centos-7: ## Builds CentOS 7 AMI
 build-ami-ubuntu-2004: ## Builds Ubuntu 20.04 AMI
 build-ami-ubuntu-2204: ## Builds Ubuntu 22.04 AMI
+build-ami-ubuntu-2404: ## Builds Ubuntu 24.04 AMI
 build-ami-rockylinux-8: ## Builds RockyLinux 8 AMI
 build-ami-rhel-8: ## Builds RHEL-8 AMI
 build-ami-flatcar: ## Builds Flatcar
@@ -811,6 +812,7 @@ validate-ami-rhel-8: ## Validates RHEL-8 AMI Packer config
 validate-ami-flatcar: ## Validates Flatcar AMI Packer config
 validate-ami-ubuntu-2004: ## Validates Ubuntu 20.04 AMI Packer config
 validate-ami-ubuntu-2204: ## Validates Ubuntu 22.04 AMI Packer config
+validate-ami-ubuntu-2404: ## Validates Ubuntu 22.04 AMI Packer config
 validate-ami-windows-2019: ## Validates Windows Server 2019 AMI Packer config
 validate-ami-all: $(AMI_VALIDATE_TARGETS) ## Validates all AMIs Packer config
 

--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -12,23 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Upgrade pip to latest
-  ansible.builtin.pip:
-    name: pip
-    executable: pip3
-    state: latest
-
-- name: Install aws clients
-  ansible.builtin.pip:
-    name: "{{ packages }}"
-    executable: pip3
-  vars:
-    packages:
-      - awscli
-  when: ansible_distribution != "Amazon" and ansible_distribution != "RedHat"
-
 - ansible.builtin.include_tasks: awscliv2.yml
-  when: ansible_distribution == "RedHat"
+  when: ansible_distribution != "Amazon"
 
 # Remove after https://github.com/aws/amazon-ssm-agent/issues/235 is fixed.
 - name: Install aws agents RPM on Redhat distributions

--- a/images/capi/ansible/roles/providers/tasks/awscliv2.yml
+++ b/images/capi/ansible/roles/providers/tasks/awscliv2.yml
@@ -1,15 +1,69 @@
 ---
-- name: Install AWS CLI
+- name: Install AWS CLI prequisites
   ansible.builtin.yum:
-    name: unzip
+    name:
+      - gnupg
+      - unzip
     state: present
+  when: ansible_distribution == "RedHat"
 
-- name: Download AWS CLI v2
+- name: Install AWS CLI prerequisites
+  ansible.builtin.apt:
+    name:
+      - gnupg
+      - unzip
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Import AWS public key
+  ansible.builtin.shell: |
+    cat <<EOF > aws-public-key
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    mQINBF2Cr7UBEADJZHcgusOJl7ENSyumXh85z0TRV0xJorM2B/JL0kHOyigQluUG
+    ZMLhENaG0bYatdrKP+3H91lvK050pXwnO/R7fB/FSTouki4ciIx5OuLlnJZIxSzx
+    PqGl0mkxImLNbGWoi6Lto0LYxqHN2iQtzlwTVmq9733zd3XfcXrZ3+LblHAgEt5G
+    TfNxEKJ8soPLyWmwDH6HWCnjZ/aIQRBTIQ05uVeEoYxSh6wOai7ss/KveoSNBbYz
+    gbdzoqI2Y8cgH2nbfgp3DSasaLZEdCSsIsK1u05CinE7k2qZ7KgKAUIcT/cR/grk
+    C6VwsnDU0OUCideXcQ8WeHutqvgZH1JgKDbznoIzeQHJD238GEu+eKhRHcz8/jeG
+    94zkcgJOz3KbZGYMiTh277Fvj9zzvZsbMBCedV1BTg3TqgvdX4bdkhf5cH+7NtWO
+    lrFj6UwAsGukBTAOxC0l/dnSmZhJ7Z1KmEWilro/gOrjtOxqRQutlIqG22TaqoPG
+    fYVN+en3Zwbt97kcgZDwqbuykNt64oZWc4XKCa3mprEGC3IbJTBFqglXmZ7l9ywG
+    EEUJYOlb2XrSuPWml39beWdKM8kzr1OjnlOm6+lpTRCBfo0wa9F8YZRhHPAkwKkX
+    XDeOGpWRj4ohOx0d2GWkyV5xyN14p2tQOCdOODmz80yUTgRpPVQUtOEhXQARAQAB
+    tCFBV1MgQ0xJIFRlYW0gPGF3cy1jbGlAYW1hem9uLmNvbT6JAlQEEwEIAD4CGwMF
+    CwkIBwIGFQoJCAsCBBYCAwECHgECF4AWIQT7Xbd/1cEYuAURraimMQrMRnJHXAUC
+    ZMKcEgUJCSEf3QAKCRCmMQrMRnJHXCilD/4vior9J5tB+icri5WbDudS3ak/ve4q
+    XS6ZLm5S8l+CBxy5aLQUlyFhuaaEHDC11fG78OduxatzeHENASYVo3mmKNwrCBza
+    NJaeaWKLGQT0MKwBSP5aa3dva8P/4oUP9GsQn0uWoXwNDWfrMbNI8gn+jC/3MigW
+    vD3fu6zCOWWLITNv2SJoQlwILmb/uGfha68o4iTBOvcftVRuao6DyqF+CrHX/0j0
+    klEDQFMY9M4tsYT7X8NWfI8Vmc89nzpvL9fwda44WwpKIw1FBZP8S0sgDx2xDsxv
+    L8kM2GtOiH0cHqFO+V7xtTKZyloliDbJKhu80Kc+YC/TmozD8oeGU2rEFXfLegwS
+    zT9N+jB38+dqaP9pRDsi45iGqyA8yavVBabpL0IQ9jU6eIV+kmcjIjcun/Uo8SjJ
+    0xQAsm41rxPaKV6vJUn10wVNuhSkKk8mzNOlSZwu7Hua6rdcCaGeB8uJ44AP3QzW
+    BNnrjtoN6AlN0D2wFmfE/YL/rHPxU1XwPntubYB/t3rXFL7ENQOOQH0KVXgRCley
+    sHMglg46c+nQLRzVTshjDjmtzvh9rcV9RKRoPetEggzCoD89veDA9jPR2Kw6RYkS
+    XzYm2fEv16/HRNYt7hJzneFqRIjHW5qAgSs/bcaRWpAU/QQzzJPVKCQNr4y0weyg
+    B8HCtGjfod0p1A==
+    =gdMc
+    -----END PGP PUBLIC KEY BLOCK-----
+    EOF
+    gpg --import aws-public-key
+    rm aws-public-key
+
+- name: Download AWS CLI v2 archive signature file
   ansible.builtin.get_url:
-    url: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+    url: https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip.sig
+    dest: /tmp/awscliv2.zip.sig
+
+- name: Download AWS CLI v2 archive
+  ansible.builtin.get_url:
+    url: https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip
     dest: /tmp/awscliv2.zip
 
-- name: Unzip AWS CLI v2
+- name: Verify AWS CLI v2 archive
+  ansible.builtin.command: gpg --verify /tmp/awscliv2.zip.sig /tmp/awscliv2.zip
+
+- name: Unzip AWS CLI v2 archive
   ansible.builtin.unarchive:
     src: /tmp/awscliv2.zip
     dest: /tmp

--- a/images/capi/packer/ami/ubuntu-2404.json
+++ b/images/capi/packer/ami/ubuntu-2404.json
@@ -1,0 +1,11 @@
+{
+  "ami_filter_name": "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*",
+  "ami_filter_owners": "099720109477",
+  "build_name": "ubuntu-24.04",
+  "distribution": "Ubuntu",
+  "distribution_release": "noble",
+  "distribution_version": "24.04",
+  "root_device_name": "/dev/sda1",
+  "source_ami": "",
+  "ssh_username": "ubuntu"
+}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -144,9 +144,8 @@ centos:
       amazon-ssm-agent:
       <<: *rh7_rpms
     command:
-      pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
+      /usr/local/sbin/aws --version:
         exit-status: 0
-        stdout: ["awscli"]
         stderr: []
         timeout: 0
   azure:
@@ -247,10 +246,9 @@ rockylinux:
       amazon-ssm-agent:
       <<: *rh8_rpms
     command:
-      pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
+      /usr/local/sbin/aws --version:
         exit-status: 0
-        stdout: [ "awscli" ]
-        stderr: [ ]
+        stderr: []
         timeout: 0
     service:
       amazon-ssm-agent:
@@ -313,10 +311,9 @@ rhel:
         package:
           <<: *rh8_rpms
     command:
-      pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
+      /usr/local/sbin/aws --version:
         exit-status: 0
-        stdout: [ "awscli" ]
-        stderr: [ ]
+        stderr: []
         timeout: 0
     service:
       amazon-ssm-agent:
@@ -430,9 +427,8 @@ ubuntu:
         stdout: ["amazon-ssm-agent"]
         stderr: []
         timeout: 0
-      pip3 list --format=columns | grep 'awscli' | awk -F' ' '{print $1}':
+      /usr/local/sbin/aws --version:
         exit-status: 0
-        stdout: ["awscli"]
         stderr: []
         timeout: 0
   gcp:
@@ -552,8 +548,8 @@ windows:
       - Manual
       - Stopped
     kubelet:
-      expected: 
-      - Automatic 
+      expected:
+      - Automatic
       - "/RequiredServices.+:.+(containerd|docker)/"
     sshd:
       expected:
@@ -563,8 +559,8 @@ windows:
   azure:
     windows-service:
 
-    files: 
-      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+    files:
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf':
         exists: true
         filetype: file
         contains:
@@ -579,11 +575,11 @@ windows:
   ova:
     windows-service:
       vmtools:
-        expected: 
-        - Automatic 
+        expected:
+        - Automatic
         - Running
     files:
-      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf':
         exists: true
         filetype: file
         contains:
@@ -598,7 +594,7 @@ windows:
         - "cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin"
         - "cloudbaseinit.plugins.windows.createuser.CreateUserPlugin"
         - "cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin"
-      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init-unattend.conf': 
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init-unattend.conf':
         exists: true
         filetype: file
         contains:
@@ -607,7 +603,7 @@ windows:
     windows-service:
 
     files:
-      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf':
         exists: true
         filetype: file
         contains:
@@ -622,7 +618,7 @@ windows:
     windows-service:
 
     files:
-      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf': 
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init.conf':
         exists: true
         filetype: file
         contains:
@@ -636,7 +632,7 @@ windows:
         - "cloudbaseinit.plugins.common.localscripts.LocalScriptsPlugin"
         - "cloudbaseinit.plugins.windows.createuser.CreateUserPlugin"
         - "cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin"
-      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init-unattend.conf': 
+      'c:/program files/Cloudbase Solutions/Cloudbase-init/conf/cloudbase-init-unattend.conf':
         exists: true
         filetype: file
         contains:


### PR DESCRIPTION
## Change description

Adds image-builder support for AWS AMIs for the new Ubuntu 24.04 LTS "Noble Numbat" release.

Refactoring of the `awscli` install was necessary, because installing things with `pip` is difficult in current distros. I unified this for all Amazon-supported distros into one set of tasks based on the [official CLI install docs](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html). The zip file is now verified with AWS' public key before unarchiving.

## Related issues

- Refs #1406 
- See also #994 for prior art

## Additional context

I tested this on my AWS account and it seems to be working:

```shell
% make build-ami-ubuntu-2404
hack/ensure-python.sh
Checking if python is available
Python 3.12.3
...
amazon-ebs.ubuntu-24.04: output will be in this color.

==> amazon-ebs.ubuntu-24.04: Prevalidating any provided VPC information
==> amazon-ebs.ubuntu-24.04: Prevalidating AMI Name: capa-ami-ubuntu-24.04-v1.28.9-1714510986
    amazon-ebs.ubuntu-24.04: Found Image ID: ami-04b70fa74e45c3917
...
==> amazon-ebs.ubuntu-24.04: Goss validate ran successfully
==> amazon-ebs.ubuntu-24.04: Running GOSS render command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"ubuntu","OS_VERSION":"24.04","PROVIDER":"amazon","containerd_version":"1.7.13","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.28.9-2.1","kubernetes_rpm_version":"1.28.9","kubernetes_source_type":"pkg","kubernetes_version":"1.28.9"}' render > /tmp/goss-spec.yaml
==> amazon-ebs.ubuntu-24.04: Goss render ran successfully
==> amazon-ebs.ubuntu-24.04: 
==> amazon-ebs.ubuntu-24.04: 
==> amazon-ebs.ubuntu-24.04: 
==> amazon-ebs.ubuntu-24.04: Downloading spec file and debug info
    amazon-ebs.ubuntu-24.04: Downloading Goss specs from, /tmp/goss-spec.yaml and /tmp/debug-goss-spec.yaml to current dir
==> amazon-ebs.ubuntu-24.04: Stopping the source instance...
    amazon-ebs.ubuntu-24.04: Stopping instance
==> amazon-ebs.ubuntu-24.04: Waiting for the instance to stop...
==> amazon-ebs.ubuntu-24.04: Creating AMI capa-ami-ubuntu-24.04-v1.28.9-1714510986 from instance i-0dc355060a892f2de
    amazon-ebs.ubuntu-24.04: AMI: ami-096ea07b8aeb94bf3
...
```

I also tested RHEL 8 and the other Ubuntu targets.