### PR TITLE
Azure: allow Mariner publishing in pipeline

### DIFF
--- a/images/capi/packer/azure/scripts/new-sku.sh
+++ b/images/capi/packer/azure/scripts/new-sku.sh
@@ -40,6 +40,9 @@ sku_id="${os}-${version}-${VM_GENERATION}"
 if [ "$OS" == "Ubuntu" ]; then
     os_type="Ubuntu"
     os_family="Linux"
+elif [ "$OS" == "Mariner" ]; then
+    os_type="CBL-Mariner"
+    os_family="Linux"
 elif [ "$OS" == "Windows" ]; then
     os_type="Other"
     os_family="Windows"


### PR DESCRIPTION
## Change description

Allows publishing of the `Mariner` Linux distro type to the Azure Marketplace via the `new-sku.sh` script.

## Related issues

- Fixes #

## Additional context

Tested IRL, works as expected.

/cc @jeremyrickard 
