### PR TITLE
Add Ubuntu 24.04 for GCE

### DIFF
--- a/docs/book/src/capi/providers/gcp.md
+++ b/docs/book/src/capi/providers/gcp.md
@@ -31,9 +31,9 @@ $ make deps-gce
 ### Run the Make target to generate GCE images.
 From `images/capi` directory, run `make build-gce-ubuntu-<version>` command depending on which ubuntu version you want to build the image for.
 
-For instance, to build an image for `ubuntu 18-04`, run
+For instance, to build an image for `ubuntu 24.04`, run
 ```bash
-$ make build-gce-ubuntu-1804
+$ make build-gce-ubuntu-2404
 ```
 
 To build all gce ubuntu images, run
@@ -48,8 +48,10 @@ The `gce` sub-directory inside `images/capi/packer` stores JSON configuration fi
 
 | File | Description
 | -------- | --------
-| `ubuntu-1804.json`     | Settings for Ubuntu 18-04 image     |
-| `ubuntu-2004.json`     | Settings for Ubuntu 20-04 image     |
+| `ubuntu-2004.json`     | Settings for Ubuntu 20.04 image     |
+| `ubuntu-2204.json`     | Settings for Ubuntu 22.04 image     |
+| `ubuntu-2404.json`     | Settings for Ubuntu 24.04 image     |
+| `rhel-8.json`     | Settings for RHEL 8 image     |
 
 ### List Images
 
@@ -59,7 +61,7 @@ List all images by running the following command in the console
 $ gcloud compute images list --project ${GCP_PROJECT_ID} --no-standard-images
 
 NAME                                         PROJECT            FAMILY                      DEPRECATED  STATUS
-cluster-api-ubuntu-1804-v1-17-11-1603233313  myregistry-292303  capi-ubuntu-1804-k8s-v1-17              READY
+cluster-api-ubuntu-2404-v1-17-11-1603233313  myregistry-292303  capi-ubuntu-2404-k8s-v1-17              READY
 cluster-api-ubuntu-2004-v1-17-11-1603233874  myregistry-292303  capi-ubuntu-2004-k8s-v1-17              READY
 ```
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -342,7 +342,7 @@ NODE_OVA_VSPHERE_BASE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-base-,$(PLATF
 NODE_OVA_VSPHERE_CLONE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-clone-,$(PLATFORMS_AND_VERSIONS))
 
 AMI_BUILD_NAMES			   ?= ami-centos-7 ami-ubuntu-2004 ami-ubuntu-2204 ami-ubuntu-2404 ami-amazon-2 ami-flatcar ami-windows-2019 ami-rockylinux-8 ami-rhel-8
-GCE_BUILD_NAMES			   ?= gce-ubuntu-2004 gce-ubuntu-2204 gce-rhel-8
+GCE_BUILD_NAMES			   ?= gce-ubuntu-2004 gce-ubuntu-2204 gce-ubuntu-2404 gce-rhel-8
 
 # Make needs these lists to be space delimited, no quotes
 VHD_TARGETS := $(shell grep VHD_TARGETS azure_targets.sh | sed 's/VHD_TARGETS=//' | tr -d \")
@@ -676,6 +676,7 @@ build-do-all: $(DO_BUILD_TARGETS) ## Builds all DigitalOcean Snapshot
 
 build-gce-ubuntu-2004: ## Builds the GCE ubuntu-2004 image
 build-gce-ubuntu-2204: ## Builds the GCE ubuntu-2204 image
+build-gce-ubuntu-2404: ## Builds the GCE ubuntu-2404 image
 build-gce-rhel-8: ## Builds the GCE rhel-8 image
 build-gce-all: $(GCE_BUILD_TARGETS) ## Builds all GCE image
 
@@ -889,6 +890,7 @@ validate-openstack-all: $(OPENSTACK_VALIDATE_TARGETS) ## Validates all Openstack
 
 validate-gce-ubuntu-2004: ## Validates Ubuntu 20.04 GCE Snapshot Packer config
 validate-gce-ubuntu-2204: ## Validates Ubuntu 22.04 GCE Snapshot Packer config
+validate-gce-ubuntu-2404: ## Validates Ubuntu 24.04 GCE Snapshot Packer config
 validate-gce-rhel-8: ## Validates RHEL 8 GCE Snapshot Packer config
 validate-gce-all: $(GCE_VALIDATE_TARGETS) ## Validates all GCE Snapshot Packer config
 

--- a/images/capi/packer/gce/ubuntu-2404.json
+++ b/images/capi/packer/gce/ubuntu-2404.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "ubuntu-2404",
+  "distribution": "ubuntu",
+  "distribution_release": "noble",
+  "distribution_version": "2404",
+  "source_image_family": "ubuntu-2404-lts-amd64",
+  "ssh_username": "ubuntu",
+  "zone": "us-central1-a"
+}


### PR DESCRIPTION
## Change description

Adds image-builder support for GCE images for the new Ubuntu 24.04 LTS "Noble Numbat" release.

## Related issues

- Refs #1406 
- See also #994 for prior art

## Additional context

There isn't yet an official Ubuntu 24.04 image from Canonical at Google: https://console.cloud.google.com/compute/instances(cameo:browse)?hl=en&filter=solution-type:vm&q=ubuntu%2024.04
But when there is, this might work. 😄 I'll keep an eye out and retest when it's available.