### PR TITLE
openstack: add goss option

### DIFF
--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -65,10 +65,14 @@
     },
     {
       "arch": "{{user `goss_arch`}}",
+      "download_path": "{{user `goss_download_path`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
       "inspect": "{{user `goss_inspect_mode`}}",
+      "remote_folder": "{{user `goss_remote_folder`}}",
+      "remote_path": "{{user `goss_remote_path`}}",
+      "skip_install": "{{user `goss_skip_install`}}",
       "tests": [
         "{{user `goss_tests_dir`}}"
       ],


### PR DESCRIPTION


## Change description
Hi,

This PR add options to allow users to override configuration of goss provisionner  installation in openstack cloud
- `download_path`
- `remote_folder`
- `remote_path`
- `skip_install`

Thank you for your great project

## Related issues


## Additional context

