### PR TITLE
Fix PowerVS builds by including wasm-shims file

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -285,6 +285,7 @@ COMMON_POWERVS_VAR_FILES := packer/config/kubernetes.json \
 					packer/config/cni.json \
 					packer/config/ppc64le/cni.json \
 					packer/config/containerd.json \
+					packer/config/wasm-shims.json \
                     packer/config/ppc64le/containerd.json \
                     packer/config/ansible-args.json \
                     packer/config/goss-args.json \


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Removes unused variable `containerd_wasm_shims_runtime_versions` while copying containerd config file.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1466 



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
