### PR TITLE
Update docs for v0.1.27

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,11 @@
 # Image Builder Releases
 
-The current release of Image Builder is [v0.1.26][] (May 20, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26`.
+The current release of Image Builder is [v0.1.27][] (May 24, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27`.
 
 ## Release Process
 
 For more detail about image-builder project releases, see the [Image Builder Book][].
 
 
-[v0.1.26]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.26
+[v0.1.27]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.27
 [Image Builder Book]: https://image-builder.sigs.k8s.io/capi/releasing.html

--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -18,7 +18,7 @@ Run the docker build target of Makefile
 The latest image-builder container image release is available here:
 
 ```commandline
-docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26
+docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27
 ```
 
 ### Examples
@@ -27,7 +27,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     - If the AWS CLI is already installed on your machine, you can simply mount the `~/.aws` folder that stores all the required credentials.
 
     ```commandline
-    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26 build-ami-ubuntu-2004
+    docker run -it --rm -v /Users/<user>/.aws:/home/imagebuilder/.aws registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27 build-ami-ubuntu-2004
     ```
     - Another alternative is to use an `aws-creds.env` file to load the credentials and pass it during docker run.
 
@@ -38,7 +38,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```
 
     ```commandline
-        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26 build-ami-ubuntu-2004
+        docker run -it --rm --env-file aws-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27 build-ami-ubuntu-2004
     ```
 
 - AZURE
@@ -53,7 +53,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```
 
     ```commandline
-    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26 build-azure-sig-ubuntu-2004
+    docker run -it --rm --env-file az-creds.env registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27 build-azure-sig-ubuntu-2004
     ```
 
 - vSphere OVA
@@ -62,7 +62,7 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
     - Docker's `--net=host` option to ensure http server starts with the host IP and not the Docker container IP. This option is Linux specific and thus implies that it can be run only from a Linux machine.
 
     ```commandline
-    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26 build-node-ova-vsphere-ubuntu-2004
+    docker run -it --rm --net=host --env PACKER_VAR_FILES=/home/imagebuilder/vsphere.json -v <complete path of vsphere.json>:/home/imagebuilder/vsphere.json registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27 build-node-ova-vsphere-ubuntu-2004
     ```
 
 In addition to this, further customizations can be done as discussed [here](./capi.md#customization).

--- a/docs/book/src/capi/releasing.md
+++ b/docs/book/src/capi/releasing.md
@@ -1,6 +1,6 @@
 # Image Builder Releases
 
-The current release of Image Builder is [v0.1.26][] (May 20, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.26`.
+The current release of Image Builder is [v0.1.27][] (May 24, 2024). The corresponding container image is `registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v0.1.27`.
 
 ## Release Process
 
@@ -22,7 +22,7 @@ Releases in image-builder follow [semantic versioning][semver] conventions. Curr
     - *If signing tags with GPG, makes your key available to the `git tag` command.*
 - Create a new tag:
   - `export IB_VERSION=v0.1.x`
-    - *Replace `x` with the next patch version. For example: `v0.1.27`.*
+    - *Replace `x` with the next patch version. For example: `v0.1.28`.*
   - `git tag -s -m "Image Builder ${IB_VERSION}" ${IB_VERSION}`
   - `git push upstream ${IB_VERSION}`
 
@@ -77,11 +77,11 @@ Wait for this PR to merge before communicating the release to users, so image-bu
 In the [#image-builder channel][] on the Kubernetes Slack, post a message announcing the new release. Include a link to the GitHub release and a thanks to the contributors:
 
 ```
-Image-builder v0.1.27 is now available: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.26
+Image-builder v0.1.28 is now available: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.27
 Thanks to all contributors!
 ```
 
-[v0.1.26]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.26
+[v0.1.27]: https://github.com/kubernetes-sigs/image-builder/releases/tag/v0.1.27
 [#image-builder channel]: https://kubernetes.slack.com/archives/C01E0Q35A8J
 [Personal access tokens]: https://github.com/settings/tokens
 [post-image-builder-push-images]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-image-builder-push-images

--- a/images/capi/scripts/release-update-docs.sh
+++ b/images/capi/scripts/release-update-docs.sh
@@ -10,7 +10,7 @@ CURRENT_VERSION=${CURRENT_VERSION#v}
 NEXT_VERSION=$(echo ${CURRENT_VERSION} | awk -F. -v OFS=. '{$NF += 1 ; print}')
 NEXT_VERSION=${NEXT_VERSION#v}
 
-OLD_DATE=$(git log -1 --format=%aI v${OLD_VERSION})
+OLD_DATE=$(git for-each-ref --format="%(taggerdate:short)" refs/tags/v${OLD_VERSION})
 OLD_DATE=$(date -d${OLD_DATE} '+%B %-d, %Y')
 TODAY_DATE=$(date '+%B %-d, %Y')
 


### PR DESCRIPTION
Updates the docs for the new release v0.1.27

Also fixed a bug in the `release-update-docs` script that incorrectly got the date of the previous tag.

/hold for new release published