### PR TITLE
In packer/openstack, add "source_image_filter" to select source image by name

### DIFF
--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -12,6 +12,12 @@
       "networks": "{{user `networks`}}",
       "security_groups": "{{user `security_groups`}}",
       "source_image": "{{user `source_image`}}",
+      "source_image_filter": {
+        "filters": {
+          "name": "{{user `source_image_filter_name`}}"
+        },
+        "most_recent": true
+      },
       "ssh_keypair_name": "{{user `ssh_keypair_name`}}",
       "ssh_private_key_file": "{{user `ssh_private_key_file`}}",
       "ssh_timeout": "2h",


### PR DESCRIPTION

## Change description
<!-- What this PR does / why we need it. -->

In packer/openstack, you can select the source image name with `source_image_filter` instead of `source_image` id.
( previous configuration with source image id work by default, no changes)

For example, to use the new  `source_image_filter_name`, and choose the most recent image by name ,  set this in your custom packer.json

```json
  "source_image": "",
  "source_image_filter_name": "ubuntu-22.04",
```

## Related issues

## Additional context
