### PR TITLE
Match ubuntu grub configuration with Canonical cloud-images

### DIFF
--- a/images/capi/ansible/roles/sysprep/files/etc/default/grub.d/50-cloudimg-settings.cfg
+++ b/images/capi/ansible/roles/sysprep/files/etc/default/grub.d/50-cloudimg-settings.cfg
@@ -1,0 +1,14 @@
+# Cloud Image specific Grub settings for Cloud Images
+# This file was created/modified by the k8s image-builder process
+
+# Set the recordfail timeout
+GRUB_RECORDFAIL_TIMEOUT=0
+
+# Do not wait on grub prompt
+GRUB_TIMEOUT=0
+
+# Set the default commandline
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0"
+
+# Set the grub console type
+GRUB_TERMINAL=console

--- a/images/capi/ansible/roles/sysprep/handlers/main.yml
+++ b/images/capi/ansible/roles/sysprep/handlers/main.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Update debian grub
+  ansible.builtin.shell: |
+    update-grub
+  changed_when: true

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -99,6 +99,16 @@
     state: absent
     path: /etc/udev/rules.d/70-persistent-net.rules
 
+- name: Configure grub for non graphical consoles
+  ansible.builtin.copy:
+    src: etc/default/grub.d/50-cloudimg-settings.cfg
+    dest: /etc/default/grub.d/50-cloudimg-settings.cfg
+    group: root
+    owner: root
+    mode: "0644"
+  notify:
+    - Update debian grub
+
 - name: Remvoing subiquity disable disable cloud-init networking config
   ansible.builtin.file:
     path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg


### PR DESCRIPTION
## Change description
This change sets up grub in the built ubuntu images the same way as it is configured in ubuntu cloud-images built by Canonical.

The defaults file as found in a regular ubuntu cloud-image is copied into /etc/defaults/grub.d/ and the grub configuration is rebuilt during the sysprep ansible role.

This means that the serial console now works making cloud provider serial consoles functional, and the splash screen is removed matching the behaviour in a regular cloud-image

## Additional context
The main change that this introduces is `console=.....` in the kernel boot parameters is set appropriately for a cloud-image

Canonical built Ubuntu cloud-image on AWS:

```
cat /proc/cmdline
ubuntu@ip-172-31-33-227:~$ cat /proc/cmdline BOOT_IMAGE=/boot/vmlinuz-6.5.0-1017-aws root=PARTUUID=ce1444c3-4426-432c-bd99-fae2b4e17929 ro console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 panic=-1
```

Canonical built Ubuntu cloud-image on Openstack

```
ubuntu@capi-image-build:~$ cat /proc/cmdline
BOOT_IMAGE=/boot/vmlinuz-5.15.0-107-generic root=UUID=c0bf3504-027d-4e05-8c89-a8ba8d0102c8 ro console=tty1 console=ttyS0
```