### PR TITLE
proxmox-ubuntu-22.04: Make boot command wait times more robust

### DIFF
--- a/images/capi/packer/proxmox/ubuntu-2204.json
+++ b/images/capi/packer/proxmox/ubuntu-2204.json
@@ -1,5 +1,5 @@
 {
-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait5s>initrd /casper/initrd <enter><wait5s>boot <enter><wait5s>",
+  "boot_command_prefix": "c<wait>linux /casper/vmlinuz --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait10s>initrd /casper/initrd <enter><wait10s>boot <enter><wait10s>",
   "build_name": "ubuntu-2204",
   "distribution_version": "2204",
   "distro_name": "ubuntu",


### PR DESCRIPTION
This increases the wait times after pressing Enter key from 5 second to 10 seconds during the boot command insertion, which more results in more robust VM startup process. Previous value of 5 seconds can result in failure due to insufficient wait time:

    ==> proxmox-iso.ubuntu-2204: Typing the boot command
    ==> proxmox-iso.ubuntu-2204: Error running boot command:
        Put "https://10.9.1.0:8006/api2/json/nodes/pm0/qemu/104/sendkey": EOF