### PR TITLE
Add cloud image based qemu builds

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -117,6 +117,7 @@ deps-qemu: ## Installs/checks dependencies for QEMU builds
 deps-qemu: deps-common
 	hack/ensure-goss.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) plugins install github.com/hashicorp/qemu
 
 .PHONY: deps-raw
 deps-raw: ## Installs/checks dependencies for RAW builds
@@ -362,7 +363,7 @@ OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2304 qemu-ubuntu-2204-efi qemu-centos-7 qemu-centos-9 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rhel-9 qemu-rockylinux-8 qemu-rockylinux-9 qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2304 qemu-ubuntu-2204-efi qemu-centos-7 qemu-centos-9 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rhel-9 qemu-rockylinux-8 qemu-rockylinux-8-cloudimg qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
 
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
@@ -772,6 +773,7 @@ build-qemu-flatcar: ## Builds Flatcar QEMU image
 build-qemu-ubuntu-2004: ## Builds Ubuntu 20.04 QEMU image
 build-qemu-ubuntu-2004-efi: ## Builds Ubuntu 20.04 QEMU image that EFI boots
 build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
+build-qemu-ubuntu-2204-cloudimg: ## Builds Ubuntu 22.04 QEMU image using cloud image
 build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
 build-qemu-ubuntu-2304: ## Builds Ubuntu 23.04 QEMU image
 build-qemu-centos-7: ## Builds CentOS 7 QEMU image
@@ -779,7 +781,9 @@ build-qemu-centos-9: ## Builds CentOS 9 Stream QEMU image
 build-qemu-rhel-8: ## Builds RHEL 8 QEMU image
 build-qemu-rhel-9: ## Builds RHEL 9 QEMU image
 build-qemu-rockylinux-8: ## Builds Rocky 8 QEMU image
+build-qemu-rockylinux-8-cloudimg: ## Builds Rocky 8 QEMU image using cloud image
 build-qemu-rockylinux-9: ## Builds Rocky 9 QEMU image
+build-qemu-rockylinux-9-cloudimg: ## Builds Rocky 9 QEMU image using cloud image
 build-qemu-all: $(QEMU_BUILD_TARGETS) ## Builds all Qemu images
 
 build-raw-flatcar: ## Builds Flatcar RAW image
@@ -936,13 +940,16 @@ validate-qemu-flatcar: ## Validates Flatcar QEMU image packer config
 validate-qemu-ubuntu-2004: ## Validates Ubuntu 20.04 QEMU image packer config
 validate-qemu-ubuntu-2004-efi: ## Validates Ubuntu 20.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
+validate-qemu-ubuntu-2204-cloudimg: ## Validates Ubuntu 22.04 QEMU image packer config using cloud image
 validate-qemu-ubuntu-2204-efi: ## Validates Ubuntu 22.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2304: ## Validates Ubuntu 23.04 QEMU image packer config
 validate-qemu-centos-7: ## Validates CentOS 7 QEMU image packer config
 validate-qemu-rhel-8: ## Validates RHEL 8 QEMU image
 validate-qemu-rhel-9: ## Validates RHEL 9 QEMU image
 validate-qemu-rockylinux-8: ## Validates Rocky Linux 8 QEMU image packer config
+validate-qemu-rockylinux-8-cloudimg: ## Validates Rocky Linux 8 QEMU image packer config using cloud image
 validate-qemu-rockylinux-9: ## Validates Rocky Linux 9 QEMU image packer config
+validate-qemu-rockylinux-9-cloudimg: ## Validates Rocky Linux 9 QEMU image packer config using cloud image
 validate-qemu-all: $(QEMU_VALIDATE_TARGETS) ## Validates all Qemu Packer config
 
 validate-raw-flatcar: ## Validates Flatcar RAW image packer config

--- a/images/capi/ansible/firstboot.yml
+++ b/images/capi/ansible/firstboot.yml
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+- name: Bootstrap Python
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Check if Python is installed
+      changed_when: false
+      failed_when: false
+      ansible.builtin.raw: test -e "{{ ansible_python_interpreter | default('/usr/bin/python3') }}"
+      register: python_installed
+
+    - name: Install Python
+      changed_when: true
+      ansible.builtin.raw: test -e /usr/bin/apt && (apt-get update && apt-get install -y python3) || (yum install -y python3)
+      when: python_installed.rc != 0
+
 - hosts: all
   become: true
   vars:

--- a/images/capi/packer/qemu/cloud-init/user-data
+++ b/images/capi/packer/qemu/cloud-init/user-data
@@ -1,0 +1,9 @@
+#cloud-config
+ssh_pwauth: true
+users:
+  - name: builder
+    passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
+    groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+    lock-passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -8,10 +8,15 @@
         "{{user `boot_command_suffix`}}"
       ],
       "boot_wait": "{{user `boot_wait`}}",
+      "cd_files": [
+        "{{user `cd_files`}}"
+      ],
+      "cd_label": "cidata",
       "cpu_model": "host",
       "cpus": "{{user `cpus`}}",
       "disk_compression": "{{ user `disk_compression`}}",
       "disk_discard": "{{user `disk_discard`}}",
+      "disk_image": "{{ user `disk_image` }}",
       "disk_interface": "virtio-scsi",
       "disk_size": "{{user `disk_size`}}",
       "firmware": "{{user `firmware`}}",
@@ -156,6 +161,7 @@
     "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
     "boot_wait": "10s",
     "build_timestamp": "{{timestamp}}",
+    "cd_files": "linux/base/*.nothing",
     "containerd_sha256": null,
     "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",
     "containerd_version": null,
@@ -164,6 +170,7 @@
     "crictl_version": null,
     "disk_compression": "false",
     "disk_discard": "unmap",
+    "disk_image": "false",
     "disk_size": "20480",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "firmware": "",

--- a/images/capi/packer/qemu/qemu-rockylinux-8-cloudimg.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-8-cloudimg.json
@@ -1,0 +1,17 @@
+{
+  "build_name": "rockylinux-8",
+  "cd_files": "./packer/qemu/cloud-init/*",
+  "disk_image": "true",
+  "distribution_version": "8",
+  "distro_arch": "amd64",
+  "distro_name": "rockylinux",
+  "distro_version": "8",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
+  "guest_os_type": "centos8-64",
+  "iso_checksum": "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/CHECKSUM",
+  "iso_checksum_type": "file",
+  "iso_url": "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2",
+  "os_display_name": "RockyLinux 8",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+  "shutdown_command": "/sbin/halt -h -p"
+}

--- a/images/capi/packer/qemu/qemu-rockylinux-9-cloudimg.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-9-cloudimg.json
@@ -1,0 +1,17 @@
+{
+  "build_name": "rockylinux-9",
+  "cd_files": "./packer/qemu/cloud-init/*",
+  "disk_image": "true",
+  "distribution_version": "9",
+  "distro_arch": "amd64",
+  "distro_name": "rockylinux",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "guest_os_type": "centos9-64",
+  "iso_checksum": "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/CHECKSUM",
+  "iso_checksum_type": "file",
+  "iso_url": "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base.latest.x86_64.qcow2",
+  "os_display_name": "RockyLinux 9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "shutdown_command": "/sbin/halt -h -p"
+}

--- a/images/capi/packer/qemu/qemu-ubuntu-2204-cloudimg.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2204-cloudimg.json
@@ -1,0 +1,13 @@
+{
+  "build_name": "ubuntu-2204",
+  "cd_files": "./packer/qemu/cloud-init/*",
+  "disk_image": "true",
+  "distribution_version": "2204",
+  "distro_name": "ubuntu",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS",
+  "iso_checksum_type": "file",
+  "iso_url": "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img",
+  "os_display_name": "Ubuntu 22.04",
+  "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
## Change description
Distributions often ship images which are pre-installed and optimized
for cloud usage which is the case for most `qemu` images.  It is far
better to leverage those existing optimized images and put our
components on top of it rather than install from scratch in an ISO
each time.

This will result in faster build times (preventing the lengthy install
process and making it a simple quick boot) and make builds more reliable
indirectly because of that.  It will also ensure that the image will be
more cloud-native with things like serial interface being mounted
in the right place, etc.

This was setup in a way that existing images can continue to live
with these new ones using a -cloudimg prefix, so both can continue
to work should there be people with a preference to build using
ISO images still.

Since some of the images don't ship with Python, the firstboot playbook
has been updated to support installing Python if it is not installed.

## Related issues
N/A


## Additional context
N/A
