### PR TITLE
cloud-init: improve logging to stream logs to the cloud-init-output.log file instead of dumping at the end

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/05_logging.cfg
+++ b/images/capi/ansible/roles/providers/files/etc/cloud/cloud.cfg.d/05_logging.cfg
@@ -64,4 +64,4 @@ log_cfgs:
 # this tells cloud-init to redirect its stdout and stderr to
 # 'tee -a /var/log/cloud-init-output.log' so the user can see output
 # there without needing to look on the console.
-output: {all: '| python3 -c ''import sys,time;sys.stdout.write("".join(( " ".join((time.strftime("[%Y-%m-%d %H:%M:%S]", time.localtime()), line)) for line in sys.stdin )))'' | tee -a /var/log/cloud-init-output.log'}
+output: {all: '| python3 -c ''exec("import sys,time\nfor line in sys.stdin:\n  sys.stdout.write(\" \".join((time.strftime(\"[%Y-%m-%d %H:%M:%S]\", time.localtime()), line)))")'' | tee -a /var/log/cloud-init-output.log'}


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This PR changes the logging command for cloud-init-output.log to stream the logs instead of dumping after finishing the command.

When debugging, the old command's python script is written to finish reading from stdin until it starts to write to stdout.
This makes it hard to debug failures while they occur because it is not possible to see easily what cloud-init is currently doing.

Example command to run for the old behaviour:

```sh
$ (echo "foo"; sleep 1; echo "bar"; sleep 1; echo "foobar") | python3 -c 'import sys,time;sys.stdout.write("".join(( " ".join((time.strftime("[%Y-%m-%d %H:%M:%S]", time.localtime()), line)) for line in sys.stdin )))'
[2024-06-06 12:02:07] foo
[2024-06-06 12:02:08] bar
[2024-06-06 12:02:09] foobar
```

Using the same echo and the new python code shows it immedately outputs the log lines as they get into the pipe:

```sh
$ (echo "foo"; sleep 1; echo "bar"; sleep 1; echo "foobar") | python3 -c 'exec("import sys,time\nfor line in sys.stdin:\n  sys.stdout.write(\" \".join((time.strftime(\"[%Y-%m-%d %H:%M:%S]\", time.localtime()), line)))")'
[2024-06-06 12:03:37] foo
[2024-06-06 12:03:38] bar
[2024-06-06 12:03:39] foobar
```

So the output is still the same, but what changes is the time when it gets streamed to the actual output file.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
