### PR TITLE
Updating photon gpg keys should not enable disabled repo

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -26,6 +26,7 @@
   ansible.builtin.command: tdnf update -y photon-repos --enablerepo=photon --refresh
   register: distro
   changed_when: '"Nothing to do" not in distro.stderr'
+  when: not disable_public_repos|default(false)|bool
 
 - name: Perform a tdnf distro-sync
   ansible.builtin.command: tdnf distro-sync -y --refresh

--- a/images/capi/ansible/roles/sysprep/tasks/photon.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/photon.yml
@@ -43,6 +43,12 @@
 
 - ansible.builtin.import_tasks: rpm_repos.yml
 
+- name: Update the repos package to import the recent gpg keys
+  ansible.builtin.command: tdnf update -y photon-repos --enablerepo=photon --refresh
+  register: distro
+  changed_when: '"Nothing to do" not in distro.stderr'
+  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+
 - name: Remove tdnf package caches
   ansible.builtin.command: /usr/bin/tdnf -y clean all
 


### PR DESCRIPTION
## Change description
Refreshing the gpg keys for photon upstream repo causes disabled repos(when disable_public_repos is enabled) to get enabled. As a result if there are extra_repos configured, instead of using the extra_repos to pull packages, packages are pulled from public repos. This breaks the functionality of `disable_public_repos` flag



## Related issues
- Fixes #1482


