### PR TITLE
Support overriding the gallert-image-definition name completely for CAPZ

### DIFF
--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -40,7 +40,7 @@ create_image_definition() {
   az sig image-definition create \
     --resource-group ${RESOURCE_GROUP_NAME} \
     --gallery-name ${GALLERY_NAME} \
-    --gallery-image-definition capi-${SIG_SKU:-$1} \
+    --gallery-image-definition ${SIG_IMAGE_DEFINITION:-capi-${SIG_SKU:-$1}} \
     --publisher ${SIG_PUBLISHER:-capz} \
     --offer ${SIG_OFFER:-capz-demo} \
     --sku ${SIG_SKU:-$2} \


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Support completely overriding the name used for the SIG image definition when creating a CAPZ image. This is configurable with the env var `SIG_IMAGE_DEFINITION` and if not set the current default behaviour will be used.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- N/A



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
