### PR TITLE
🌱 move to cx22 types for hcloud

### DIFF
--- a/images/capi/packer/hcloud/hcloud-config.json
+++ b/images/capi/packer/hcloud/hcloud-config.json
@@ -2,6 +2,6 @@
   "containerd_wasm_shims_runtimes": "spin,slight",
   "hcloud_location": "{{env `HCLOUD_LOCATION`}}",
   "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
-  "server_type": "cx21",
+  "server_type": "cx22",
   "token": "{{env `HCLOUD_TOKEN`}}"
 }


### PR DESCRIPTION


## Change description
<!-- What this PR does / why we need it. -->

the current cx21 server type is deprecated and will be removed in September.
this commit moves the same to cx22 is the new alternative for the same.

Ref: https://www.hetzner.com/news/new-cx-plans/

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
