### PR TITLE
Only modify grub configuration if update-grub command is present

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -99,6 +99,11 @@
     state: absent
     path: /etc/udev/rules.d/70-persistent-net.rules
 
+- name: Determine if update-grub is present
+  ansible.builtin.stat:
+    path: /usr/sbin/update-grub
+  register: _stat_update_grub
+
 - name: Configure grub for non graphical consoles
   ansible.builtin.copy:
     src: etc/default/grub.d/50-cloudimg-settings.cfg
@@ -108,6 +113,7 @@
     mode: "0644"
   notify:
     - Update debian grub
+  when: _stat_update_grub.stat.exists
 
 - name: Remvoing subiquity disable disable cloud-init networking config
   ansible.builtin.file:


### PR DESCRIPTION
## Change description
Only update the grub config on debian based hosts which have the `update-grub` command available.

#1483 broke the `pull-azure-sigs` tests and this is a fix for hosts which boot without grub.


## Additional context
Boot information from a "confidential" type azure instance suggests it is EFI boot directly to the kernel.

```
adminuser@instance-0-vm:/boot/grub$ efibootmgr -v
BootCurrent: 0001
Timeout: 0 seconds
BootOrder: 0004,0001,0000
Boot0000* EFI Network	AcpiEx(VMBus,,)/VenHw(9b17e5a2-0891-42dd-b653-80b5c22809ba,635161f83edfc546913ff2d2f965ed0e273a0d001d340d003a27341d000d3a27)/MAC(000000000000,0)/IPv4(0.0.0.00.0.0.0,0,0)
Boot0001* EFI SCSI Device	AcpiEx(VMBus,,)/VenHw(9b17e5a2-0891-42dd-b653-80b5c22809ba,d96361baa104294db60572e2ffb1dc7f1a78b3f8821e1848a1c363d806ec15bb)/SCSI(0,0)
Boot0002* EFI SCSI Device	AcpiEx(VMBus,,)/VenHw(9b17e5a2-0891-42dd-b653-80b5c22809ba,d96361baa104294db60572e2ffb1dc7f1a78b3f8821e1848a1c363d806ec15bb)/SCSI(0,1)
Boot0003* EFI SCSI Device	AcpiEx(VMBus,,)/VenHw(9b17e5a2-0891-42dd-b653-80b5c22809ba,d96361baa104294db60572e2ffb1dc7f1a78b3f8821e1848a1c363d806ec15bb)/SCSI(0,2)
Boot0004* Ubuntu with kernel 6.5.0-1022-azure	HD(15,GPT,f1e55731-4690-417c-801d-ce49fb512839,0x2800,0x200000)/File(\EFI\ubuntu\shimx64.efi)\.k.e.r.n.e.l...e.f.i.-.6...5...0.-.1.0.2.2.-.a.z.u.r.e. .
```

There are no grub packages or utilities installed on this instance at all, even though there is a /boot/grub/grub.cfg present.