### PR TITLE
Optionally source /etc/default/kubelet in kubelet.service

### DIFF
--- a/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+++ b/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
@@ -7,5 +7,6 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/sysconfig/kubelet
+EnvironmentFile=-/etc/default/kubelet
 ExecStart=
 ExecStart={{ sysusr_prefix }}/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS


### PR DESCRIPTION
On Debian/Ubuntu systems, /etc/default/kubelet is installed instead of /etc/sysconfig/kubelet [0]. So this file also needs to be sources in case it exists.

[0]
https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/kubernetes/tasks/main.yml#L48-L54


## Change description
This PR does optionally source the file `/etc/default/kubelet` for the systemd `kubelet.service`.
That is required because on Debian based systems, `/etc/default/kubelet` is used instead of `/etc/sysconfig/kubelet`.

