### PR TITLE
Implement hardening recommendations from kube-bench

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -122,7 +122,23 @@
     dest: "{{ systemd_prefix }}/system/kubelet.service.d/10-kubeadm.conf"
     owner: root
     group: root
-    mode: "0644"
+    mode: "0600"
+
+- name: Set more secure permissions on kubelet config.yaml
+  ansible.builtin.file:
+    path: /var/lib/kubelet/config.yaml
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Set correct ownership of etcd
+  ansible.builtin.file:
+    path: /var/lib/etcd/member
+    owner: etcd
+    group: etcd
+    mode: "0600"
+    recurse: true
+    state: directory
 
 - name: Create kubelet systemd file
   ansible.builtin.template:


### PR DESCRIPTION
Remediations for some things Kube-bench reported on a cluster.


<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Changes permissions of kubeadm config, kubelet config and etcd directory as recommended by [kube bench](https://github.com/aquasecurity/kube-bench).

```
[FAIL] 4.1.1 Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)
[FAIL] 4.1.9 If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated)
[FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd
```

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
