### PR TITLE
fix(packer/openstack): allow availability_zone

### DIFF
--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -1,6 +1,7 @@
 {
   "builders": [
     {
+      "availability_zone": "{{user `availability_zone`}}",
       "config_drive": "{{user `attach_config_drive`}}",
       "flavor": "{{user `flavor`}}",
       "floating_ip_network": "{{user `floating_ip_network`}}",
@@ -25,6 +26,7 @@
       "type": "openstack",
       "use_blockstorage_volume": "{{user `use_blockstorage_volume`}}",
       "use_floating_ip": "{{user `use_floating_ip`}}",
+      "volume_availability_zone": "{{user `volume_availability_zone`}}",
       "volume_size": "{{user `volume_size`}}",
       "volume_type": "{{user `volume_type`}}"
     }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
This PR adds support for packer openstack `availability_zone` and `volume_availability_zone` arguments.

This is needed because currently creating the OpenStack Instance fails with `Invalid volume: Instance <instance-id> and volume <volume-id> are not in the same availability_zone. Instance is in None. Volume is in dc1.` and setting `availability_zone` and `volume_availability_zone` has no effect because they are not recognised.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->
 
none

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

none
