### PR TITLE
Add centos-9 support for CAPIBM PowerVS images

### DIFF
--- a/docs/book/src/capi/providers/ibmcloud.md
+++ b/docs/book/src/capi/providers/ibmcloud.md
@@ -13,18 +13,19 @@
 The build [prerequisites](../capi.md#prerequisites) for using `image-builder` for building PowerVS images are managed by running:
 
 ```bash
-cd image-builder/images/capi
-make deps-powervs
+$ git clone https://github.com/kubernetes-sigs/image-builder.git
+$ cd image-builder/images/capi/
+$ make deps-powervs
 ```
 
 From the `images/capi` directory, run `make build-powervs-centos-8`. The image is built and uploaded to your bucket capibm-powervs-{BUILD_NAME}-{KUBERNETES_VERSION}-{BUILD_TIMESTAMP}.
 
+> **Note:** Fill the required fields which are listed [here](#common-powervs-options) in a json file and pass it to the `PACKER_VAR_FILES` environment variable while building the image.
+
 For building a centos-streams8 based CAPI image, run the following commands -
 
 ```bash
-$ git clone https://github.com/kubernetes-sigs/image-builder.git
-$ cd image-builder/images/capi/
-$ ANSIBLE_SSH_ARGS="-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa" make build-powervs-centos-8
+$ ANSIBLE_SSH_ARGS="-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedAlgorithms=+ssh-rsa" PACKER_VAR_FILES=variables.json make build-powervs-centos-8
 ```
 
 ### Configuration
@@ -34,6 +35,7 @@ In addition to the configuration found in `images/capi/packer/config`, the `powe
 | File | Description |
 |------|-------------|
 | `centos-8.json` | The settings for the CentOS 8 image |
+| `centos-9.json` | The settings for the CentOS 8 image |
 
 #### Common PowerVS options
 
@@ -57,8 +59,9 @@ This table lists several common options that a user may want to set via `PACKER_
 The parameters can be set via a variable file and passed via `PACKER_VAR_FILES`. See [Customization](../capi.md#customization) for examples.
 
 
-Note: When setting `dhcp_network: true`, make sure to customize the network settings while building OS using [pvsadm tool](https://github.com/ppc64le-cloud/pvsadm/blob/main/docs/Build%20DHCP%20enabled%20Centos%20Images.md).
-Also run the image-builder from system from where the DHCP private IP can be reached and SSH able.
+> **Note:** 
+> 1. When setting `dhcp_network: true`, you need to build an OS image with certain network settings using [pvsadm tool](https://github.com/ppc64le-cloud/pvsadm/blob/main/docs/Build%20DHCP%20enabled%20Centos%20Images.md) and replace [the fields](https://github.com/kubernetes-sigs/image-builder/blob/cb925047f388090a0db3430ca3172da63eff952c/images/capi/packer/powervs/centos-8.json#L6) with the custom image details.
+> 2. Clone the image-builder repo and run `make build` commands from a system where the DHCP private IP can be reached and SSH able.
 
 ## CAPIBM - VPC
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -367,7 +367,7 @@ QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES				?=      raw-ubuntu-2004 raw-ubuntu-2004-efi raw-flatcar raw-rhel-8 raw-rhel-9 raw-rhel-9-efi
 
-POWERVS_BUILD_NAMES         ?= powervs-centos-8
+POWERVS_BUILD_NAMES         ?= powervs-centos-8 powervs-centos-9
 
 NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2004 nutanix-ubuntu-2204 nutanix-ubuntu-2404 nutanix-rhel-8 nutanix-rhel-9 nutanix-rockylinux-8 nutanix-rockylinux-9 nutanix-flatcar nutanix-windows-2022
 
@@ -932,7 +932,8 @@ validate-osc-ubuntu-2004: ## Validates Ubuntu 20.04 Outscale Snapshot Packer con
 validate-osc-ubuntu-2204: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config
 validate-osc-all: $(OSC_VALIDATE_TARGETS) ## Validates all Outscale Snapshot Packer config
 
-validate-powervs-centos-8: ## Validates the PowerVS CentOS image packer config
+validate-powervs-centos-8: ## Validates the PowerVS CentOS 8 image packer config
+validate-powervs-centos-9: ## Validates the PowerVS CentOS 9 image packer config
 validate-powervs-all: $(POWERVS_VALIDATE_TARGETS) ## Validates all PowerVS Packer config
 
 validate-nutanix-ubuntu-2004: ## Validates Ubuntu 20.04 Nutanix Packer config

--- a/images/capi/packer/powervs/centos-9.json
+++ b/images/capi/packer/powervs/centos-9.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "centos-streams9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "source_cos_bucket": "power-oss-bucket",
+  "source_cos_object": "centos-streams-9.ova.gz",
+  "source_cos_region": "us-south",
+  "ssh_username": "root"
+}


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
- Add centos-9 support for CAPIBM PowerVS images
- Minor doc enhancements


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
