### PR TITLE
Add containerd configuration for hosts.toml paths

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -151,6 +151,11 @@
     path: /etc/containerd
     state: directory
 
+- name: Creates containerd certificates directory
+  ansible.builtin.file:
+    path: /etc/containerd/certs.d
+    state: directory
+
 - name: Copy in containerd config file {{ containerd_config_file }}
   vars:
     runtime_versions: "{{ containerd_wasm_shims_runtime_versions | from_json }}"

--- a/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
+++ b/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml
@@ -11,6 +11,8 @@ imports = ["/etc/containerd/conf.d/*.toml"]
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ pause_image }}"
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
 {% if kubernetes_semver is version('v1.21.0', '>=') %}
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"


### PR DESCRIPTION
## Change description

This configuration addition allows hosts.toml files to be located when pulling CRI images.

This makes it possible to provide registry hosts config for private registries using self-signed CAs.

This falls back to Docker's Certificate file pattern where PEM certificates can be placed into `/etc/containerd/certs.d/<registry>/registry.crt`

https://github.com/containerd/containerd/blob/main/docs/hosts.md#cri
