### PR TITLE
Support configuring VLAN and MTU for proxmox builds

### DIFF
--- a/images/capi/packer/proxmox/packer.json
+++ b/images/capi/packer/proxmox/packer.json
@@ -27,7 +27,9 @@
       "name": "{{user `build_name`}}",
       "network_adapters": [
         {
-          "bridge": "{{user `bridge`}}"
+          "bridge": "{{user `bridge`}}",
+          "mtu": "{{ user `mtu` }}",
+          "vlan_tag": "{{user `vlan_tag`}}"
         }
       ],
       "node": "{{ user `node` }}",
@@ -180,6 +182,7 @@
     "kubernetes_series": null,
     "kubernetes_source_type": null,
     "memory": "2048",
+    "mtu": "{{env `PROXMOX_MTU`}}",
     "node": "{{env `PROXMOX_NODE`}}",
     "proxmox_url": "{{env `PROXMOX_URL`}}",
     "sockets": "2",
@@ -189,6 +192,7 @@
     "storage_pool_type": "lvm",
     "token": "{{env `PROXMOX_TOKEN`}}",
     "username": "{{env `PROXMOX_USERNAME`}}",
+    "vlan_tag": "{{env `PROXMOX_VLAN`}}",
     "vmid": ""
   }
 }


### PR DESCRIPTION
## Change description
The VM created in Proxmox to build the template was missing the ability have the VLAN, or MTU set. The packer proxmox integration supports it, so this change is just the addition of the settings and environment variables.

Packer docs are [here](https://developer.hashicorp.com/packer/integrations/hashicorp/proxmox/latest/components/builder/iso#network-adapters)

If the value is not specified via the new environment variables then the vlan and MTU on the VM is not set and everything behaves as it did before.

