### PR TITLE
Allow Azure auth with federated token in scripts

### DIFF
--- a/images/capi/packer/azure/.pipelines/delete-storage-account.yaml
+++ b/images/capi/packer/azure/.pipelines/delete-storage-account.yaml
@@ -3,7 +3,11 @@ steps:
       set -o pipefail
       RESOURCE_GROUP_NAME=$(jq -r '.builds[-1].custom_data.resource_group_name' manifest.json | cut -d ":" -f2)
       STORAGE_ACCOUNT_NAME=$(jq -r '.builds[-1].custom_data.storage_account_name' manifest.json | cut -d ":" -f2)
-      az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+      if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")"
+      else
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}"
+      fi
       az account set -s ${AZURE_SUBSCRIPTION_ID}
       az storage account delete -n ${STORAGE_ACCOUNT_NAME} -g ${RESOURCE_GROUP_NAME} --yes
   displayName: cleanup - delete storage account

--- a/images/capi/packer/azure/.pipelines/generate-sas.yaml
+++ b/images/capi/packer/azure/.pipelines/generate-sas.yaml
@@ -8,12 +8,17 @@ steps:
       printf "${OS_DISK_URI}" | tee packer/azure/vhd-base-url.out
       printf "${OS_DISK_URI}?" | tee packer/azure/vhd-url.out
       printf "${RESOURCE_GROUP_NAME}" | tee packer/azure/resource-group-name.out
-      az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+      if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")"
+        export ENABLE_AUTH_MODE_LOGIN="true"   # Use --auth-mode "login" in az storage commands.
+      else
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}"
+      fi
       az account set -s ${AZURE_SUBSCRIPTION_ID}
       ACCOUNT_KEY=$(az storage account keys list -g ${RESOURCE_GROUP_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --account-name ${STORAGE_ACCOUNT_NAME} --query '[0].value')
       start_date=$(date +"%Y-%m-%dT00:00Z" -d "-1 day")
       expiry_date=$(date +"%Y-%m-%dT00:00Z" -d "+1 year")
-      az storage container generate-sas --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start $start_date --expiry $expiry_date | tr -d '\"' | tee -a packer/azure/vhd-url.out
+      az storage container generate-sas ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start $start_date --expiry $expiry_date | tr -d '\"' | tee -a packer/azure/vhd-url.out
   displayName: Getting OS VHD URL
   workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
   condition: eq(variables.CLEANUP, 'False')

--- a/images/capi/packer/azure/.pipelines/test-vhd.yaml
+++ b/images/capi/packer/azure/.pipelines/test-vhd.yaml
@@ -45,7 +45,11 @@ jobs:
       echo "${RESOURCE_GROUP}" is the group
 
       # Azure CLI login
-      az login -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --service-principal --tenant $AZURE_TENANT_ID
+      if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")"
+      else
+        az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}"
+      fi
 
       # Find the VHD blob location from its storage account
       AZURE_LOCATION=$(az storage account show --name "${STORAGE_ACCOUNT_NAME}" --query '[location]' -o tsv)

--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -4,7 +4,11 @@
 
 tracestate="$(shopt -po xtrace)"
 set +o xtrace
-az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} >/dev/null 2>&1
+if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+  az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" >/dev/null 2>&1
+else
+  az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}" >/dev/null 2>&1
+fi
 az account set -s ${AZURE_SUBSCRIPTION_ID} >/dev/null 2>&1
 eval "$tracestate"
 

--- a/images/capi/packer/azure/scripts/init-vhd.sh
+++ b/images/capi/packer/azure/scripts/init-vhd.sh
@@ -5,7 +5,13 @@
 echo "Sign into Azure"
 tracestate="$(shopt -po xtrace)"
 set +o xtrace
-az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} >/dev/null 2>&1
+
+if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+  az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" > /dev/null 2>&1
+  export ENABLE_AUTH_MODE_LOGIN="true"   # Use --auth-mode "login" in az storage commands.
+else
+  az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p ${AZURE_CLIENT_SECRET} >/dev/null 2>&1
+fi
 az account set -s ${AZURE_SUBSCRIPTION_ID} >/dev/null 2>&1
 eval "$tracestate"
 

--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -88,7 +88,11 @@ trap cleanup EXIT
 make deps-azure
 
 # Latest Flatcar version is often available on Azure with a delay, so resolve ourselves
-az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID}
+if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
+  az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")"
+else
+  az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}"
+fi
 get_flatcar_version() {
     az vm image show --urn kinvolk:flatcar-container-linux-free:stable:latest --query 'name' -o tsv
 }


### PR DESCRIPTION
## Change description

Adds the possibility to log in more securely to Azure using `az login --federated-token` to the scripts called by prow and ADO pipelines.

This is a prerequisite to moving image-builder prow jobs to community infrastructure.

## Related issues

- Fixes #



## Additional context

/area provider/azure
/kind cleanup