### PR TITLE
Use AZURE_STORAGE_AUTH_MODE with federated auth

### DIFF
--- a/images/capi/packer/azure/.pipelines/generate-sas.yaml
+++ b/images/capi/packer/azure/.pipelines/generate-sas.yaml
@@ -10,7 +10,7 @@ steps:
       printf "${RESOURCE_GROUP_NAME}" | tee packer/azure/resource-group-name.out
       if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
         az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")"
-        export ENABLE_AUTH_MODE_LOGIN="true"   # Use --auth-mode "login" in az storage commands.
+        export AZURE_STORAGE_AUTH_MODE="login"   # Use auth mode "login" in az storage commands.
       else
         az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}"
       fi
@@ -18,7 +18,7 @@ steps:
       ACCOUNT_KEY=$(az storage account keys list -g ${RESOURCE_GROUP_NAME} --subscription ${AZURE_SUBSCRIPTION_ID} --account-name ${STORAGE_ACCOUNT_NAME} --query '[0].value')
       start_date=$(date +"%Y-%m-%dT00:00Z" -d "-1 day")
       expiry_date=$(date +"%Y-%m-%dT00:00Z" -d "+1 year")
-      az storage container generate-sas ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start $start_date --expiry $expiry_date | tr -d '\"' | tee -a packer/azure/vhd-url.out
+      az storage container generate-sas --name system --permissions lr --account-name ${STORAGE_ACCOUNT_NAME} --account-key ${ACCOUNT_KEY} --start $start_date --expiry $expiry_date | tr -d '\"' | tee -a packer/azure/vhd-url.out
   displayName: Getting OS VHD URL
   workingDirectory: '$(system.defaultWorkingDirectory)/images/capi'
   condition: eq(variables.CLEANUP, 'False')

--- a/images/capi/packer/azure/scripts/delete-unused-storage.sh
+++ b/images/capi/packer/azure/scripts/delete-unused-storage.sh
@@ -85,7 +85,7 @@ which pub &> /dev/null || (echo "Please install pub from https://github.com/devi
 
 if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
   az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")"
-  export ENABLE_AUTH_MODE_LOGIN="true"   # Use --auth-mode "login" in az storage commands.
+  export AZURE_STORAGE_AUTH_MODE="login"   # Use auth mode "login" in az storage commands.
 else
   az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p "${AZURE_CLIENT_SECRET}"
 fi
@@ -142,14 +142,14 @@ for account in $(az storage account list -g "${RESOURCE_GROUP}" -o tsv --query "
           if [[ ${url} =~ ${storage_account} ]]; then
             echo "Archiving storage account ${storage_account} (${label}) that is ${age} days old"
             # create a destination container
-            if [[ $(az storage container exists ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --account-name "${ARCHIVE_STORAGE_ACCOUNT}" -n "${dest_label}" -o tsv 2>/dev/null) != "True" ]]; then
-              ${ECHO} az storage container create ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --only-show-errors --public-access=container \
+            if [[ $(az storage container exists --account-name "${ARCHIVE_STORAGE_ACCOUNT}" -n "${dest_label}" -o tsv 2>/dev/null) != "True" ]]; then
+              ${ECHO} az storage container create --only-show-errors --public-access=container \
                 -n ${dest_label} -g "${RESOURCE_GROUP}" --account-name "${ARCHIVE_STORAGE_ACCOUNT}" 2>/dev/null
             fi
             # for each source container
-            for container in $(az storage container list ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --only-show-errors --account-name ${storage_account} --query "[].name" -o tsv 2>/dev/null); do
+            for container in $(az storage container list --only-show-errors --account-name ${storage_account} --query "[].name" -o tsv 2>/dev/null); do
               # copy it to the destination container
-              ${ECHO} az storage blob copy start-batch ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} \
+              ${ECHO} az storage blob copy start-batch \
                 --account-name ${ARCHIVE_STORAGE_ACCOUNT} \
                 --destination-container ${dest_label} \
                 --destination-path ${container} \
@@ -159,9 +159,9 @@ for account in $(az storage account list -g "${RESOURCE_GROUP}" -o tsv --query "
                 2>/dev/null
             done
             # poll the target container until all blobs have "succeeded" copy status
-            for target in $(az storage blob list ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --account-name ${ARCHIVE_STORAGE_ACCOUNT} -c ${dest_label} --query '[].name' -o tsv 2>/dev/null); do
+            for target in $(az storage blob list --account-name ${ARCHIVE_STORAGE_ACCOUNT} -c ${dest_label} --query '[].name' -o tsv 2>/dev/null); do
               while true; do
-                status=$(az storage blob show ${ENABLE_AUTH_MODE_LOGIN:+"--auth-mode login"} --account-name ${ARCHIVE_STORAGE_ACCOUNT} --container-name ${dest_label} --name $target -o tsv --query 'properties.copy.status' 2>/dev/null)
+                status=$(az storage blob show --account-name ${ARCHIVE_STORAGE_ACCOUNT} --container-name ${dest_label} --name $target -o tsv --query 'properties.copy.status' 2>/dev/null)
                 if [[ ${status} == "success" ]]; then
                   echo "Copied ${dest_label}/${target}"
                   break

--- a/images/capi/packer/azure/scripts/init-vhd.sh
+++ b/images/capi/packer/azure/scripts/init-vhd.sh
@@ -8,7 +8,7 @@ set +o xtrace
 
 if [[ -n "${AZURE_FEDERATED_TOKEN_FILE:-}" ]]; then
   az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" --federated-token "$(cat "${AZURE_FEDERATED_TOKEN_FILE}")" > /dev/null 2>&1
-  export ENABLE_AUTH_MODE_LOGIN="true"   # Use --auth-mode "login" in az storage commands.
+  export AZURE_STORAGE_AUTH_MODE="login"   # Use auth mode "login" in az storage commands.
 else
   az login --service-principal -u "${AZURE_CLIENT_ID}" -t "${AZURE_TENANT_ID}" -p ${AZURE_CLIENT_SECRET} >/dev/null 2>&1
 fi


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

Fixes the implementation in #1507 based on experience with similar changes in CAPZ. In particular, exports the `AZURE_STORAGE_AUTH_MODE="login"` var which seems to be respected where `--auth-mode=login` was not.

## Related issues

- Refs kubernetes-sigs/cluster-api-provider-azure#4980



## Additional context

