### PR TITLE
Use UTC+0 for system clock in Windows VMware OVA

### DIFF
--- a/images/capi/packer/ova/windows/windows-2019-efi/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019-efi/autounattend.xml
@@ -127,8 +127,13 @@ Installation Notes:
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>%SystemRoot%\System32\reg.exe ADD "HKLM\System\CurrentControlSet\Control\TimeZoneInformation" /v RealTimeIsUniversal /d 1 /t REG_DWORD /f</Path>
                     <Order>1</Order>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>

--- a/images/capi/packer/ova/windows/windows-2019/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019/autounattend.xml
@@ -119,8 +119,13 @@ Installation Notes:
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>%SystemRoot%\System32\reg.exe ADD "HKLM\System\CurrentControlSet\Control\TimeZoneInformation" /v RealTimeIsUniversal /d 1 /t REG_DWORD /f</Path>
                     <Order>1</Order>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>

--- a/images/capi/packer/ova/windows/windows-2022-efi/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022-efi/autounattend.xml
@@ -127,8 +127,13 @@ Installation Notes:
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>%SystemRoot%\System32\reg.exe ADD "HKLM\System\CurrentControlSet\Control\TimeZoneInformation" /v RealTimeIsUniversal /d 1 /t REG_DWORD /f</Path>
                     <Order>1</Order>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>

--- a/images/capi/packer/ova/windows/windows-2022/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022/autounattend.xml
@@ -119,8 +119,13 @@ Installation Notes:
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>%SystemRoot%\System32\reg.exe ADD "HKLM\System\CurrentControlSet\Control\TimeZoneInformation" /v RealTimeIsUniversal /d 1 /t REG_DWORD /f</Path>
                     <Order>1</Order>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <WillReboot>Always</WillReboot>
+                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
Set the system clock to UTC+0 to avoid time change during VMware Tools installation. 



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1518



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
