### PR TITLE
adding a make target for openstack-ubuntu-2404

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -366,7 +366,7 @@ OCI_BUILD_NAMES				?= oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-ora
 
 DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204 do-ubuntu-2404
 
-OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-flatcar
+OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-flatcar
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204
 
@@ -786,6 +786,7 @@ build-node-ova-local-base-ubuntu-2004: ## Builds Ubuntu 20.04 Base Node OVA w lo
 
 build-openstack-ubuntu-2004: ## Builds Ubuntu 20.04 OpenStack image
 build-openstack-ubuntu-2204: ## Builds Ubuntu 22.04 OpenStack image
+build-openstack-ubuntu-2404: ## Builds Ubuntu 24.04 OpenStack image
 build-openstack-flatcar: ## Builds Flatcar OpenStack image
 build-openstack-all: $(OPENSTACK_BUILD_TARGETS)
 
@@ -911,6 +912,7 @@ validate-do-all: $(DO_VALIDATE_TARGETS) ## Validates all DigitalOcean Snapshot P
 
 validate-openstack-ubuntu-2004: ## Validates Ubuntu 20.04 Openstack Image Packer config
 validate-openstack-ubuntu-2204: ## Validates Ubuntu 22.04 Openstack Image Packer config
+validate-openstack-ubuntu-2404: ## Validates Ubuntu 22.04 Openstack Image Packer config
 validate-openstack-flatcar: ## Validates Flatcar Openstack Image Packer config
 validate-openstack-all: $(OPENSTACK_VALIDATE_TARGETS) ## Validates all Openstack Glance Image Packer config
 

--- a/images/capi/packer/openstack/ubuntu-2404.json
+++ b/images/capi/packer/openstack/ubuntu-2404.json
@@ -1,0 +1,5 @@
+{
+  "build_name": "ubuntu-2404",
+  "distro_name": "ubuntu",
+  "ssh_username": "ubuntu"
+}


### PR DESCRIPTION
## Change description
This enables make targets for Ubuntu 24.04 on OpenStack. I mean that's it really, nothing too special about it! As always I've been using this for a couple of weeks before putting into this project.


## Related issues

https://github.com/kubernetes-sigs/image-builder/issues/1406


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->