### PR TITLE
use dirty state when releasing boskos projects

### DIFF
--- a/images/capi/scripts/ci-gce.sh
+++ b/images/capi/scripts/ci-gce.sh
@@ -50,7 +50,7 @@ cleanup() {
 
   # stop boskos heartbeat
   if [ -n "${BOSKOS_HOST:-}" ]; then
-    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state used
+    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state dirty
   fi
 
   exit "${test_status}"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Switches from "used" to "dirty" for boskosctl project release

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

I'm pretty sure this usage explains why we have projects stuck in state "other" in the project pool. It appears to be copied from an upstream sample which is being corrected in https://github.com/kubernetes-sigs/boskos/pull/202

See also 
https://kubernetes.slack.com/archives/CCK68P2Q2/p1722900397667809