### PR TITLE
add dependabot to image builder repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,22 @@ updates:
       - "ok-to-test"
       - "kind/cleanup"
       - "release-note-none"
+
+  # pip
+  - package-ecosystem: "pip"
+    directories:
+        - "/"
+        - "images/capi"
+    schedule:
+      interval: "weekly"
+      time: "09:00"
+      # Use America/New_York Standard Time (UTC -05:00)
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "dependabot"
+      include: scope
+    labels:
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "release-note-none"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Please see the documentation for all configuration options: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  # github-actions
+  - directory: "/"
+    package-ecosystem: "github-actions"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+      time: "09:00"
+      # Use America/New_York Standard Time (UTC -05:00)
+      timezone: "America/New_York"
+    groups:
+      all-github-actions:
+        patterns: [ "*" ]
+    commit-message:
+      prefix: "dependabot"
+      include: scope
+    labels:
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "release-note-none"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "09:00"
+      # Use America/New_York Standard Time (UTC -05:00)
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "dependabot"
+      include: scope
+    ignore:
+      - dependency-name: 'golang'
+    labels:
+      - "ok-to-test"
+      - "kind/cleanup"
+      - "release-note-none"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
- This PR adds dependabot to image-builder repo. 


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->




## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.
 
This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
