### PR TITLE
Fix broken Ubuntu EFI OVA builds

### DIFF
--- a/images/capi/packer/ova/ubuntu-2204-efi.json
+++ b/images/capi/packer/ova/ubuntu-2204-efi.json
@@ -3,7 +3,7 @@
   "boot_disable_ipv6": "0",
   "boot_media_path": "/media/HTTP",
   "build_name": "ubuntu-2204-efi",
-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/22.04.efi/*",
   "cd_label": "cidata",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",

--- a/images/capi/packer/ova/ubuntu-2404-efi.json
+++ b/images/capi/packer/ova/ubuntu-2404-efi.json
@@ -2,7 +2,7 @@
   "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
   "boot_disable_ipv6": "0",
   "build_name": "ubuntu-2404-efi",
-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/24.04.efi/*",
   "cd_label": "cidata",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",


### PR DESCRIPTION


## Change description
<!-- What this PR does / why we need it. -->
Introduction of Ubuntu 24.04 and corresponding movement to use CD drives for cloud-init broke existing Ubuntu 22.04 EFI based image builds. These changes fixes those breakages.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1536



## Additional context
Please note that currently there are no-presubmit tests configured for UEFI Ubuntu images. Resulting in this regression. Also since all presubmit jobs for vSphere has been blocked, we will not be in position test it using presubmit job
