### PR TITLE
Allow specifying Flatcar version for base AMI

### DIFF
--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -1,5 +1,5 @@
 {
-  "ami_filter_name": "Flatcar*{{env `FLATCAR_CHANNEL`}}*",
+  "ami_filter_name": "Flatcar*{{env `FLATCAR_CHANNEL`}}*{{env `FLATCAR_VERSION`}}*",
   "ami_filter_owners": "075585003325",
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This PR updates the `ami_filter_name` used for Flatcar when building AMIs so that it supports the `FLATCAR_VERSION` environment variable being set like other providers do.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
