### PR TITLE
Better handling of Flatcar iso boot command

### DIFF
--- a/images/capi/packer/ova/flatcar.json
+++ b/images/capi/packer/ova/flatcar.json
@@ -1,7 +1,7 @@
 {
   "ansible_extra_vars": "guestinfo_datasource_slug={{user `guestinfo_datasource_slug`}} guestinfo_datasource_ref={{user `guestinfo_datasource_ref`}} guestinfo_datasource_script={{user `guestinfo_datasource_script`}} ansible_python_interpreter=/opt/bin/python",
-  "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter>curl -sLo /tmp/ignition.json https://raw.githubusercontent.com/kubernetes-sigs/image-builder/21f6a77a9a46a217949579d52f7b671568521678/images/capi/packer/files/flatcar/ignition/bootstrap-pass-auth.json<enter>sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json<enter>sudo flatcar-install -d /dev/sda -o vmware_raw -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json<enter>sudo reboot<enter>",
-  "boot_wait": "60s",
+  "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter><wait>curl -sLo /tmp/ignition.json https://raw.githubusercontent.com/kubernetes-sigs/image-builder/21f6a77a9a46a217949579d52f7b671568521678/images/capi/packer/files/flatcar/ignition/bootstrap-pass-auth.json && sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json && sudo flatcar-install -d /dev/sda -o vmware_raw -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json && sudo reboot<enter>",
+  "boot_wait": "180s",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",
   "containerd_cri_socket": "/run/docker/libcontainerd/docker-containerd.sock",

--- a/images/capi/packer/qemu/qemu-flatcar.json
+++ b/images/capi/packer/qemu/qemu-flatcar.json
@@ -1,8 +1,8 @@
 {
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python oem_id={{user `oem_id`}}",
-  "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter>curl -sLo /tmp/ignition.json ",
-  "boot_command_suffix": "/bootstrap-pass-auth.json<enter>sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json<enter>sudo flatcar-install -d /dev/sda -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json<enter>sudo reboot<enter>",
-  "boot_wait": "120s",
+  "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter><wait>curl -sLo /tmp/ignition.json ",
+  "boot_command_suffix": "/bootstrap-pass-auth.json<enter>sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json<enter>sudo flatcar-install -d /dev/sda -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json && sudo reboot<enter>",
+  "boot_wait": "180s",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",
   "crictl_source_type": "http",

--- a/images/capi/packer/raw/raw-flatcar.json
+++ b/images/capi/packer/raw/raw-flatcar.json
@@ -1,8 +1,8 @@
 {
   "ansible_extra_vars": "ansible_python_interpreter=/opt/bin/python",
-  "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter>curl -sLo /tmp/ignition.json ",
-  "boot_command_suffix": "/bootstrap-pass-auth.json<enter>sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json<enter>sudo flatcar-install -d /dev/sda -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json<enter>sudo reboot<enter>",
-  "boot_wait": "120s",
+  "boot_command_prefix": "sudo systemctl mask sshd.socket --now<enter><wait>curl -sLo /tmp/ignition.json ",
+  "boot_command_suffix": "/bootstrap-pass-auth.json<enter>sed -i \"s|BUILDERPASSWORDHASH|$(mkpasswd -5 {{user `ssh_password`}})|\" /tmp/ignition.json<enter>sudo flatcar-install -d /dev/sda -C {{user `channel_name`}} -V {{user `release_version`}} -i /tmp/ignition.json && sudo reboot<enter>",
+  "boot_wait": "180s",
   "build_name": "flatcar-{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
   "channel_name": "{{env `FLATCAR_CHANNEL`}}",
   "crictl_source_type": "http",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Increases the `boot_wait` for Flatcar for OVA and updates the boot commands to be more resilient to the delay in some of the commands running (that can prevent the reboot command from being picked up at the end).


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Related to upstream image - https://github.com/flatcar/Flatcar/issues/1514



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
