### PR TITLE
Set correct Guest OS type to Windows Server 2022 for VMware OVAs

### DIFF
--- a/images/capi/packer/ova/windows-2022-efi.json
+++ b/images/capi/packer/ova/windows-2022-efi.json
@@ -15,5 +15,6 @@
   "os_iso_url": "file:/path/en-us_windows_server_2022_x64_dvd_620d7eac.iso",
   "vmtools_iso_path": "[datastore] ISO/vmtools/windows-11.1.5.iso",
   "vmtools_iso_url": "file:/path/VMware-tools-windows-11.1.5-16724464.iso",
-  "vsphere_guest_os_type": "windows9Server64Guest"
+  "vmx_version": "18",
+  "vsphere_guest_os_type": "windows2019srvNext_64Guest"
 }

--- a/images/capi/packer/ova/windows-2022.json
+++ b/images/capi/packer/ova/windows-2022.json
@@ -12,5 +12,6 @@
   "os_iso_url": "file:/path/en-us_windows_server_2022_x64_dvd_620d7eac.iso",
   "vmtools_iso_path": "[datastore] ISO/vmtools/windows-11.1.5.iso",
   "vmtools_iso_url": "file:/path/VMware-tools-windows-11.1.5-16724464.iso",
-  "vsphere_guest_os_type": "windows9Server64Guest"
+  "vmx_version": "18",
+  "vsphere_guest_os_type": "windows2019srvNext_64Guest"
 }


### PR DESCRIPTION

## Change description
Set correct Guest OS type to Windows Server 2022 for VMware OVAs




## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1544 



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
