### PR TITLE
Install AWS CLI with --update flag

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/awscliv2.yml
+++ b/images/capi/ansible/roles/providers/tasks/awscliv2.yml
@@ -91,7 +91,7 @@
   when: ansible_os_family != "Flatcar"
 
 - name: Install AWS CLI v2
-  ansible.builtin.command: /tmp/aws/install -i /usr/local/aws-cli -b /usr/local/sbin
+  ansible.builtin.command: /tmp/aws/install --update -i /usr/local/aws-cli -b /usr/local/sbin
   when: ansible_os_family != "Flatcar"
 
 - name: Remove temporary files


### PR DESCRIPTION
## Change description

When using an AMI with aws CLI already the process fails due to this error:
```
Found preexisting AWS CLI installation: /usr/local/aws-cli/v2/current. Please rerun install script with --update flag.
```
I propose to install the aws cli with the --upgrade option in order to overcome these situations
