### PR TITLE
Fix timesyncd support in latest Flatcar release for Azure

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -20,12 +20,22 @@
     path: /etc/chrony/chrony.conf
     create: true
     line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+  # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
+  when: ansible_os_family != "Flatcar" or (ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '<'))
 
 - name: Ensure makestep parameter set as per Azure recommendation
   ansible.builtin.lineinfile:
     path: /etc/chrony/chrony.conf
     regexp: ^makestep
     line: makestep 1.0 -1
+  # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
+  when: ansible_os_family != "Flatcar" or (ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '<'))
+
+- name: Start service systemd-timesyncd, if not started
+  ansible.builtin.service:
+    name: systemd-timesyncd
+    state: started
+  when: ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '>=')
 
 - name: Install iptables persistence
   ansible.builtin.apt:


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

The latest stable release of Flatcar [now includes default support for ntp on Azure](https://github.com/flatcar/scripts/pull/1792) which is causing the following issue when trying to build with image-builder:

```
    azure-arm.sig-flatcar-gen2: TASK [providers : Configure PTP] ***********************************************
    azure-arm.sig-flatcar-gen2: An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OSError: [Errno 18] Invalid cross-device link: b'/tmp/.ansible/ansible-tmp-1724908280.8035567-1467-271096777552195/tmplopt3bfo' -> b'/usr/share/oem-azure/chrony.conf'
    azure-arm.sig-flatcar-gen2: fatal: [default]: FAILED! => {"changed": false, "msg": "The destination directory (/usr/share/oem-azure) is not writable by the current user. Error was: [Errno 30] Read-only file system: b'/usr/share/oem-azure/.ansible_tmpyspstzmwchrony.conf'"}
```

This change updates the Ansible tasks to only perform the actions on the appropriate Flatcar versions.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

N/A


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

Slack thread: https://kubernetes.slack.com/archives/C03GQ8B5XNJ/p1724911221970159