### PR TITLE
Pin base container image to Ubuntu 24.04

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=docker.io/library/ubuntu:latest
+ARG BASE_IMAGE=docker.io/library/ubuntu:24.04
 FROM $BASE_IMAGE
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

The `ubuntu:latest` tag has now been updated to point to 24.04 which caused some surprises when I was trying to build a new image built on top of image-builder as some packages have changed and the ubuntu user has also changed.

This PR specifically pins the base image to ubuntu:24.04 so we can release it as an explicit image-builder release that can have the change called out in the changelog.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

N/A



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
