### PR TITLE
Ensure systemd-timesyncd service is started on Flatcar

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -31,12 +31,6 @@
   # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
   when: ansible_os_family != "Flatcar" or (ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '<'))
 
-- name: Start service systemd-timesyncd, if not started
-  ansible.builtin.service:
-    name: systemd-timesyncd
-    state: started
-  when: ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '>=')
-
 - name: Install iptables persistence
   ansible.builtin.apt:
     name: "{{ packages }}"

--- a/images/capi/ansible/roles/setup/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/flatcar.yml
@@ -31,3 +31,8 @@
   ansible.builtin.systemd:
     enabled: true
     name: systemd-timesyncd.service
+
+- name: Start service systemd-timesyncd, if not started
+  ansible.builtin.service:
+    name: systemd-timesyncd
+    state: started


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Makes sure that the `systemd-timesyncd` service is started on Flatcar as we expect it to be running when running the Goss validation tests


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1555


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

I'd previously added this specifically for Azure (as I thought it was related to the issues with the latest Flatcar Azure release) but after looking it seems it's a general issue for Flatcar builds that had gone unnoticed until now so I'm removing the Azure specific in favour of the Flatcar general task.