### PR TITLE
Disable Goss inspect_mode to have validation failures fail the image …

### DIFF
--- a/images/capi/packer/config/goss-args.json
+++ b/images/capi/packer/config/goss-args.json
@@ -4,7 +4,7 @@
   "goss_entry_file": "goss/goss.yaml",
   "goss_format": "json",
   "goss_format_options": "pretty",
-  "goss_inspect_mode": "true",
+  "goss_inspect_mode": "false",
   "goss_remote_folder": "",
   "goss_remote_path": "",
   "goss_skip_install": "false",


### PR DESCRIPTION
…build

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Sets the default `inspect_mode` for Goss to `false` to ensure that Goss validation failures cause the image build process to fail.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1554



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

Requires the following to be merged first otherwise Flatcar builds will start failing: https://github.com/kubernetes-sigs/image-builder/pull/1556