### PR TITLE
Add vnc_bind_address var to QEMU builder

### DIFF
--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -34,7 +34,8 @@
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",
       "type": "qemu",
-      "vm_name": "{{user `vm_name`}}"
+      "vm_name": "{{user `vm_name`}}",
+      "vnc_bind_address": "{{user `vnc_bind_address`}}"
     }
   ],
   "post-processors": [
@@ -202,6 +203,7 @@
     "qemu_binary": "qemu-system-x86_64",
     "ssh_password": "builder",
     "ssh_username": "builder",
-    "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
+    "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+    "vnc_bind_address": "127.0.0.1"
   }
 }


### PR DESCRIPTION
It is useful when building on a remote host to be able to use this variable to gain access to the VNC console directly.

This variable is used in the OVA builder, so this commit is essentially a copy from that.

The default packer value of 127.0.0.1 is defined here to retain the default behaviour.
