### PR TITLE
Fix Goss variables for RHEL-based images

### DIFF
--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -144,7 +144,10 @@ centos:
   amazon:
     package:
       amazon-ssm-agent:
-      <<: *rh7_rpms
+    os_version:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
     command:
       /usr/local/sbin/aws --version:
         exit-status: 0
@@ -157,19 +160,23 @@ centos:
     package:
       python2-pip:
       open-vm-tools:
-      <<: *rh7_rpms
+    os_version:
+    - distro_version: "7"
+      package:
+        <<: *rh7_rpms
   qemu:
     package:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
-      python2-pip:
-      <<: *rh7_rpms
-  raw:
-    package:
-      cloud-init:
-      cloud-utils-growpart:
-      python2-pip:
+    os_version:
+    - distro_version: "7"
+      package:
+        python2-pip:
+        <<: *rh7_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
   hcloud:
     package:
       cloud-init:
@@ -249,7 +256,10 @@ rockylinux:
   amazon:
     package:
       amazon-ssm-agent:
-      <<: *rh8_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
     command:
       /usr/local/sbin/aws --version:
         exit-status: 0
@@ -263,10 +273,6 @@ rockylinux:
     package:
       open-vm-tools:
     os_version:
-    - distro_version: "7"
-      package:
-        python2-pip:
-        <<: *rh7_rpms
     - distro_version: "8"
       package:
         python2-pip:
@@ -279,23 +285,27 @@ rockylinux:
       open-vm-tools:
       cloud-init:
       cloud-utils:
-      python3-netifaces:
-      <<: *rh8_rpms
-  raw:
-    package:
-      cloud-init:
-      cloud-utils:
-      python3-netifaces:
-      <<: *rh8_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
   nutanix:
     package:
       cloud-init:
-      python3-netifaces:
       iscsi-initiator-utils:
       nfs-utils:
       lvm2:
       xfsprogs:
-      <<: *rh8_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
     service:
       iscsid:
         enabled: true
@@ -304,17 +314,19 @@ rockylinux:
     package:
       cloud-init:
       cloud-utils-growpart:
-      python3-netifaces:
-      <<: *rh8_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
 rhel:
   common-package: *common_rpms
   amazon:
     package:
       amazon-ssm-agent:
     os_version:
-      - distro_version: "8"
-        package:
-          <<: *rh8_rpms
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
     command:
       /usr/local/sbin/aws --version:
         exit-status: 0
@@ -328,9 +340,9 @@ rhel:
     package:
       open-vm-tools:
     os_version:
-      - distro_version: "8"
-        package:
-          <<: *rh8_rpms
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
   gcp:
     command:
       find -L /bin -maxdepth 1 -type f -executable -printf "%f\n" | grep -Fx 'gcloud':
@@ -339,9 +351,9 @@ rhel:
         stderr: []
         timeout: 0
     os_version:
-      - distro_version: "8"
-        package:
-          <<: *rh8_rpms
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
   ova:
     package:
       open-vm-tools:
@@ -362,23 +374,38 @@ rhel:
       open-vm-tools:
       cloud-init:
       cloud-utils-growpart:
-      python2-pip:
-      <<: *rh7_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
   raw:
     package:
       cloud-init:
       cloud-utils-growpart:
-      python2-pip:
-      <<: *rh7_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
   nutanix:
     package:
       cloud-init:
-      python3-netifaces:
       iscsi-initiator-utils:
       nfs-utils:
       lvm2:
       xfsprogs:
-      <<: *rh8_rpms
+    os_version:
+    - distro_version: "8"
+      package:
+        <<: *rh8_rpms
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
     service:
       iscsid:
         enabled: true


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->
After upgrading to image-builder `v0.1.35`, we noticed that all of our RHEL 8/RHEL 9 QEMU and raw image builds were failing. These were all Goss validation failures due to missing packages `ebtables`, `python-requests`, `python-netifaces`.

<details>
<summary>❌  Kubernetes v1.28 RHEL 8 raw image build before fix</summary>

```console
{
    "duration": 3909607,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "false"
    ],
    "human": "Expected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "meta": null,
    "property": "installed",
    "resource-id": "ebtables",
    "resource-type": "Package",
    "result": 1,
    "successful": false,
    "summary-line": "Package: ebtables: installed:\nExpected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "test-type": 0,
    "title": ""
},
{
    "duration": 3924687,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "false"
    ],
    "human": "Expected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "meta": null,
    "property": "installed",
    "resource-id": "python-netifaces",
    "resource-type": "Package",
    "result": 1,
    "successful": false,
    "summary-line": "Package: python-netifaces: installed:\nExpected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "test-type": 0,
    "title": ""
},
{
    "duration": 3901542,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "false"
    ],
    "human": "Expected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "meta": null,
    "property": "installed",
    "resource-id": "python-requests",
    "resource-type": "Package",
    "result": 1,
    "successful": false,
    "summary-line": "Package: python-requests: installed:\nExpected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "test-type": 0,
    "title": ""
},
{
    "duration": 3932550,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "false"
    ],
    "human": "Expected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "meta": null,
    "property": "installed",
    "resource-id": "python2-pip",
    "resource-type": "Package",
    "result": 1,
    "successful": false,
    "summary-line": "Package: python2-pip: installed:\nExpected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
    "test-type": 0,
    "title": ""
},
...
"summary": {
    failed-count": 4,
    summary-line": "Count: 60, Failed: 4, Duration: 0.373s",
    test-count": 60,
    total-duration": 373414673
}

Provisioning step had errors: Running the cleanup provisioner, if present...
Deleting output directory...
Build 'qemu' errored after 19 minutes 31 seconds: Error running Goss: goss non-zero exit status

Wait completed after 19 minutes 31 seconds

Some builds didn't complete successfully and had errors:
Error running Goss: goss non-zero exit status
```

</details>

This is because during image build, [these RH8 rpms](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/node/defaults/main.yml#L44-L47) get installed on the image for RHEL versions >= 8,  but the Goss check expects [these RH7 rpms](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/goss/goss-vars.yaml#L21-L24) (missing ones above) to be installed for the [RHEL QEMU builder](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/goss/goss-vars.yaml#L365-L366) and [RHEL raw builder](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/goss/goss-vars.yaml#L371-L372). These checks would have been failing earlier too, but since Goss was in inspect mode up until `v0.1.34`, these failures were ignored
```
==> qemu: Goss validate failed

==> qemu: Inspect mode on : proceeding without failing Packer
```
But with the [Goss inspect mode disable](https://github.com/kubernetes-sigs/image-builder/pull/1557) going into `v0.1.35`, this issue was surfaced.

This PR fixes this issue by assigning the Goss RPM var list for RHEL QEMU and raw based on the distro version. I have also cleaned up the Goss variable entries for builds which have been removed.

I ran the build with this fix and this time, Goss verified against the correct list of packages and the image build was successful.

<details>
<summary>✅   Kubernetes v1.28 RHEL 8 raw image build after fix</summary>

```console
{
    "duration": 41676509,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "true"
    ],
    "human": "",
    "meta": null,
    "property": "installed",
    "resource-id": "nftables",
    "resource-type": "Package",
    "result": 0,
    "successful": true,
    "summary-line": "Package: nftables: installed: matches expectation: [true]",
    "test-type": 0,
    "title": ""
},
{
    "duration": 10172346,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "true"
    ],
    "human": "",
    "meta": null,
    "property": "installed",
    "resource-id": "python3-netifaces",
    "resource-type": "Package",
    "result": 0,
    "successful": true,
    "summary-line": "Package: python3-netifaces: installed: matches expectation: [true]",
    "test-type": 0,
    "title": ""
},
{
    "duration": 9902686,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "true"
    ],
    "human": "",
    "meta": null,
    "property": "installed",
    "resource-id": "python3-requests",
    "resource-type": "Package",
    "result": 0,
    "successful": true,
    "summary-line": "Package: python3-requests: installed: matches expectation: [true]",
    "test-type": 0,
    "title": ""
},
{
    "duration": 14596674,
    "err": null,
    "expected": [
        "true"
    ],
    "found": [
        "true"
    ],
    "human": "",
    "meta": null,
    "property": "installed",
    "resource-id": "python3-pip",
    "resource-type": "Package",
    "result": 0,
    "successful": true,
    "summary-line": "Package: python3-pip: installed: matches expectation: [true]",
    "test-type": 0,
    "title": ""
},
...
"summary": {
    "failed-count": 0,
    "summary-line": "Count: 58, Failed: 0, Duration: 0.451s",
    "test-count": 58,
    "total-duration": 451497986
}

Goss validate ran successfully
...

Builds finished. The artifacts of successful builds are:
VM files in directory: ./output/rhel-8-kube-v1.28.13
```

</details>