### PR TITLE
cleanup: Use artifacts.k8s.io instead of storage.googleapis.com for ECR credential provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 .idea/
+.venv/

--- a/images/capi/ansible/roles/ecr_credential_provider/defaults/main.yml
+++ b/images/capi/ansible/roles/ecr_credential_provider/defaults/main.yml
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-
 ecr_credential_provider_version: v1.31.0
 ecr_credential_provider_os: linux
 ecr_credential_provider_arch: amd64
-ecr_credential_provider_base_url: https://storage.googleapis.com/k8s-artifacts-prod/binaries/cloud-provider-aws
+ecr_credential_provider_base_url: https://artifacts.k8s.io/binaries/cloud-provider-aws
 ecr_credential_provider_install_dir: /opt/bin
 ecr_credential_provider_binary_filename: ecr-credential-provider
 ecr_credential_provider_match_images:


### PR DESCRIPTION
## Change description
The `k8s-artifacts-prod` is currently fronted by a proxy at `artifacts.k8s.io`. Assuming that there's the potential for S3 or Azure Blob Storage to ever be used as a backend in addition to/as a replacement for GCS, we should be good citizens and use the proxy to access our objects.