### PR TITLE
outscale: user can define vm_type

### DIFF
--- a/images/capi/packer/outscale/packer.json
+++ b/images/capi/packer/outscale/packer.json
@@ -29,7 +29,7 @@
         "kubernetes_version": "{{user `kubernetes_semver`}}"
       },
       "type": "outscale-bsu",
-      "vm_type": "tinav5.c2r4p2"
+      "vm_type": "{{user `vm_type`}}"
     }
   ],
   "provisioners": [
@@ -115,6 +115,7 @@
     "kubernetes_series": null,
     "kubernetes_source_type": null,
     "region": "{{env `OSC_REGION`}}",
-    "secret_key": "{{env `OSC_SECRET_KEY`}}"
+    "secret_key": "{{env `OSC_SECRET_KEY`}}",
+    "vm_type": "tinav5.c2r4p2"
   }
 }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Using outscale provider, the user can override `vm_type` variables

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
