### PR TITLE
Fix gMSA setup on Windows

### DIFF
--- a/docs/book/src/capi/windows/windows.md
+++ b/docs/book/src/capi/windows/windows.md
@@ -50,7 +50,7 @@ Ansible doesn't run on directly on Windows (wsl works) but can used to configure
 ## Set up Windows machine
 Follow the [WinRM Setup](https://docs.ansible.com/ansible/latest/os_guide/windows_setup.html) in the Ansible documentation for configuring WinRM on the Windows machine. Note the [ConfigureRemotingForAnsible.ps1](https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1) is for development only. Refer to [Ansible WinRM documentation](https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html) for details for advance configuration.
 
-After WinRM is installed you can edit or `/etc/ansible/hosts` file with the following:
+After WinRM is installed you can edit the `/etc/ansible/hosts` file with the following:
 
 ```
 [winhost]

--- a/images/capi/ansible/windows/roles/gmsa/tasks/gmsa_keyvault.yml
+++ b/images/capi/ansible/windows/roles/gmsa/tasks/gmsa_keyvault.yml
@@ -43,19 +43,22 @@
     dest: "{{ kubernetes_install_path }}"
 
 - name: Register gMSA Key Vault plugin
-  ansible.windows.win_shell: |
-    {{ kubernetes_install_path }}\install-gmsa-keyvault-plugin.ps1
-- name: Install registry CCG logging manifest
-  ansible.windows.win_shell: |
-    wevtutil.exe um {{ kubernetes_install_path }}\CCGEvents.man
-    wevtutil.exe im {{ kubernetes_install_path }}\CCGEvents.man
-- name: Install registry Key Vault plugin logging manifest
-  ansible.windows.win_shell: |
-    wevtutil.exe um {{ kubernetes_install_path }}\CCGAKVPluginEvents.man
-    wevtutil.exe im {{ kubernetes_install_path }}\CCGAKVPluginEvents.man
-- name: Clean up gMSA install files
-  ansible.windows.win_shell: |
-    Remove-Item {{ kubernetes_install_path }}\CCGEvents.man
-    Remove-Item {{ kubernetes_install_path }}\CCGAKVPluginEvents.man
-    Remove-Item {{ kubernetes_install_path }}\registerplugin.reg
-    Remove-Item {{ kubernetes_install_path }}\install-gmsa-keyvault-plugin.ps1
+  block:
+    - name: Import gMSA Key Vault plugin
+      ansible.windows.win_shell: |
+          {{ kubernetes_install_path }}\install-gmsa-keyvault-plugin.ps1
+    - name: Install registry CCG logging manifest
+      ansible.windows.win_shell: |
+        wevtutil.exe um {{ kubernetes_install_path }}\CCGEvents.man
+        wevtutil.exe im {{ kubernetes_install_path }}\CCGEvents.man
+    - name: Install registry Key Vault plugin logging manifest
+      ansible.windows.win_shell: |
+        wevtutil.exe um {{ kubernetes_install_path }}\CCGAKVPluginEvents.man
+        wevtutil.exe im {{ kubernetes_install_path }}\CCGAKVPluginEvents.man
+  always:
+    - name: Cleanup gMSA install files
+      ansible.windows.win_shell: |
+        Remove-Item {{ kubernetes_install_path }}\CCGEvents.man
+        Remove-Item {{ kubernetes_install_path }}\CCGAKVPluginEvents.man
+        Remove-Item {{ kubernetes_install_path }}\registerplugin.reg
+        Remove-Item {{ kubernetes_install_path }}\install-gmsa-keyvault-plugin.ps1

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -231,16 +231,12 @@ command:
     stdout:
     - "C:\\Windows\\System32\\CCGAKVPlugin.dll"
     timeout: 30000
-  {{if ne .Vars.distribution_version "2025"}}
-  # TODO: [SEPTEMEBER 2024] Known issue in Windows Server 2025 preview image.
-  # WIP to fix the bug: The property value is null/empty
   Key Vault gMSA CCG interface is registered:
     exec: powershell -command "(Get-Item 'HKLM:SOFTWARE\Classes\Interface\{6ECDA518-2010-4437-8BC3-46E752B7B172}') | Ft -autosize -wrap"
     exit-status: 0
     stdout:
     - "ICcgDomainAuthCredentials"
     timeout: 30000
-  {{end}}
 {{end}}
 
 {{ if ne .Vars.ssh_source_url "" }}


### PR DESCRIPTION
## PR Description
This PR resilves the following issues caused when trying to import registry keys from registerplugin.reg:
1. Error opening the file. There may be a disk or file system error.
2. Failed to open registry key

**TL;DR**

1. The gMSA setup on WS2025 fails with the error: `Error opening the file. There may be a disk or file system error.`

    https://github.com/kubernetes-sigs/image-builder/blob/e224d7c470797cf0458530105f755cea39140ab5/images/capi/ansible/windows/roles/gmsa/files/install-gmsa-keyvault-plugin.ps1#L119

    To resolve the issue, we now use an absolute path to the registerplugin.reg file since it is copied to the same location where the install-gmsa-keyvault-plugin.ps1 script is executed.

    https://github.com/kubernetes-sigs/image-builder/blob/e224d7c470797cf0458530105f755cea39140ab5/images/capi/ansible/windows/roles/gmsa/tasks/gmsa_keyvault.yml#L43

4. `reg.exe import` fails with "Failed to open registry key"
This happens when the registry keys already exist. To resolve this, we parse the registerplugin.reg file (downloaded from [kubernetesartifacts.azureedge.net/ccgakvplugin](https://kubernetesartifacts.azureedge.net/ccgakvplugin/v1.1.4/binaries/windows-gmsa-ccgakvplugin-v1.1.4.zip)) to identify all the registry keys that will be updated by importing registerplugin.reg, we transfer ownership to the user and then restore it to the original owner.