### PR TITLE
fix: update packer qemu plugin name

### DIFF
--- a/images/capi/packer/oci/config.pkr.hcl
+++ b/images/capi/packer/oci/config.pkr.hcl
@@ -1,6 +1,6 @@
 packer {
   required_plugins {
-    vultr = {
+    oracle = {
       source =  "github.com/hashicorp/oracle"
       version = "~> 1.1.0"
     }

--- a/images/capi/packer/outscale/config.pkr.hcl
+++ b/images/capi/packer/outscale/config.pkr.hcl
@@ -1,6 +1,6 @@
 packer {
   required_plugins {
-    vultr = {
+    outscale = {
       source =  "github.com/outscale/outscale"
       version = "~> 1.2.0"
     }

--- a/images/capi/packer/qemu/config.pkr.hcl
+++ b/images/capi/packer/qemu/config.pkr.hcl
@@ -1,6 +1,6 @@
 packer {
   required_plugins {
-    vultr = {
+    qemu = {
       source =  "github.com/hashicorp/qemu"
       version = "~> 1.1.0"
     }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Change wrong plugin name for qemu, oci and outscale builders.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Related #1524 



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
