### PR TITLE
GCE: use n2-standard-2 machine type

### DIFF
--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -114,7 +114,7 @@
     "kubernetes_semver": null,
     "kubernetes_series": null,
     "kubernetes_source_type": null,
-    "machine_type": "n1-standard-1",
+    "machine_type": "n2-standard-2",
     "project_id": "{{env `GCP_PROJECT_ID`}}",
     "service_account_email": "",
     "source_image_family": "{{user `source_image_family`}}",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

N1 machines are less and less available. I could not build my image in multiple zones of european regions.
N2 seams to be more available.
