### PR TITLE
fix(capi-ubuntu24): pin cloud-init deb package version

### DIFF
--- a/images/capi/packer/ami/ubuntu-2404.json
+++ b/images/capi/packer/ami/ubuntu-2404.json
@@ -1,6 +1,7 @@
 {
   "ami_filter_name": "ubuntu/images/*ubuntu-noble-24.04-amd64-server-*",
   "ami_filter_owners": "099720109477",
+  "ansible_extra_vars": "pinned_debs=\"cloud-init=24.1.3-0ubuntu3\"",
   "build_name": "ubuntu-24.04",
   "distribution": "Ubuntu",
   "distribution_release": "noble",


### PR DESCRIPTION

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Newer version published on Ubuntu upstream stable channel introduced differences in cloud-init behavior making AMI builds stale. Several issues are around community/projects and there is not yet consensus on how to move forward. At the same time, project is stale because of this and a lot of users are affected.

Pinning cloud-init version to what we know for sure it's working to unblock development. This is tested for both amd64/arm64 arch.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes # Several issues around projects

- https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5115
- https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4745
- etc

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
