### PR TITLE
fix: pin cloud-init for ubuntu 22.04 image

### DIFF
--- a/images/capi/packer/ami/ubuntu-2204.json
+++ b/images/capi/packer/ami/ubuntu-2204.json
@@ -1,6 +1,7 @@
 {
   "ami_filter_name": "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*",
   "ami_filter_owners": "099720109477",
+  "ansible_extra_vars": "pinned_debs=\"cloud-init=23.1.2-0ubuntu0~22.04.1\"",
   "build_name": "ubuntu-22.04",
   "distribution": "Ubuntu",
   "distribution_release": "jammy",


### PR DESCRIPTION


<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

This pins the cloud-init version in the CAPA AMI for ubuntu 22.04 to an older version. This is required as newer versions of cloud-init don't work with the way CAPA gets the user-data onto the instance.

This is a temporary solution until a more long-term solution is found (which is currently being worked on, see #1583 ).

## Related issues

- Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5115
- Relates:https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4745


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
