### PR TITLE
Get Rocky Linux 9 building on Proxmox

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/proxmox.yml
+++ b/images/capi/ansible/roles/providers/tasks/proxmox.yml
@@ -60,8 +60,10 @@
   ansible.builtin.systemd:
     name: networkd-dispatcher
     state: started
+  when: ansible_os_family == "Debian"
 
 - name: Ensure networkd-dispatcher is enabled
   ansible.builtin.systemd:
     name: networkd-dispatcher
     enabled: true
+  when: ansible_os_family == "Debian"

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -282,9 +282,9 @@ rockylinux:
         <<: *rh9_rpms
   qemu:
     package:
-      open-vm-tools:
+      qemu-guest-agent:
       cloud-init:
-      cloud-utils:
+      cloud-utils-growpart:
     os_version:
     - distro_version: "8"
       package:

--- a/images/capi/packer/proxmox/linux/rockylinux/http/9/ks.cfg
+++ b/images/capi/packer/proxmox/linux/rockylinux/http/9/ks.cfg
@@ -3,7 +3,7 @@ repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/Ap
 cdrom
 
 # Use text install
-graphical
+text
 
 # Don't run the Setup Agent on first boot
 firstboot --disabled

--- a/images/capi/packer/proxmox/linux/rockylinux/http/9/ks.cfg
+++ b/images/capi/packer/proxmox/linux/rockylinux/http/9/ks.cfg
@@ -3,7 +3,7 @@ repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/Ap
 cdrom
 
 # Use text install
-text
+graphical
 
 # Don't run the Setup Agent on first boot
 firstboot --disabled
@@ -33,10 +33,10 @@ services --enabled="NetworkManager,sshd,chronyd"
 timezone UTC
 
 # System booloader configuration
-bootloader --location=mbr --boot-drive=sda
+bootloader --location=mbr --boot-drive=vda
 zerombr
-clearpart --all --initlabel --drives=sda
-part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+clearpart --all --initlabel --drives=vda
+part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=vda
 
 skipx
 

--- a/images/capi/packer/proxmox/packer.json
+++ b/images/capi/packer/proxmox/packer.json
@@ -13,10 +13,10 @@
       "disks": [
         {
           "disk_size": "{{user `disk_size`}}",
-          "format": "qcow2",
+          "format": "raw",
           "storage_pool": "{{user `storage_pool`}}",
           "storage_pool_type": "{{user `storage_pool_type`}}",
-          "type": "scsi"
+          "type": "virtio"
         }
       ],
       "http_directory": "{{user `http_directory`}}",

--- a/images/capi/packer/proxmox/rockylinux-9.json
+++ b/images/capi/packer/proxmox/rockylinux-9.json
@@ -16,5 +16,5 @@
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p",
   "vsphere_guest_os_type": "rockylinux_64Guest",
-  "cpu_type": "x86-64-v2-AES"
+  "cpu_type": "Westmere"
 }

--- a/images/capi/packer/proxmox/rockylinux-9.json
+++ b/images/capi/packer/proxmox/rockylinux-9.json
@@ -15,5 +15,6 @@
   "os_display_name": "RockyLinux 9",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p",
-  "vsphere_guest_os_type": "rockylinux_64Guest"
+  "vsphere_guest_os_type": "rockylinux_64Guest",
+  "cpu_type": "x86-64-v2-AES"
 }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This does a handful of things to get Rocky Linux 9 building under Proxmox.

First, in the Ansible playbook, I restrict networkd-dispatcher to Ubuntu since it doesn't appear to exist as a package under RHEL9/Rocky 9.

Next, Goss was looking for cloud-utils as an installed package, but the correct package is cloud-utils-growpart. In addition to that, Goss was verifying open-vm-tools was installed, but that's a hypervisor integration for vSphere, not QEMU/Proxmox. So I replaced that with qemu-guest-agent.

After that, I switched the disk format to raw. QCOW2 isn't supported on ZFS, and the Packer default is raw anyway:

https://developer.hashicorp.com/packer/integrations/hashicorp/proxmox/latest/components/builder/iso#disks

Raw will work on all filesystems supported by Proxmox, so it's a safe default.

I also switched the disk interface to virtio. With the scsi interface, Rocky wasn't detecting any disks. I can switch this to sata if needed, but both Ubuntu 24.04 and 22.04 built fine with virtio and IIRC, it should get slightly better performance than the scsi interface.

Finally, I set the CPU type to Westmere because RHEL9 (and thus Rocky) requires a minimum of x86-64-v2 to boot. Intel Westmere is the oldest microarchitecture that qualifies for this distinction. The default CPU type (kvm64) gives a kernel panic on installer startup without this. Please note that the genericized CPU type (x86-64-v2-AES) requires Proxmox 8.0+, so setting this to Westmere allows older versions of Proxmox to use the image-builder.

https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_8.0

I've personally tested this against my Proxmox server running the latest (8.2.2) and have built images for Rocky Linux 9, Ubuntu 22.04, and Ubuntu 24.04, so it should be regression free.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
