### PR TITLE
Set random ssh password for builder

### DIFF
--- a/images/capi/packer/nutanix/packer.json
+++ b/images/capi/packer/nutanix/packer.json
@@ -157,7 +157,7 @@
     "scp_extra_vars": "",
     "source_image_delete": "false",
     "source_image_force": "false",
-    "ssh_password": "builder",
+    "ssh_password": "{{ uuid }}",
     "ssh_username": "builder",
     "vm_force_delete": "false"
   }

--- a/images/capi/packer/ova/packer-common.json
+++ b/images/capi/packer/ova/packer-common.json
@@ -23,7 +23,7 @@
   "remote_type": "",
   "remote_username": "",
   "skip_compaction": "false",
-  "ssh_password": "builder",
+  "ssh_password": "{{ uuid }}",
   "ssh_proxy_host": "",
   "ssh_proxy_port": "",
   "ssh_timeout": "60m",

--- a/images/capi/packer/proxmox/packer.json
+++ b/images/capi/packer/proxmox/packer.json
@@ -192,7 +192,7 @@
     "node": "{{env `PROXMOX_NODE`}}",
     "proxmox_url": "{{env `PROXMOX_URL`}}",
     "sockets": "2",
-    "ssh_password": "builder",
+    "ssh_password": "{{ uuid }}",
     "ssh_username": "builder",
     "storage_pool": "{{env `PROXMOX_STORAGE_POOL`}}",
     "storage_pool_type": "lvm",

--- a/images/capi/packer/qemu/packer.json
+++ b/images/capi/packer/qemu/packer.json
@@ -201,7 +201,7 @@
     "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "python_path": "",
     "qemu_binary": "qemu-system-x86_64",
-    "ssh_password": "builder",
+    "ssh_password": "{{ uuid }}",
     "ssh_username": "builder",
     "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "vnc_bind_address": "127.0.0.1"

--- a/images/capi/packer/raw/packer.json
+++ b/images/capi/packer/raw/packer.json
@@ -177,7 +177,7 @@
     "output_directory": "./output/{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
     "python_path": "",
     "qemu_binary": "qemu-system-x86_64",
-    "ssh_password": "builder",
+    "ssh_password": "{{ uuid }}",
     "ssh_username": "builder",
     "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}"
   }


### PR DESCRIPTION
For providers that don't have a built-in support for random ssh keys this change makes sure that the default builder password used during the image build process is a randomly generated value.

Fixes kubernetes/kubernetes#128007

/assign @drew-viles @mboersma @jsturtevant 