### PR TITLE
Fix user-data filename in Nutanix gitignore

### DIFF
--- a/images/capi/packer/nutanix/.gitignore
+++ b/images/capi/packer/nutanix/.gitignore
@@ -1,2 +1,2 @@
 packer.json
-user-data.tmpl
+user-data


### PR DESCRIPTION
Fix user-data filename in Nutanix gitignore to use the generated filename instead of the checked-in file.