### PR TITLE
outscale: user can make OMI publicly accessible or not

### DIFF
--- a/images/capi/packer/outscale/packer.json
+++ b/images/capi/packer/outscale/packer.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "access_key": "{{ user `access_key` }}",
-      "global_permission": true,
+      "global_permission": "{{ user `global_permission` }}",
       "omi_account_ids": [
         "{{ user `account_id` }}"
       ],
@@ -97,6 +97,7 @@
     "distribution_release": null,
     "distribution_version": null,
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "global_permission": "true",
     "kubernetes_cni_deb_version": null,
     "kubernetes_cni_http_source": null,
     "kubernetes_cni_rpm_version": null,


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

On outscale, user can choose to make OMI publicly accessible or not
Default: publicly accessible

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
