### PR TITLE
[WIP] Bump goss to v0.4.9

### DIFF
--- a/docs/book/src/capi/goss/goss.md
+++ b/docs/book/src/capi/goss/goss.md
@@ -38,7 +38,7 @@ Supported arguments are passed through file: `packer/config/goss-args.json`
   "goss_url": "",
   "goss_format_options": "pretty",
   "goss_vars_file": "packer/goss/goss-vars.yaml",
-  "goss_version": "0.3.16"
+  "goss_version": "0.4.9"
 }
 ```
 ##### Supported values for some of the arguments can be found [here](https://github.com/goss-org/goss).

--- a/images/capi/packer/config/goss-args.json
+++ b/images/capi/packer/config/goss-args.json
@@ -13,5 +13,5 @@
   "goss_tests_dir": "packer/goss",
   "goss_url": "",
   "goss_vars_file": "packer/goss/goss-vars.yaml",
-  "goss_version": "0.3.16"
+  "goss_version": "0.4.9"
 }

--- a/images/capi/scripts/ci-goss-populate.sh
+++ b/images/capi/scripts/ci-goss-populate.sh
@@ -28,8 +28,8 @@ cd "${CAPI_ROOT}" || exit 1
 source hack/utils.sh
 ensure_py3
 
-_version="v0.3.16"
-_bin_url="https://github.com/aelsabbahy/goss/releases/download/${_version}/goss-linux-amd64"
+_version="v0.4.9"
+_bin_url="https://github.com/goss-org/goss/releases/tag/${_version}/goss-linux-amd64"
 
 if ! command -v goss >/dev/null 2>&1; then
   if [[ ${HOSTOS} == "linux" ]]; then


### PR DESCRIPTION
## Change description

Updates the `goss` serverspec alternative tool to [v0.4.9](https://github.com/goss-org/goss/releases/tag/v0.4.9)

## Related issues

N/A

## Additional context
