### PR TITLE
Bump pywinrm to v0.5.0

### DIFF
--- a/images/capi/hack/ensure-ansible-windows.sh
+++ b/images/capi/hack/ensure-ansible-windows.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="0.4.3"
+_version="0.5.0"
 
 if [[ ${HOSTOS} == "darwin" ]]; then
     echo "IMPORTANT: Winrm connection plugin for Ansible on MacOS causes connection issues."


### PR DESCRIPTION
/kind cleanup

## Change description

Updates the python [`pywinrm`](https://pypi.org/project/pywinrm/) library to a less ancient version, [v0.5.0](https://github.com/diyan/pywinrm/releases/tag/v0.5.0).

## Related issues

N/A

