### PR TITLE
Bump ansible-core to v2.15.2

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -23,7 +23,7 @@ set -o pipefail
 source hack/utils.sh
 
 # Note: ansible-core v2.16.x requires Python >= 3.10.
-_version="2.15.10"
+_version="2.15.12"
 
 # Change directories to the parent directory of the one in which this
 # script is located.


### PR DESCRIPTION
/kind cleanup

## Change description

Updates `ansible-core` to [v2.15.12](https://pypi.org/project/ansible-core/2.15.12/), keeping compatibility with Python 3.9 still.


## Related issues

N/A
