### PR TITLE
Fix openstack build goss failing network-dispatcher

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -32,6 +32,12 @@
     enabled: false
   when: ansible_os_family == "Debian"
 
+- name: Install networkd-dispatcher service (Run networkd-dispatcher)
+  ansible.builtin.systemd:
+    name: networkd-dispatcher
+    state: started
+    enabled: true
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
     src: "{{ item.src }}"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
I've added the missing part that installs networkd-dispatcher and starts it:
```yaml
- name: Install networkd-dispatcher service (Run networkd-dispatcher)
  ansible.builtin.systemd:
    name: networkd-dispatcher
    state: started
    enabled: true
```


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1626 



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
