### PR TITLE
fix(amazon-2): epel, install kubernetes steps

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
@@ -26,6 +26,8 @@
     allow_downgrade: true
     state: present
     lock_timeout: 60
+    disable_excludes: "kubernetes"
+    disable_plugin: "priorities"
   vars:
     packages:
       - kubelet-{{ kubernetes_rpm_version }}

--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -26,18 +26,30 @@
 - name: Perform dnf clean
   ansible.builtin.command: /usr/bin/yum -y clean all
 
+- name: Enable the EPEL repository
+  ansible.builtin.command: amazon-linux-extras enable epel
+  args:
+    creates: /etc/yum.repos.d/epel.repo
+  when: packer_builder_type.startswith('amazon')
+
+- name: Install EPEL package
+  ansible.builtin.yum:
+    name: epel-release
+    state: present
+  when: packer_builder_type.startswith('amazon')
+
 - name: Import epel gpg key
   ansible.builtin.rpm_key:
     state: present
     key: "{{ epel_rpm_gpg_key }}"
-  when: epel_rpm_gpg_key != ""
+  when: epel_rpm_gpg_key != "" and not packer_builder_type.startswith('amazon')
 
 - name: Add epel repo
   ansible.builtin.yum:
     name: "{{ redhat_epel_rpm }}"
     state: present
     lock_timeout: 60
-  when: redhat_epel_rpm != ""
+  when: redhat_epel_rpm != "" and not packer_builder_type.startswith('amazon')
 
 - ansible.builtin.import_tasks: rpm_repos.yml
 


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
- Fix failing amazon-2

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5142


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
```console
$ make build-ami-amazon-2
make -C images/capi build-ami-amazon-2
make[1]: Entering directory '/home/hungtran/dev/image-builder/images/capi'
hack/image-grok-latest-flatcar-version.sh: line 9: jq: command not found
hack/ensure-python.sh
fatal: No names found, cannot describe anything.
Checking if python is available
Python 3.12.3
hack/ensure-ansible.sh
ansible [core 2.16.3]
Starting galaxy collection install process
Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.
hack/ensure-packer.sh
Packer is already installed, checking version...
existing packer version: 1.9.5
Packer version is as expected
Packer version 1.9.5 is already installed
hack/ensure-ansible-windows.sh
fatal: No names found, cannot describe anything.
/home/hungtran/dev/image-builder/images/capi/.local/bin/packer init packer/config.pkr.hcl
/home/hungtran/dev/image-builder/images/capi/.local/bin/packer build -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/kubernetes.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/cni.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/containerd.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/wasm-shims.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/ansible-args.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/goss-args.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/common.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/additional_components.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/ecr_credential_provider.json"  -color=true -var-file="/home/hungtran/dev/image-builder/images/capi/packer/ami/amazon-2.json"  packer/ami/packer.json
fatal: No names found, cannot describe anything.
Warning: Bundled plugins used

This template relies on the use of plugins bundled into the Packer binary.
The practice of bundling external plugins into Packer will be removed in an
upcoming version.

To remove this warning and ensure builds keep working you can install these
external plugins with the 'packer plugins install' command

* packer plugins install github.com/hashicorp/amazon

Alternatively, if you upgrade your templates to HCL2, you can use 'packer init'
with a 'required_plugins' block to automatically install external plugins.

You can try HCL2 by running 'packer hcl2_upgrade
/home/hungtran/dev/image-builder/images/capi/packer/ami/packer.json'


amazon-ebs.amazon-2: output will be in this color.

==> amazon-ebs.amazon-2: Prevalidating any provided VPC information
==> amazon-ebs.amazon-2: Prevalidating AMI Name: capa-ami-amazon-2-v1.30.5-1732554009
    amazon-ebs.amazon-2: Found Image ID: ami-09e4ba81d75ebeb6a
==> amazon-ebs.amazon-2: Creating temporary keypair: packer_6744ad1a-4638-c10f-9fec-ac6d0b3a32f9
==> amazon-ebs.amazon-2: Creating temporary security group for this instance: packer_6744ad21-221f-6222-b992-fd995c34d600
==> amazon-ebs.amazon-2: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
==> amazon-ebs.amazon-2: Launching a source AWS instance...
    amazon-ebs.amazon-2: Instance ID: i-00db74b07fd865130
==> amazon-ebs.amazon-2: Waiting for instance (i-00db74b07fd865130) to become ready...
==> amazon-ebs.amazon-2: Using SSH communicator to connect: 18.234.153.50
==> amazon-ebs.amazon-2: Waiting for SSH to become available...
==> amazon-ebs.amazon-2: Connected to SSH!
==> amazon-ebs.amazon-2: Provisioning with shell script: ./packer/files/flatcar/scripts/bootstrap-flatcar.sh
==> amazon-ebs.amazon-2: Provisioning with Ansible...
    amazon-ebs.amazon-2: Setting up proxy adapter for Ansible....
==> amazon-ebs.amazon-2: Executing Ansible: ansible-playbook -e packer_build_name="amazon-2" -e packer_builder_type=amazon-ebs --ssh-extra-args '-o IdentitiesOnly=yes' --extra-vars containerd_url=https://github.com/containerd/containerd/releases/download/v1.7.20/cri-containerd-cni-1.7.20-linux-amd64.tar.gz containerd_sha256=041fa3cfd4e6689d37516e4c7752741df0974e7985d97258c1009b20f25f33c7 pause_image=registry.k8s.io/pause:3.9 containerd_additional_settings= containerd_cri_socket=/var/run/containerd/containerd.sock containerd_version=1.7.20 containerd_wasm_shims_url=https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.11.1/containerd-wasm-shims-<RTVERSION>-<SHIM>-linux-x86_64.tar.gz containerd_wasm_shims_version=v0.11.1 containerd_wasm_shims_sha256={"lunatic":"7054bc882db755ce5f3ded46d114bfd4e0a318e437fa18a2601295d20b616b32","slight":"a6ea87d965037933a7d9edb5e20cfc175265c8e1ca92a16535f1f3c3f376f5b0","spin":"dcffedb8e4d2f585a851b3de489fa1e8a0054ec0ad72cf111c623623919245d0","wws":"e917f90692d798d80873aa0f37990c7d652f2846129d64fecbfd41ffa77799b8"} containerd_wasm_shims_runtimes="" containerd_wasm_shims_runtime_versions="{"lunatic":"v1","slight":"v1","spin":"v2","wws":"v1"}" crictl_url=https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-amd64.tar.gz crictl_sha256=https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-amd64.tar.gz.sha256 crictl_source_type=pkg custom_role_names="" firstboot_custom_roles_pre="" firstboot_custom_roles_post="" node_custom_roles_pre="" node_custom_roles_post="" disable_public_repos=false extra_debs="" extra_repos="" extra_rpms="" http_proxy= https_proxy= kubeadm_template=etc/kubeadm.yml kubernetes_apiserver_port=6443 kubernetes_cni_http_source=https://github.com/containernetworking/plugins/releases/download kubernetes_cni_http_checksum=sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz.sha256 kubernetes_goarch=amd64 kubernetes_http_source=https://dl.k8s.io/release kubernetes_container_registry=registry.k8s.io kubernetes_rpm_repo=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/ kubernetes_rpm_gpg_key=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key kubernetes_rpm_gpg_check=True kubernetes_deb_repo=https://pkgs.k8s.io/core:/stable:/v1.30/deb/ kubernetes_deb_gpg_key=https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key kubernetes_cni_deb_version= kubernetes_cni_rpm_version= kubernetes_cni_semver=v1.2.0 kubernetes_cni_source_type=pkg kubernetes_semver=v1.30.5 kubernetes_source_type=pkg kubernetes_load_additional_imgs=false kubernetes_deb_version=1.30.5-1.1 kubernetes_rpm_version=1.30.5 no_proxy= pip_conf_file= python_path= redhat_epel_rpm=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm epel_rpm_gpg_key= reenable_public_repos=true remove_extra_repos=false systemd_prefix=/usr/lib/systemd sysusr_prefix=/usr sysusrlocal_prefix=/usr/local load_additional_components=false additional_registry_images=false additional_registry_images_list= ecr_credential_provider=false additional_url_images=false additional_url_images_list= additional_executables=false additional_executables_list= additional_executables_destination_path= additional_s3=false build_target=virt amazon_ssm_agent_rpm=https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm enable_containerd_audit= kubernetes_enable_automatic_resource_sizing=false debug_tools=false ubuntu_repo=http://us.archive.ubuntu.com/ubuntu ubuntu_security_repo=http://security.ubuntu.com/ubuntu gpu_block_nouveau_loading= --extra-vars  --extra-vars  --scp-extra-args "-O" -e ansible_ssh_private_key_file=/tmp/ansible-key1734562869 -i /tmp/packer-provisioner-ansible2014262570 /home/hungtran/dev/image-builder/images/capi/ansible/node.yml
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: PLAY [all] *********************************************************************
    amazon-ebs.amazon-2: [WARNING]: Platform linux on host default is using the discovered Python
    amazon-ebs.amazon-2: interpreter at /usr/bin/python3.7, but future installation of another Python
    amazon-ebs.amazon-2: interpreter could change the meaning of that path. See
    amazon-ebs.amazon-2: https://docs.ansible.com/ansible-
    amazon-ebs.amazon-2: core/2.16/reference_appendices/interpreter_discovery.html for more information.
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [Gathering Facts] *********************************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [ansible.builtin.include_role : node] *************************************
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [setup : Perform dnf clean] ***********************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [setup : Enable the EPEL repository] **************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [setup : Install EPEL package] ********************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [setup : Perform a yum update] ********************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [setup : Install baseline dependencies] ***********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [setup : Install extra rpms] **********************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Ensure sysstat is running and comes on at reboot] *****************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Disable security updates on boot] *********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Ensure overlay module is present] *********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Ensure br_netfilter module is present] ****************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Persist required kernel modules] **********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Set and persist kernel params] ************************************
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'net.bridge.bridge-nf-call-iptables', 'val': 1})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'net.bridge.bridge-nf-call-ip6tables', 'val': 1})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'net.ipv4.ip_forward', 'val': 1})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'net.ipv6.conf.all.forwarding', 'val': 1})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'net.ipv6.conf.all.disable_ipv6', 'val': 0})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'net.ipv4.tcp_congestion_control', 'val': 'bbr'})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'vm.overcommit_memory', 'val': 1})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'kernel.panic', 'val': 10})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'kernel.panic_on_oops', 'val': 1})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'fs.inotify.max_user_instances', 'val': 8192})
    amazon-ebs.amazon-2: changed: [default] => (item={'param': 'fs.inotify.max_user_watches', 'val': 524288})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Disable conntrackd service] ***************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Ensure auditd is running and comes on at reboot] ******************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Set transparent huge pages to madvise] ****************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Copy udev etcd network tuning rules] ******************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [node : Copy etcd network tuning script] **********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [ansible.builtin.include_role : providers] ********************************
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : ansible.builtin.include_tasks] *******************************
    amazon-ebs.amazon-2: included: /home/hungtran/dev/image-builder/images/capi/ansible/roles/providers/tasks/aws.yml for default
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Install aws agents RPM] **************************************
    amazon-ebs.amazon-2: ok: [default] => (item=amazon-ssm-agent)
    amazon-ebs.amazon-2: ok: [default] => (item=awscli)
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Ensure ssm agent is running RPM] *****************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Creates unit file directory for cloud-final] *****************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Create cloud-final boot order drop in file] ******************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Creates unit file directory for cloud-config] ****************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Create cloud-config boot order drop in file] *****************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Make sure all cloud init services are enabled] ***************
    amazon-ebs.amazon-2: ok: [default] => (item=cloud-final)
    amazon-ebs.amazon-2: ok: [default] => (item=cloud-config)
    amazon-ebs.amazon-2: ok: [default] => (item=cloud-init)
    amazon-ebs.amazon-2: ok: [default] => (item=cloud-init-local)
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Create cloud-init config file] *******************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [providers : Ensure chrony is running] ************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [ansible.builtin.include_role : containerd] *******************************
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Install libseccomp package] *********************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Download containerd] ****************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Create a directory if it does not exist] ********************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Unpack containerd] ******************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Delete /opt/cni directory] **********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Delete /etc/cni directory] **********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Create unit file directory] *********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Create containerd memory pressure drop-in file] *************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Create containerd max tasks drop-in file] *******************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Create containerd http proxy conf file if needed] ***********
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Creates containerd config directory] ************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Creates containerd certificates directory] ******************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Copy in containerd config file etc/containerd/config.toml] ***
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Copy in crictl config] **************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Start containerd service] ***********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [containerd : Delete containerd tarball] **********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [ansible.builtin.include_role : kubernetes] *******************************
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Add the Kubernetes repo] ************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Install Kubernetes] *****************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Symlink cri-tools] ******************************************
    amazon-ebs.amazon-2: changed: [default] => (item=ctr)
    amazon-ebs.amazon-2: changed: [default] => (item=crictl)
    amazon-ebs.amazon-2: changed: [default] => (item=critest)
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Create kubelet default config file] *************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Enable kubelet service] *************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Create the Kubernetes version file] *************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Create libexec directory] ***********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Generate kubectl bash completion] ***************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Generate kubeadm bash completion] ***************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Generate crictl bash completion] ****************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Set KUBECONFIG variable and alias] **************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Check if Kubernetes container registry is using Amazon ECR] ***
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Create kubeadm config file] *********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Kubeadm pull images] ****************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [kubernetes : Delete kubeadm config] **************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [ansible.builtin.include_role : sysprep] **********************************
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Define file modes] *********************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Get installed packages] ****************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Create the package list] ***************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Exclude the packages from upgrades] ****************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove yum package caches] *************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove yum package lists] **************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Reset network interface IDs] ***********************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove the kickstart log] **************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove containerd http proxy conf file if needed] **************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Truncate machine id] *******************************************
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/machine-id', 'state': 'absent', 'mode': '0444'})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/machine-id', 'state': 'touch', 'mode': '0444'})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Truncate hostname file] ****************************************
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/hostname', 'state': 'absent', 'mode': '0644'})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/hostname', 'state': 'touch', 'mode': '0644'})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Set hostname] **************************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Reset hosts file] **********************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Truncate audit logs] *******************************************
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/var/log/wtmp', 'state': 'absent', 'mode': '0664'})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/var/log/lastlog', 'state': 'absent', 'mode': '0644'})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/var/log/wtmp', 'state': 'touch', 'mode': '0664'})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/var/log/lastlog', 'state': 'touch', 'mode': '0644'})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove cloud-init lib dir and logs] ****************************
    amazon-ebs.amazon-2: changed: [default] => (item=/var/lib/cloud)
    amazon-ebs.amazon-2: changed: [default] => (item=/var/log/cloud-init.log)
    amazon-ebs.amazon-2: changed: [default] => (item=/var/log/cloud-init-output.log)
    amazon-ebs.amazon-2: changed: [default] => (item=/var/run/cloud-init)
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Reset cloud-init] **********************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove cloud-init.disabled] ************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Find temp files] ***********************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Reset temp space] **********************************************
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/tmp/systemd-private-e036af18b11047599b9b653ae30fece3-chronyd.service-f87ptZ', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 17, 'inode': 8421711, 'dev': 66305, 'nlink': 3, 'atime': 1732554038.308, 'mtime': 1732554038.308, 'ctime': 1732554038.308, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: ok: [default] => (item={'path': '/tmp/ansible_ansible.builtin.find_payload_0wtbs6r8', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 54, 'inode': 12768160, 'dev': 66305, 'nlink': 2, 'atime': 1732554837.783191, 'mtime': 1732554837.783191, 'ctime': 1732554837.783191, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/var/tmp/systemd-private-e036af18b11047599b9b653ae30fece3-chronyd.service-0K6VZr', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 17, 'inode': 77890, 'dev': 66305, 'nlink': 3, 'atime': 1732554038.308, 'mtime': 1732554038.308, 'ctime': 1732554038.308, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: [WARNING]: Skipped '/lib/netplan' path due to this access issue: '/lib/netplan'
    amazon-ebs.amazon-2: is not a directory
    amazon-ebs.amazon-2: [WARNING]: Skipped '/etc/netplan' path due to this access issue: '/etc/netplan'
    amazon-ebs.amazon-2: is not a directory
    amazon-ebs.amazon-2: [WARNING]: Skipped '/run/netplan' path due to this access issue: '/run/netplan'
    amazon-ebs.amazon-2: is not a directory
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Find netplan files] ********************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Find SSH host keys] ********************************************
    amazon-ebs.amazon-2: ok: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove SSH host keys] ******************************************
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/ssh/ssh_host_rsa_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 998, 'size': 1675, 'inode': 326476, 'dev': 66305, 'nlink': 1, 'atime': 1732554044.0929418, 'mtime': 1732554044.0929418, 'ctime': 1732554044.0969417, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/ssh/ssh_host_rsa_key.pub', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 382, 'inode': 326477, 'dev': 66305, 'nlink': 1, 'atime': 1732554044.0929418, 'mtime': 1732554044.0929418, 'ctime': 1732554044.1009417, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ecdsa_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 998, 'size': 227, 'inode': 326478, 'dev': 66305, 'nlink': 1, 'atime': 1732554044.1049416, 'mtime': 1732554044.1049416, 'ctime': 1732554044.1089416, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ecdsa_key.pub', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 162, 'inode': 326479, 'dev': 66305, 'nlink': 1, 'atime': 1732554044.1049416, 'mtime': 1732554044.1049416, 'ctime': 1732554044.1089416, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ed25519_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 998, 'size': 387, 'inode': 326480, 'dev': 66305, 'nlink': 1, 'atime': 1732554044.1209416, 'mtime': 1732554044.1209416, 'ctime': 1732554044.1249416, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ed25519_key.pub', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 82, 'inode': 326481, 'dev': 66305, 'nlink': 1, 'atime': 1732554044.1209416, 'mtime': 1732554044.1209416, 'ctime': 1732554044.1249416, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove SSH authorized users] ***********************************
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/root/.ssh/authorized_keys'})
    amazon-ebs.amazon-2: changed: [default] => (item={'path': '/home/ec2-user/.ssh/authorized_keys'})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Truncate all remaining log files in /var/log] ******************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Delete all logrotated logs] ************************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Truncate shell history] ****************************************
    amazon-ebs.amazon-2: ok: [default] => (item={'path': '/root/.bash_history'})
    amazon-ebs.amazon-2: ok: [default] => (item={'path': '/home/ec2-user/.bash_history'})
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: TASK [sysprep : Remove archived journalctl logs] *******************************
    amazon-ebs.amazon-2: changed: [default]
    amazon-ebs.amazon-2:
    amazon-ebs.amazon-2: PLAY RECAP *********************************************************************
    amazon-ebs.amazon-2: default                    : ok=86   changed=63   unreachable=0    failed=0    skipped=402  rescued=0    ignored=0
    amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2: Provisioning with Goss
==> amazon-ebs.amazon-2: Configured to run on Linux
    amazon-ebs.amazon-2: Creating directory: /tmp/goss
    amazon-ebs.amazon-2: Installing Goss from, https://github.com/goss-org/goss/releases/download/v0.3.16/goss-linux-amd64
    amazon-ebs.amazon-2: Downloading Goss to /tmp/goss-0.3.16-linux-amd64
    amazon-ebs.amazon-2: goss version v0.3.16
==> amazon-ebs.amazon-2: Uploading goss tests...
    amazon-ebs.amazon-2: Uploading vars file packer/goss/goss-vars.yaml
    amazon-ebs.amazon-2: Inline variables are --vars-inline '{"ARCH":"amd64","OS":"amazon linux","OS_VERSION":"2","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}'
    amazon-ebs.amazon-2: Uploading Dir packer/goss
    amazon-ebs.amazon-2: Creating directory: /tmp/goss/goss
==> amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2: Running goss tests...
==> amazon-ebs.amazon-2: Running GOSS render command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"amazon linux","OS_VERSION":"2","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}' render > /tmp/goss-spec.yaml
==> amazon-ebs.amazon-2: Goss render ran successfully
==> amazon-ebs.amazon-2: Running GOSS render debug command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"amazon linux","OS_VERSION":"2","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}' render -d > /tmp/debug-goss-spec.yaml
==> amazon-ebs.amazon-2: Goss render debug ran successfully
==> amazon-ebs.amazon-2: Running GOSS validate command: cd /tmp/goss && sudo  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"amazon linux","OS_VERSION":"2","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}' validate --retry-timeout 0s --sleep 1s -f json -o pretty
    amazon-ebs.amazon-2: {
    amazon-ebs.amazon-2:     "results": [
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 95970192,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "0"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "0"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "exit-status",
    amazon-ebs.amazon-2:             "resource-id": "crictl ps",
    amazon-ebs.amazon-2:             "resource-type": "Command",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Command: crictl ps: exit-status: matches expectation: [0]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 158931361,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "conntrack-tools",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: conntrack-tools: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 180153871,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "0"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "0"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "exit-status",
    amazon-ebs.amazon-2:             "resource-id": "crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort",
    amazon-ebs.amazon-2:             "resource-type": "Command",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Command: crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort: exit-status: matches expectation: [0]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 19739,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "coredns",
    amazon-ebs.amazon-2:                 "etcd",
    amazon-ebs.amazon-2:                 "kube-apiserver",
    amazon-ebs.amazon-2:                 "kube-controller-manager",
    amazon-ebs.amazon-2:                 "kube-proxy",
    amazon-ebs.amazon-2:                 "kube-scheduler",
    amazon-ebs.amazon-2:                 "pause"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "coredns",
    amazon-ebs.amazon-2:                 "etcd",
    amazon-ebs.amazon-2:                 "kube-apiserver",
    amazon-ebs.amazon-2:                 "kube-controller-manager",
    amazon-ebs.amazon-2:                 "kube-proxy",
    amazon-ebs.amazon-2:                 "kube-scheduler",
    amazon-ebs.amazon-2:                 "pause"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "stdout",
    amazon-ebs.amazon-2:             "resource-id": "crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort",
    amazon-ebs.amazon-2:             "resource-type": "Command",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Command: crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort: stdout: matches expectation: [coredns etcd kube-apiserver kube-controller-manager kube-proxy kube-scheduler pause]",
    amazon-ebs.amazon-2:             "test-type": 2,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 171803031,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "0"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "0"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "exit-status",
    amazon-ebs.amazon-2:             "resource-id": "containerd --version | awk -F' ' '{print substr($3,2); }'",
    amazon-ebs.amazon-2:             "resource-type": "Command",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Command: containerd --version | awk -F' ' '{print substr($3,2); }': exit-status: matches expectation: [0]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 373911841,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "audit",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: audit: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 353047476,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "sysstat",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: sysstat: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 489916262,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "ntp",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: ntp: installed: matches expectation: [false]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 492172744,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "ebtables",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: ebtables: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 434457957,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "chrony",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: chrony: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 376216516,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "curl",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: curl: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 546627251,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "python3-pip",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: python3-pip: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 380458994,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "ca-certificates",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: ca-certificates: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 590605507,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "awscli",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: awscli: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 427246416,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "amazon-ssm-agent",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: amazon-ssm-agent: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 418004748,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "cloud-utils-growpart",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: cloud-utils-growpart: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 424445242,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "python-requests",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: python-requests: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 47802149,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "dockerd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: dockerd: enabled: matches expectation: [false]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 24304324,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "dockerd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: dockerd: running: matches expectation: [false]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 403969440,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "socat",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: socat: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 416135566,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "yum-utils",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: yum-utils: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 388200160,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "kubeadm",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubeadm: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 109830,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 ""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "[\"1.30.5\"]"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "version",
    amazon-ebs.amazon-2:             "resource-id": "kubeadm",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubeadm: version: matches expectation: []",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 403964657,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "cloud-init",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: cloud-init: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 415659591,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "kubectl",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubectl: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 61713,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 ""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "[\"1.30.5\"]"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "version",
    amazon-ebs.amazon-2:             "resource-id": "kubectl",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubectl: version: matches expectation: []",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 27694534,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "kubelet",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: kubelet: enabled: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 52696060,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "kubelet",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: kubelet: running: matches expectation: [false]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 31080,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"10\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"10\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "kernel.panic",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: kernel.panic: value: matches expectation: [\"10\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 24310,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "kernel.panic_on_oops",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: kernel.panic_on_oops: value: matches expectation: [\"1\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 26644,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "net.bridge.bridge-nf-call-iptables",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: net.bridge.bridge-nf-call-iptables: value: matches expectation: [\"1\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 22995,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "net.ipv6.conf.all.forwarding",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: net.ipv6.conf.all.forwarding: value: matches expectation: [\"1\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 22592,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"0\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"0\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "net.ipv6.conf.all.disable_ipv6",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: net.ipv6.conf.all.disable_ipv6: value: matches expectation: [\"0\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 18915,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "net.ipv4.ip_forward",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: net.ipv4.ip_forward: value: matches expectation: [\"1\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 16733,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "net.bridge.bridge-nf-call-ip6tables",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: net.bridge.bridge-nf-call-ip6tables: value: matches expectation: [\"1\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 21384,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "\"1\""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "value",
    amazon-ebs.amazon-2:             "resource-id": "vm.overcommit_memory",
    amazon-ebs.amazon-2:             "resource-type": "KernelParam",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "KernelParam: vm.overcommit_memory: value: matches expectation: [\"1\"]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 397974333,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "kubelet",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubelet: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 81007,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 ""
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "[\"1.30.5\"]"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "version",
    amazon-ebs.amazon-2:             "resource-id": "kubelet",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubelet: version: matches expectation: []",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 376099848,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "python-netifaces",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: python-netifaces: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 45803041,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "conntrackd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: conntrackd: enabled: matches expectation: [false]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 28958673,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "false"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "conntrackd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: conntrackd: running: matches expectation: [false]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 355265832,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "jq",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: jq: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 49743980,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "auditd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: auditd: enabled: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 33145143,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "auditd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: auditd: running: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 193775337,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "installed",
    amazon-ebs.amazon-2:             "resource-id": "kubernetes-cni",
    amazon-ebs.amazon-2:             "resource-type": "Package",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Package: kubernetes-cni: installed: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 39339090,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "chronyd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: chronyd: enabled: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 31727821,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "chronyd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: chronyd: running: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 23565084,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "amazon-ssm-agent",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: amazon-ssm-agent: enabled: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 19340741,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "amazon-ssm-agent",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: amazon-ssm-agent: running: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 27725623,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "enabled",
    amazon-ebs.amazon-2:             "resource-id": "containerd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: containerd: enabled: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         },
    amazon-ebs.amazon-2:         {
    amazon-ebs.amazon-2:             "duration": 16201929,
    amazon-ebs.amazon-2:             "err": null,
    amazon-ebs.amazon-2:             "expected": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "found": [
    amazon-ebs.amazon-2:                 "true"
    amazon-ebs.amazon-2:             ],
    amazon-ebs.amazon-2:             "human": "",
    amazon-ebs.amazon-2:             "meta": null,
    amazon-ebs.amazon-2:             "property": "running",
    amazon-ebs.amazon-2:             "resource-id": "containerd",
    amazon-ebs.amazon-2:             "resource-type": "Service",
    amazon-ebs.amazon-2:             "result": 0,
    amazon-ebs.amazon-2:             "successful": true,
    amazon-ebs.amazon-2:             "summary-line": "Service: containerd: running: matches expectation: [true]",
    amazon-ebs.amazon-2:             "test-type": 0,
    amazon-ebs.amazon-2:             "title": ""
    amazon-ebs.amazon-2:         }
    amazon-ebs.amazon-2:     ],
    amazon-ebs.amazon-2:     "summary": {
    amazon-ebs.amazon-2:         "failed-count": 0,
    amazon-ebs.amazon-2:         "summary-line": "Count: 51, Failed: 0, Duration: 0.995s",
    amazon-ebs.amazon-2:         "test-count": 51,
    amazon-ebs.amazon-2:         "total-duration": 995052418
    amazon-ebs.amazon-2:     }
    amazon-ebs.amazon-2: }
==> amazon-ebs.amazon-2: Goss validate ran successfully
==> amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2:
==> amazon-ebs.amazon-2: Downloading spec file and debug info
    amazon-ebs.amazon-2: Downloading Goss specs from, /tmp/goss-spec.yaml and /tmp/debug-goss-spec.yaml to current dir
==> amazon-ebs.amazon-2: Stopping the source instance...
    amazon-ebs.amazon-2: Stopping instance
==> amazon-ebs.amazon-2: Waiting for the instance to stop...
==> amazon-ebs.amazon-2: Creating AMI capa-ami-amazon-2-v1.30.5-1732554009 from instance i-00db74b07fd865130
    amazon-ebs.amazon-2: AMI: ami-07af87b14055895c0
==> amazon-ebs.amazon-2: Waiting for AMI to become ready...
```