### PR TITLE
[Fix] - Removing Config Specification tcp_congestion_control 

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -58,7 +58,6 @@
     - { param: net.ipv4.ip_forward, val: 1 }
     - { param: net.ipv6.conf.all.forwarding, val: 1 }
     - { param: net.ipv6.conf.all.disable_ipv6, val: 0 }
-    - { param: net.ipv4.tcp_congestion_control, val: bbr }
     - { param: vm.overcommit_memory, val: 1 }
     - { param: kernel.panic, val: 10 }
     - { param: kernel.panic_on_oops, val: 1 }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
- This PR will remove the `tcp_congestion_control` specification of BBR from the image-builder. Cloud providers default's are typically the preferred and most optimal. AKS, EKS and GKE are all set to `cubic` by default. 

- I've also noticed that when TCP congestion does occur (at least in Azure) BBR performs poorly and packet drops occur at a much higher rate. 


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #
N/A (Will look for relevant issues if any).


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
