### PR TITLE
add HTTPCallbackAddress, needed when running within a kubernetes cluster

### DIFF
--- a/images/capi/packer/proxmox/packer.json.tmpl
+++ b/images/capi/packer/proxmox/packer.json.tmpl
@@ -175,6 +175,7 @@
     "crictl_version": null,
     "disk_size": "20G",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+    "http_callback_address": "{{env `PROXMOX_HTTP_CALLBACK_ADDRESS`}}",
     "http_directory": "./packer/proxmox/linux/{{user `distro_name`}}/http/",
     "iso_storage_pool": "{{env `PROXMOX_ISO_POOL`}}",
     "kubernetes_cni_deb_version": null,


### PR DESCRIPTION
## Change description

When running within a kubernetes workflow/pipelines, the http server used by the vm to communicate back completion cannot be reached directly. Instead, with kubernetes you 'expose' a pod via a LoadBalancer ip or ingress. The exposed ip is available but must be passed in somehow in order for it to be used.

This pull request adds a variable PROXMOX_HTTP_CALLBACK_ADDRESS, which if provided, will be used by the proxmox provider to pass the needed ip to the vm.

Two additional pull requests have been submitted to packer related repos to make this work:
- packer-plugin-sdk: https://github.com/hashicorp/packer-plugin-sdk/pull/268
- packer-plugin-proxmox: https://github.com/hashicorp/packer-plugin-proxmox/pull/305

## Related issues

- Fixes #1618

