### PR TITLE
fix(ami-rockylinux8): fix ami_filter, awscli2

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/awscliv2.yml
+++ b/images/capi/ansible/roles/providers/tasks/awscliv2.yml
@@ -21,7 +21,7 @@
       - gnupg
       - unzip
     state: present
-  when: ansible_distribution == "RedHat"
+  when: ansible_distribution == "RedHat" or packer_build_name is search('rockylinux')
 
 - name: Install AWS CLI prerequisites
   ansible.builtin.apt:

--- a/images/capi/packer/ami/rockylinux-8.json
+++ b/images/capi/packer/ami/rockylinux-8.json
@@ -1,5 +1,5 @@
 {
-  "ami_filter_name": "Rocky-8-ec2-8.5-*",
+  "ami_filter_name": "Rocky-8-EC2-Base-8.9-*",
   "ami_filter_owners": "679593333241",
   "build_name": "rockylinux-8",
   "distribution": "rockylinux",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
- Fix failing rockylinux8


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5142



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
```console
$ PACKER_VAR_FILES=local.json make build-ami-rockylinux-8
hack/image-grok-latest-flatcar-version.sh: line 9: jq: command not found
hack/ensure-python.sh
fatal: No names found, cannot describe anything.
Checking if python is available
Python 3.12.3
hack/ensure-ansible.sh
ansible [core 2.16.3]
Starting galaxy collection install process
Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.
hack/ensure-packer.sh
Packer is already installed, checking version...
existing packer version: 1.9.5
Packer version is as expected
Packer version 1.9.5 is already installed
hack/ensure-ansible-windows.sh
fatal: No names found, cannot describe anything.
/home/hungtran/dev/image-builder/images/capi/.local/bin/packer init packer/config.pkr.hcl
/home/hungtran/dev/image-builder/images/capi/.local/bin/packer build -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/kubernetes.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/cni.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/containerd.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/wasm-shims.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/ansible-args.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/goss-args.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/common.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/additional_components.json"  -var-file="/home/hungtran/dev/image-builder/images/capi/packer/config/ecr_credential_provider.json"  -color=true -var-file="/home/hungtran/dev/image-builder/images/capi/packer/ami/rockylinux-8.json" -var-file="/home/hungtran/dev/image-builder/images/capi/local.json"  packer/ami/packer.json
fatal: No names found, cannot describe anything.
Warning: Bundled plugins used

This template relies on the use of plugins bundled into the Packer binary.
The practice of bundling external plugins into Packer will be removed in an
upcoming version.

To remove this warning and ensure builds keep working you can install these
external plugins with the 'packer plugins install' command

* packer plugins install github.com/hashicorp/amazon

Alternatively, if you upgrade your templates to HCL2, you can use 'packer init'
with a 'required_plugins' block to automatically install external plugins.

You can try HCL2 by running 'packer hcl2_upgrade
/home/hungtran/dev/image-builder/images/capi/packer/ami/packer.json'


amazon-ebs.rockylinux-8: output will be in this color.

==> amazon-ebs.rockylinux-8: Prevalidating any provided VPC information
==> amazon-ebs.rockylinux-8: Prevalidating AMI Name: capa-ami-rockylinux-8-v1.30.5-1732713725
    amazon-ebs.rockylinux-8: Found Image ID: ami-011ef2017d41cb239
==> amazon-ebs.rockylinux-8: Using existing SSH private key
==> amazon-ebs.rockylinux-8: Creating temporary security group for this instance: packer_67471d05-e400-503b-2184-f9de40cd16c1
==> amazon-ebs.rockylinux-8: Authorizing access to port 22 from [0.0.0.0/0] in the temporary security groups...
==> amazon-ebs.rockylinux-8: Launching a source AWS instance...
    amazon-ebs.rockylinux-8: Instance ID: i-013bc9a9bb9bf6ddd
==> amazon-ebs.rockylinux-8: Waiting for instance (i-013bc9a9bb9bf6ddd) to become ready...
==> amazon-ebs.rockylinux-8: Using SSH communicator to connect: 98.83.24.140
==> amazon-ebs.rockylinux-8: Waiting for SSH to become available...
==> amazon-ebs.rockylinux-8: Connected to SSH!
==> amazon-ebs.rockylinux-8: Provisioning with shell script: ./packer/files/flatcar/scripts/bootstrap-flatcar.sh
==> amazon-ebs.rockylinux-8: Provisioning with Ansible...
    amazon-ebs.rockylinux-8: Setting up proxy adapter for Ansible....
==> amazon-ebs.rockylinux-8: Executing Ansible: ansible-playbook -e packer_build_name="rockylinux-8" -e packer_builder_type=amazon-ebs --ssh-extra-args '-o IdentitiesOnly=yes' --extra-vars containerd_url=https://github.com/containerd/containerd/releases/download/v1.7.20/cri-containerd-cni-1.7.20-linux-amd64.tar.gz containerd_sha256=041fa3cfd4e6689d37516e4c7752741df0974e7985d97258c1009b20f25f33c7 pause_image=registry.k8s.io/pause:3.9 containerd_additional_settings= containerd_cri_socket=/var/run/containerd/containerd.sock containerd_version=1.7.20 containerd_wasm_shims_url=https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.11.1/containerd-wasm-shims-<RTVERSION>-<SHIM>-linux-x86_64.tar.gz containerd_wasm_shims_version=v0.11.1 containerd_wasm_shims_sha256={"lunatic":"7054bc882db755ce5f3ded46d114bfd4e0a318e437fa18a2601295d20b616b32","slight":"a6ea87d965037933a7d9edb5e20cfc175265c8e1ca92a16535f1f3c3f376f5b0","spin":"dcffedb8e4d2f585a851b3de489fa1e8a0054ec0ad72cf111c623623919245d0","wws":"e917f90692d798d80873aa0f37990c7d652f2846129d64fecbfd41ffa77799b8"} containerd_wasm_shims_runtimes="" containerd_wasm_shims_runtime_versions="{"lunatic":"v1","slight":"v1","spin":"v2","wws":"v1"}" crictl_url=https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-amd64.tar.gz crictl_sha256=https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.30.0/crictl-v1.30.0-linux-amd64.tar.gz.sha256 crictl_source_type=pkg custom_role_names="" firstboot_custom_roles_pre="" firstboot_custom_roles_post="" node_custom_roles_pre="" node_custom_roles_post="" disable_public_repos=false extra_debs="" extra_repos="" extra_rpms="" http_proxy= https_proxy= kubeadm_template=etc/kubeadm.yml kubernetes_apiserver_port=6443 kubernetes_cni_http_source=https://github.com/containernetworking/plugins/releases/download kubernetes_cni_http_checksum=sha256:https://storage.googleapis.com/k8s-artifacts-cni/release/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz.sha256 kubernetes_goarch=amd64 kubernetes_http_source=https://dl.k8s.io/release kubernetes_container_registry=registry.k8s.io kubernetes_rpm_repo=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/ kubernetes_rpm_gpg_key=https://pkgs.k8s.io/core:/stable:/v1.30/rpm/repodata/repomd.xml.key kubernetes_rpm_gpg_check=True kubernetes_deb_repo=https://pkgs.k8s.io/core:/stable:/v1.30/deb/ kubernetes_deb_gpg_key=https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key kubernetes_cni_deb_version= kubernetes_cni_rpm_version= kubernetes_cni_semver=v1.2.0 kubernetes_cni_source_type=pkg kubernetes_semver=v1.30.5 kubernetes_source_type=pkg kubernetes_load_additional_imgs=false kubernetes_deb_version=1.30.5-1.1 kubernetes_rpm_version=1.30.5 no_proxy= pip_conf_file= python_path= redhat_epel_rpm=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm epel_rpm_gpg_key=https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8 reenable_public_repos=true remove_extra_repos=false systemd_prefix=/usr/lib/systemd sysusr_prefix=/usr sysusrlocal_prefix=/usr/local load_additional_components=false additional_registry_images=false additional_registry_images_list= ecr_credential_provider=false additional_url_images=false additional_url_images_list= additional_executables=false additional_executables_list= additional_executables_destination_path= additional_s3=false build_target=virt amazon_ssm_agent_rpm=https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm enable_containerd_audit= kubernetes_enable_automatic_resource_sizing=false debug_tools=false ubuntu_repo=http://us.archive.ubuntu.com/ubuntu ubuntu_security_repo=http://security.ubuntu.com/ubuntu gpu_block_nouveau_loading= --extra-vars  --extra-vars  --scp-extra-args "-O" -e ansible_ssh_private_key_file=/tmp/ansible-key190967313 -i /tmp/packer-provisioner-ansible431979314 /home/hungtran/dev/image-builder/images/capi/ansible/node.yml
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: PLAY [all] *********************************************************************
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [Gathering Facts] *********************************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [ansible.builtin.include_role : node] *************************************
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [setup : Perform dnf clean] ***********************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [setup : Import epel gpg key] *********************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [setup : Add epel repo] ***************************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [setup : Perform a yum update] ********************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [setup : Install baseline dependencies] ***********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [setup : Install extra rpms] **********************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Ensure overlay module is present] *********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Ensure br_netfilter module is present] ****************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Persist required kernel modules] **********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Set and persist kernel params] ************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'net.bridge.bridge-nf-call-iptables', 'val': 1})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'net.bridge.bridge-nf-call-ip6tables', 'val': 1})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'net.ipv4.ip_forward', 'val': 1})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'net.ipv6.conf.all.forwarding', 'val': 1})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'net.ipv6.conf.all.disable_ipv6', 'val': 0})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'net.ipv4.tcp_congestion_control', 'val': 'bbr'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'vm.overcommit_memory', 'val': 1})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'kernel.panic', 'val': 10})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'kernel.panic_on_oops', 'val': 1})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'fs.inotify.max_user_instances', 'val': 8192})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'param': 'fs.inotify.max_user_watches', 'val': 524288})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Disable conntrackd service] ***************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Ensure auditd is running and comes on at reboot] ******************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Set transparent huge pages to madvise] ****************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Copy udev etcd network tuning rules] ******************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [node : Copy etcd network tuning script] **********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [ansible.builtin.include_role : providers] ********************************
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : ansible.builtin.include_tasks] *******************************
    amazon-ebs.rockylinux-8: included: /home/hungtran/dev/image-builder/images/capi/ansible/roles/providers/tasks/aws.yml for default
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : ansible.builtin.include_tasks] *******************************
    amazon-ebs.rockylinux-8: included: /home/hungtran/dev/image-builder/images/capi/ansible/roles/providers/tasks/awscliv2.yml for default
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Install AWS CLI prequisites] *********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Import AWS public key] ***************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Download AWS CLI v2 archive signature file] ******************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Download AWS CLI v2 archive] *********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Verify AWS CLI v2 archive] ***********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Unzip AWS CLI v2 archive] ************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Install AWS CLI v2] ******************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Remove temporary files] **************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Install aws agents RPM on Redhat distributions] **************
    amazon-ebs.rockylinux-8: changed: [default] => (item=https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm)
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Ensure ssm agent is running RPM] *****************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Creates unit file directory for cloud-final] *****************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Create cloud-final boot order drop in file] ******************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Creates unit file directory for cloud-config] ****************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Create cloud-config boot order drop in file] *****************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Make sure all cloud init services are enabled] ***************
    amazon-ebs.rockylinux-8: ok: [default] => (item=cloud-final)
    amazon-ebs.rockylinux-8: ok: [default] => (item=cloud-config)
    amazon-ebs.rockylinux-8: ok: [default] => (item=cloud-init)
    amazon-ebs.rockylinux-8: ok: [default] => (item=cloud-init-local)
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Create cloud-init config file] *******************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [providers : Ensure chrony is running] ************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [ansible.builtin.include_role : containerd] *******************************
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Install libseccomp package] *********************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Download containerd] ****************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Create a directory if it does not exist] ********************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Unpack containerd] ******************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Delete /opt/cni directory] **********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Delete /etc/cni directory] **********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Create unit file directory] *********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Create containerd memory pressure drop-in file] *************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Create containerd max tasks drop-in file] *******************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Create containerd http proxy conf file if needed] ***********
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Creates containerd config directory] ************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Creates containerd certificates directory] ******************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Copy in containerd config file etc/containerd/config.toml] ***
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Copy in crictl config] **************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Start containerd service] ***********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [containerd : Delete containerd tarball] **********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [ansible.builtin.include_role : kubernetes] *******************************
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Add the Kubernetes repo] ************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Install Kubernetes] *****************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Symlink cri-tools] ******************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item=ctr)
    amazon-ebs.rockylinux-8: changed: [default] => (item=crictl)
    amazon-ebs.rockylinux-8: changed: [default] => (item=critest)
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Create kubelet default config file] *************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Enable kubelet service] *************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Create the Kubernetes version file] *************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Create libexec directory] ***********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Generate kubectl bash completion] ***************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Generate kubeadm bash completion] ***************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Generate crictl bash completion] ****************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Set KUBECONFIG variable and alias] **************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Check if Kubernetes container registry is using Amazon ECR] ***
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Create kubeadm config file] *********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Kubeadm pull images] ****************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [kubernetes : Delete kubeadm config] **************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [ansible.builtin.include_role : sysprep] **********************************
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Define file modes] *********************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Get installed packages] ****************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Create the package list] ***************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Exclude the packages from upgrades] ****************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove yum package caches] *************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove yum package lists] **************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Reset network interface IDs] ***********************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove the kickstart log] **************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove containerd http proxy conf file if needed] **************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Truncate machine id] *******************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/machine-id', 'state': 'absent', 'mode': '0444'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/machine-id', 'state': 'touch', 'mode': '0444'})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Truncate hostname file] ****************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/hostname', 'state': 'absent', 'mode': '0644'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/hostname', 'state': 'touch', 'mode': '0644'})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Set hostname] **************************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Reset hosts file] **********************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Truncate audit logs] *******************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/var/log/wtmp', 'state': 'absent', 'mode': '0664'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/var/log/lastlog', 'state': 'absent', 'mode': '0644'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/var/log/wtmp', 'state': 'touch', 'mode': '0664'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/var/log/lastlog', 'state': 'touch', 'mode': '0644'})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove cloud-init lib dir and logs] ****************************
    amazon-ebs.rockylinux-8: changed: [default] => (item=/var/lib/cloud)
    amazon-ebs.rockylinux-8: changed: [default] => (item=/var/log/cloud-init.log)
    amazon-ebs.rockylinux-8: changed: [default] => (item=/var/log/cloud-init-output.log)
    amazon-ebs.rockylinux-8: changed: [default] => (item=/var/run/cloud-init)
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Reset cloud-init] **********************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove cloud-init.disabled] ************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Find temp files] ***********************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Reset temp space] **********************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/tmp/awscliv2.zip.sig', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 566, 'inode': 8698985, 'dev': 66309, 'nlink': 1, 'atime': 1732715510.0060396, 'mtime': 1732715510.0020397, 'ctime': 1732715510.0050397, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/tmp/awscliv2.zip', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 67085237, 'inode': 25167737, 'dev': 66309, 'nlink': 1, 'atime': 1732715515.1920378, 'mtime': 1732715515.0510378, 'ctime': 1732715515.191038, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/tmp/systemd-private-f7cf47cd07ec4faca1138fdc8a12dc33-chronyd.service-I9z8nG', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 17, 'inode': 17384904, 'dev': 66309, 'nlink': 3, 'atime': 1732714548.5395527, 'mtime': 1732714548.5405529, 'ctime': 1732714548.5405529, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/tmp/aws', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 78, 'inode': 17384907, 'dev': 66309, 'nlink': 3, 'atime': 1732648522.0, 'mtime': 1732648522.0, 'ctime': 1732715534.407032, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: ok: [default] => (item={'path': '/tmp/ansible_ansible.builtin.find_payload_yinotsb9', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 54, 'inode': 2923319, 'dev': 66309, 'nlink': 2, 'atime': 1732716140.8838737, 'mtime': 1732716140.8838737, 'ctime': 1732716140.8838737, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/var/tmp/cloud-init', 'mode': '1777', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 6, 'inode': 16798832, 'dev': 66309, 'nlink': 2, 'atime': 1732713821.7757156, 'mtime': 1732713821.9067156, 'ctime': 1732713821.9067156, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': True, 'rgrp': True, 'xgrp': True, 'woth': True, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/var/tmp/systemd-private-f7cf47cd07ec4faca1138fdc8a12dc33-chronyd.service-ppTN0f', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 17, 'inode': 839459, 'dev': 66309, 'nlink': 3, 'atime': 1732714548.5405529, 'mtime': 1732714548.5405529, 'ctime': 1732714548.5405529, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: [WARNING]: Skipped '/lib/netplan' path due to this access issue: '/lib/netplan'
    amazon-ebs.rockylinux-8: is not a directory
    amazon-ebs.rockylinux-8: [WARNING]: Skipped '/etc/netplan' path due to this access issue: '/etc/netplan'
    amazon-ebs.rockylinux-8: is not a directory
    amazon-ebs.rockylinux-8: [WARNING]: Skipped '/run/netplan' path due to this access issue: '/run/netplan'
    amazon-ebs.rockylinux-8: is not a directory
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Find netplan files] ********************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Find SSH host keys] ********************************************
    amazon-ebs.rockylinux-8: ok: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove SSH host keys] ******************************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/ssh/ssh_host_rsa_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 995, 'size': 2635, 'inode': 25516654, 'dev': 66309, 'nlink': 1, 'atime': 1732713823.1847157, 'mtime': 1732713822.7657156, 'ctime': 1732713822.7707157, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/ssh/ssh_host_rsa_key.pub', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 588, 'inode': 25516655, 'dev': 66309, 'nlink': 1, 'atime': 1732713822.8097157, 'mtime': 1732713822.7657156, 'ctime': 1732713822.7707157, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ecdsa_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 995, 'size': 537, 'inode': 25516656, 'dev': 66309, 'nlink': 1, 'atime': 1732713823.1937156, 'mtime': 1732713822.7787156, 'ctime': 1732713822.7817156, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ecdsa_key.pub', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 196, 'inode': 25516657, 'dev': 66309, 'nlink': 1, 'atime': 1732713822.8097157, 'mtime': 1732713822.7787156, 'ctime': 1732713822.7817156, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ed25519_key', 'mode': '0640', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 995, 'size': 432, 'inode': 25516658, 'dev': 66309, 'nlink': 1, 'atime': 1732713823.1947157, 'mtime': 1732713822.8037157, 'ctime': 1732713822.8087156, 'gr_name': 'ssh_keys', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/etc/ssh/ssh_host_ed25519_key.pub', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 116, 'inode': 25516659, 'dev': 66309, 'nlink': 1, 'atime': 1732713822.8097157, 'mtime': 1732713822.8037157, 'ctime': 1732713822.8087156, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove SSH authorized users] ***********************************
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/root/.ssh/authorized_keys'})
    amazon-ebs.rockylinux-8: changed: [default] => (item={'path': '/home/rocky/.ssh/authorized_keys'})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Truncate all remaining log files in /var/log] ******************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Delete all logrotated logs] ************************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Truncate shell history] ****************************************
    amazon-ebs.rockylinux-8: ok: [default] => (item={'path': '/root/.bash_history'})
    amazon-ebs.rockylinux-8: ok: [default] => (item={'path': '/home/rocky/.bash_history'})
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Rotate journalctl to archive logs] *****************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: TASK [sysprep : Remove archived journalctl logs] *******************************
    amazon-ebs.rockylinux-8: changed: [default]
    amazon-ebs.rockylinux-8:
    amazon-ebs.rockylinux-8: PLAY RECAP *********************************************************************
    amazon-ebs.rockylinux-8: default                    : ok=94   changed=72   unreachable=0    failed=0    skipped=395  rescued=0    ignored=0
    amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8: Provisioning with Goss
==> amazon-ebs.rockylinux-8: Configured to run on Linux
    amazon-ebs.rockylinux-8: Creating directory: /tmp/goss
    amazon-ebs.rockylinux-8: Installing Goss from, https://github.com/goss-org/goss/releases/download/v0.3.16/goss-linux-amd64
    amazon-ebs.rockylinux-8: Downloading Goss to /tmp/goss-0.3.16-linux-amd64
    amazon-ebs.rockylinux-8: goss version v0.3.16
==> amazon-ebs.rockylinux-8: Uploading goss tests...
    amazon-ebs.rockylinux-8: Uploading vars file packer/goss/goss-vars.yaml
    amazon-ebs.rockylinux-8: Inline variables are --vars-inline '{"ARCH":"amd64","OS":"rockylinux","OS_VERSION":"8","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}'
    amazon-ebs.rockylinux-8: Uploading Dir packer/goss
    amazon-ebs.rockylinux-8: Creating directory: /tmp/goss/goss
==> amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8: Running goss tests...
==> amazon-ebs.rockylinux-8: Running GOSS render command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"rockylinux","OS_VERSION":"8","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}' render > /tmp/goss-spec.yaml
==> amazon-ebs.rockylinux-8: Goss render ran successfully
==> amazon-ebs.rockylinux-8: Running GOSS render debug command: cd /tmp/goss &&  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"rockylinux","OS_VERSION":"8","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}' render -d > /tmp/debug-goss-spec.yaml
==> amazon-ebs.rockylinux-8: Goss render debug ran successfully
==> amazon-ebs.rockylinux-8: Running GOSS validate command: cd /tmp/goss && sudo  /tmp/goss-0.3.16-linux-amd64 --gossfile goss/goss.yaml --vars /tmp/goss/goss-vars.yaml --vars-inline '{"ARCH":"amd64","OS":"rockylinux","OS_VERSION":"8","PROVIDER":"amazon","containerd_version":"1.7.20","kubernetes_cni_deb_version":"","kubernetes_cni_rpm_version":"","kubernetes_cni_source_type":"pkg","kubernetes_cni_version":"1.2.0","kubernetes_deb_version":"1.30.5-1.1","kubernetes_rpm_version":"1.30.5","kubernetes_source_type":"pkg","kubernetes_version":"1.30.5"}' validate --retry-timeout 0s --sleep 1s -f json -o pretty
    amazon-ebs.rockylinux-8: {
    amazon-ebs.rockylinux-8:     "results": [
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 14010303,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "sysstat",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: sysstat: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 14285202,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "yum-utils",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: yum-utils: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 27055308,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "exit-status",
    amazon-ebs.rockylinux-8:             "resource-id": "containerd --version | awk -F' ' '{print substr($3,2); }'",
    amazon-ebs.rockylinux-8:             "resource-type": "Command",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Command: containerd --version | awk -F' ' '{print substr($3,2); }': exit-status: matches expectation: [0]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 15519910,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "socat",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: socat: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 10226569,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "kubelet",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubelet: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 116903,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 ""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "[\"1.30.5\"]"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "version",
    amazon-ebs.rockylinux-8:             "resource-id": "kubelet",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubelet: version: matches expectation: []",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 81285323,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "amazon-ssm-agent",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: amazon-ssm-agent: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 85110544,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "audit",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: audit: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 94850078,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "exit-status",
    amazon-ebs.rockylinux-8:             "resource-id": "crictl ps",
    amazon-ebs.rockylinux-8:             "resource-type": "Command",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Command: crictl ps: exit-status: matches expectation: [0]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 119063355,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "kubeadm",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubeadm: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 76515,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 ""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "[\"1.30.5\"]"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "version",
    amazon-ebs.rockylinux-8:             "resource-id": "kubeadm",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubeadm: version: matches expectation: []",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 132001998,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "kubernetes-cni",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubernetes-cni: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 121740296,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "nftables",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: nftables: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 131771455,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "chrony",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: chrony: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 101961128,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "ntp",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: ntp: installed: matches expectation: [false]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 156448931,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "exit-status",
    amazon-ebs.rockylinux-8:             "resource-id": "crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort",
    amazon-ebs.rockylinux-8:             "resource-type": "Command",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Command: crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort: exit-status: matches expectation: [0]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 23534,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "coredns",
    amazon-ebs.rockylinux-8:                 "etcd",
    amazon-ebs.rockylinux-8:                 "kube-apiserver",
    amazon-ebs.rockylinux-8:                 "kube-controller-manager",
    amazon-ebs.rockylinux-8:                 "kube-proxy",
    amazon-ebs.rockylinux-8:                 "kube-scheduler",
    amazon-ebs.rockylinux-8:                 "pause"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "coredns",
    amazon-ebs.rockylinux-8:                 "etcd",
    amazon-ebs.rockylinux-8:                 "kube-apiserver",
    amazon-ebs.rockylinux-8:                 "kube-controller-manager",
    amazon-ebs.rockylinux-8:                 "kube-proxy",
    amazon-ebs.rockylinux-8:                 "kube-scheduler",
    amazon-ebs.rockylinux-8:                 "pause"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "stdout",
    amazon-ebs.rockylinux-8:             "resource-id": "crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort",
    amazon-ebs.rockylinux-8:             "resource-type": "Command",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Command: crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $2}' | sed 's/-amd64//g' | sort: stdout: matches expectation: [coredns etcd kube-apiserver kube-controller-manager kube-proxy kube-scheduler pause]",
    amazon-ebs.rockylinux-8:             "test-type": 2,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 78714429,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "ca-certificates",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: ca-certificates: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 87575954,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "python3-requests",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: python3-requests: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 64619456,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "python3-pip",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: python3-pip: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 100035442,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "curl",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: curl: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 61731996,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "kubectl",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubectl: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 901887,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 ""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "[\"1.30.5\"]"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "version",
    amazon-ebs.rockylinux-8:             "resource-id": "kubectl",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: kubectl: version: matches expectation: []",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 73173037,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "jq",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: jq: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 77808880,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "python3-netifaces",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: python3-netifaces: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 71185981,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "cloud-init",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: cloud-init: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 86591567,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "conntrack-tools",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: conntrack-tools: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 56603,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"10\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"10\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "kernel.panic",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: kernel.panic: value: matches expectation: [\"10\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 25262,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "kernel.panic_on_oops",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: kernel.panic_on_oops: value: matches expectation: [\"1\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 367394,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "net.bridge.bridge-nf-call-iptables",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: net.bridge.bridge-nf-call-iptables: value: matches expectation: [\"1\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 72764,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "net.ipv6.conf.all.forwarding",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: net.ipv6.conf.all.forwarding: value: matches expectation: [\"1\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 257837,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"0\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"0\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "net.ipv6.conf.all.disable_ipv6",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: net.ipv6.conf.all.disable_ipv6: value: matches expectation: [\"0\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 27765,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "net.ipv4.ip_forward",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: net.ipv4.ip_forward: value: matches expectation: [\"1\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 126905,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "net.bridge.bridge-nf-call-ip6tables",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: net.bridge.bridge-nf-call-ip6tables: value: matches expectation: [\"1\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 91395,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "\"1\""
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "value",
    amazon-ebs.rockylinux-8:             "resource-id": "vm.overcommit_memory",
    amazon-ebs.rockylinux-8:             "resource-type": "KernelParam",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "KernelParam: vm.overcommit_memory: value: matches expectation: [\"1\"]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 86309190,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "installed",
    amazon-ebs.rockylinux-8:             "resource-id": "cloud-utils-growpart",
    amazon-ebs.rockylinux-8:             "resource-type": "Package",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Package: cloud-utils-growpart: installed: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 87734489,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "kubelet",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: kubelet: enabled: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 58066685,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "kubelet",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: kubelet: running: matches expectation: [false]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 97963897,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "auditd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: auditd: enabled: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 47494755,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "auditd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: auditd: running: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 98392254,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "conntrackd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: conntrackd: enabled: matches expectation: [false]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 56140073,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "conntrackd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: conntrackd: running: matches expectation: [false]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 104537198,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "chronyd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: chronyd: enabled: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 52348830,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "chronyd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: chronyd: running: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 91674854,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "amazon-ssm-agent",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: amazon-ssm-agent: enabled: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 61636001,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "amazon-ssm-agent",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: amazon-ssm-agent: running: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 82007215,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "containerd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: containerd: enabled: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 58795998,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "true"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "containerd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: containerd: running: matches expectation: [true]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 91921366,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "enabled",
    amazon-ebs.rockylinux-8:             "resource-id": "dockerd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: dockerd: enabled: matches expectation: [false]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 53879124,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "false"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "running",
    amazon-ebs.rockylinux-8:             "resource-id": "dockerd",
    amazon-ebs.rockylinux-8:             "resource-type": "Service",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Service: dockerd: running: matches expectation: [false]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         },
    amazon-ebs.rockylinux-8:         {
    amazon-ebs.rockylinux-8:             "duration": 1553942303,
    amazon-ebs.rockylinux-8:             "err": null,
    amazon-ebs.rockylinux-8:             "expected": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "found": [
    amazon-ebs.rockylinux-8:                 "0"
    amazon-ebs.rockylinux-8:             ],
    amazon-ebs.rockylinux-8:             "human": "",
    amazon-ebs.rockylinux-8:             "meta": null,
    amazon-ebs.rockylinux-8:             "property": "exit-status",
    amazon-ebs.rockylinux-8:             "resource-id": "/usr/local/sbin/aws --version",
    amazon-ebs.rockylinux-8:             "resource-type": "Command",
    amazon-ebs.rockylinux-8:             "result": 0,
    amazon-ebs.rockylinux-8:             "successful": true,
    amazon-ebs.rockylinux-8:             "summary-line": "Command: /usr/local/sbin/aws --version: exit-status: matches expectation: [0]",
    amazon-ebs.rockylinux-8:             "test-type": 0,
    amazon-ebs.rockylinux-8:             "title": ""
    amazon-ebs.rockylinux-8:         }
    amazon-ebs.rockylinux-8:     ],
    amazon-ebs.rockylinux-8:     "summary": {
    amazon-ebs.rockylinux-8:         "failed-count": 0,
    amazon-ebs.rockylinux-8:         "summary-line": "Count: 51, Failed: 0, Duration: 1.555s",
    amazon-ebs.rockylinux-8:         "test-count": 51,
    amazon-ebs.rockylinux-8:         "total-duration": 1554659473
    amazon-ebs.rockylinux-8:     }
    amazon-ebs.rockylinux-8: }
==> amazon-ebs.rockylinux-8: Goss validate ran successfully
==> amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8:
==> amazon-ebs.rockylinux-8: Downloading spec file and debug info
    amazon-ebs.rockylinux-8: Downloading Goss specs from, /tmp/goss-spec.yaml and /tmp/debug-goss-spec.yaml to current dir
==> amazon-ebs.rockylinux-8: Stopping the source instance...
    amazon-ebs.rockylinux-8: Stopping instance
==> amazon-ebs.rockylinux-8: Waiting for the instance to stop...
==> amazon-ebs.rockylinux-8: Creating AMI capa-ami-rockylinux-8-v1.30.5-1732713725 from instance i-013bc9a9bb9bf6ddd
    amazon-ebs.rockylinux-8: AMI: ami-0cade1a8f27fad1b2
==> amazon-ebs.rockylinux-8: Waiting for AMI to become ready...
```