### PR TITLE
fix(ansible/openstack): run networkd-dispatcher only on debian

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -37,6 +37,7 @@
     name: networkd-dispatcher
     state: started
     enabled: true
+  when: ansible_os_family == "Debian"
 
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

https://github.com/kubernetes-sigs/image-builder/pull/1627 introduced starting the networkd-dispatcher service. networkd-dispatcher is only available on debian based systems (as you can see in other tasks in the providers/openstack file). 

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

none



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

none