### PR TITLE
Fix state for Ansible RHSM repository module

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -58,7 +58,7 @@
     - name: Remove subscriptions
       community.general.rhsm_repository:
         name: "*"
-        state: absent
+        state: disabled
     - name: Unregister system
       community.general.redhat_subscription:
         state: absent


### PR DESCRIPTION
I observed this in all the RedHat image builds in our CI
```console
qemu: TASK [sysprep : Remove subscriptions] ******************************************
qemu: fatal: [default]: FAILED! => {"changed": false, "msg": "value of state must be one of: enabled, disabled, got: absent"}
```

This task is defined [here](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/sysprep/tasks/redhat.yml#L58-L61) and uses the community.general.rhsm_repository` module, provided by the Ansible collection `community.general`. Upon further digging, I found that `community.general` recently released version `v10.0.0` where they removed the state `present`/`absent` in favor of `enabled`/`disabled`. Hence we need to use the same in image-builder, since when I checked recent PRs, it 
 was community.general v10.0.0 that was getting installed in the presubmits.