### PR TITLE
Enable cleanup for /var/log/messages on Photon for vSphere Provider

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -84,16 +84,19 @@ photon_3_rpms:
   - python-netifaces
   - python-requests
   - jq
+  - logrotate
 
 # Creating photon_4_rpms for adding future packages if needed.
 # Since empty list errors out, jq is added.
 photon_4_rpms:
   - jq
+  - logrotate
 
 # Creating photon_5_rpms for adding future packages if needed.
 # Since empty list errors out, jq is added.
 photon_5_rpms:
   - jq
+  - logrotate
 
 common_virt_rpms:
   - open-vm-tools

--- a/images/capi/ansible/roles/providers/defaults/main.yml
+++ b/images/capi/ansible/roles/providers/defaults/main.yml
@@ -15,3 +15,4 @@
 networkd_dispatcher_download_url: https://gitlab.com/craftyguy/networkd-dispatcher/-/archive/2.1/networkd-dispatcher-2.1.tar.gz
 packer_builder_type: ""
 build_target: virt
+var_log_messages_maxsize: 100M

--- a/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
@@ -77,3 +77,9 @@
     owner: root
     group: root
     mode: a+x
+
+- name: Create configuration for rotate /var/log/messages
+  ansible.builtin.template:
+    src: etc/logrotate.d/messages.j2
+    dest: /etc/logrotate.d/messages
+    mode: a+x

--- a/images/capi/ansible/roles/providers/templates/etc/logrotate.d/messages.j2
+++ b/images/capi/ansible/roles/providers/templates/etc/logrotate.d/messages.j2
@@ -1,0 +1,10 @@
+/var/log/messages {
+    compress
+    nodateext
+    rotate 5
+    daily
+    maxsize {{ var_log_messages_maxsize }}
+    missingok
+    notifempty
+    copytruncate
+}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -88,12 +88,15 @@ photon_3_rpms: &photon_3_rpms
   python-netifaces:
   python-requests:
   jq:
+  logrotate:
 
 photon_4_rpms: &photon_4_rpms
   jq:
+  logrotate:
 
 photon_5_rpms: &photon_5_rpms
   jq:
+  logrotate:
 
 arch: "amd64"
 containerd_version: ""
@@ -216,6 +219,12 @@ photon:
     <<: *common_photon_rpms
     audit:
   ova:
+    files:
+      '/etc/logrotate.d/messages':
+        exists: true
+        filetype: file
+        contains:
+        - "maxsize"
     command:
       grep apparmor=0 /boot/photon.cfg:
         exit-status: 0


### PR DESCRIPTION

## Change description

This PR adds logrotate binary and corresponding configurations to enable log rotation and cleanup for /var/log/messages in Photon for vSphere Provider



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1647


