### PR TITLE
Update rocky linux image url

### DIFF
--- a/images/capi/packer/ova/rockylinux-9.json
+++ b/images/capi/packer/ova/rockylinux-9.json
@@ -11,7 +11,7 @@
   "guest_os_type": "rockylinux-64",
   "iso_checksum": "ee3ac97fdffab58652421941599902012179c37535aece76824673105169c4a2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.4-x86_64-minimal.iso",
+  "iso_url": "https://dl.rockylinux.org/vault/rocky/9.4/isos/x86_64/Rocky-9.4-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 9",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p",

--- a/images/capi/packer/proxmox/rockylinux-9.json
+++ b/images/capi/packer/proxmox/rockylinux-9.json
@@ -11,7 +11,7 @@
   "guest_os_type": "rockylinux-64",
   "iso_checksum": "ee3ac97fdffab58652421941599902012179c37535aece76824673105169c4a2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.4-x86_64-minimal.iso",
+  "iso_url": "https://dl.rockylinux.org/vault/rocky/9.4/isos/x86_64/Rocky-9.4-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 9",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p",

--- a/images/capi/packer/qemu/qemu-rockylinux-9.json
+++ b/images/capi/packer/qemu/qemu-rockylinux-9.json
@@ -10,7 +10,7 @@
   "guest_os_type": "centos9-64",
   "iso_checksum": "ee3ac97fdffab58652421941599902012179c37535aece76824673105169c4a2",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://download.rockylinux.org/pub/rocky/9/isos/x86_64/Rocky-9.4-x86_64-minimal.iso",
+  "iso_url": "https://dl.rockylinux.org/vault/rocky/9.4/isos/x86_64/Rocky-9.4-x86_64-minimal.iso",
   "os_display_name": "RockyLinux 9",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
This PR changes the URL to download the Rocky Linux images using the Rocky archive ones. The current URL returns a 404 error.



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->




## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
