### PR TITLE
ci(docker): add OCI labels to the Docker image

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -17,6 +17,11 @@
 ARG BASE_IMAGE=docker.io/library/ubuntu:24.04
 FROM $BASE_IMAGE
 
+ARG TAG=dev
+LABEL org.opencontainers.image.source=https://github.com/kubernetes-sigs/image-builder
+LABEL org.opencontainers.image.url=https://image-builder.sigs.k8s.io
+LABEL org.opencontainers.image.version=$TAG
+
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	apt-transport-https \
 	build-essential \

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -1121,7 +1121,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the Docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the Docker image


### PR DESCRIPTION


## Change description
<!-- What this PR does / why we need it. -->

This change adds OCI labels to the container image. It can be used by some tools to automatically fetch the corresponding CHANGELOG (e.g. Renovate).

Common OCI labels are documented here: https://github.com/opencontainers/image-spec/blob/main/annotations.md

