### PR TITLE
Make image-build-flatcar.sh POSIX-compliant

### DIFF
--- a/images/capi/hack/image-build-flatcar.sh
+++ b/images/capi/hack/image-build-flatcar.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-[[ -n ${DEBUG:-} ]] && set -o xtrace
+[ -n "${DEBUG:-}" ] && set -o xtrace
 
 export VAGRANT_VAGRANTFILE=${VAGRANT_VAGRANTFILE:-/tmp/Vagrantfile.builder-flatcar}
 export VAGRANT_SSH_PRIVATE_KEY=${VAGRANT_SSH_PRIVATE_KEY:-/tmp/vagrant-insecure-key}
@@ -125,15 +125,15 @@ export FLATCAR_CHANNEL FLATCAR_VERSION
 
 rm -rf ./output/flatcar-"${channel}-${release}"-kube-*
 
-if [[ ${CAPI_PROVIDER} = "qemu" ]]; then
-    FLATCAR_MAKE_OPTS+="FLATCAR_CHANNEL=$channel FLATCAR_VERSION=$release "
-    FLATCAR_MAKE_OPTS+="SSH_PRIVATE_KEY_FILE=${VAGRANT_SSH_PRIVATE_KEY} "
-    FLATCAR_MAKE_OPTS+="SSH_PUBLIC_KEY_FILE=${VAGRANT_SSH_PUBLIC_KEY} "
+if [ "${CAPI_PROVIDER}" = "qemu" ]; then
+    FLATCAR_MAKE_OPTS="${FLATCAR_MAKE_OPTS}FLATCAR_CHANNEL=$channel FLATCAR_VERSION=$release "
+    FLATCAR_MAKE_OPTS="${FLATCAR_MAKE_OPTS}SSH_PRIVATE_KEY_FILE=${VAGRANT_SSH_PRIVATE_KEY} "
+    FLATCAR_MAKE_OPTS="${FLATCAR_MAKE_OPTS}SSH_PUBLIC_KEY_FILE=${VAGRANT_SSH_PUBLIC_KEY} "
 
     fetch_vagrant_ssh_keys
     make ${FLATCAR_MAKE_OPTS} build-qemu-flatcar
     run_vagrant
-elif [[ ${CAPI_PROVIDER} = "aws" ]] || [[ ${CAPI_PROVIDER} = "ami" ]]; then
+elif [ "${CAPI_PROVIDER}" = "aws" ] || [ "${CAPI_PROVIDER}" = "ami" ]; then
     make ${FLATCAR_MAKE_OPTS} build-ami-flatcar
 else
     echo "Unknown CAPI_PROVIDER=${CAPI_PROVIDER}. exit."


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This PR makes the `image-build-flatcar.sh` script POSIX-compliant.

The current syntax is broken on my Ubuntu dev machine with the default sh shell so I assume this is broken for others, too.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

None.


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

None.