### PR TITLE
Proxmox add config variables

### DIFF
--- a/docs/book/src/capi/providers/proxmox.md
+++ b/docs/book/src/capi/providers/proxmox.md
@@ -73,7 +73,7 @@ Then the user (not token) must be given the following permissions on the path `/
 
 *We suggest creating a new role, since no built-in PVE roles covers just these.*
 
-Note that you might have to change disk format from `qcow2` to `raw` in `images/capi/packer/proxmox/packer.json.tmpl` if the storage for the VM disk is block only.
+Note that you might have to change disk format from `qcow2` to `raw` using the `disk_format` packer flag if the storage for the VM disk is block only (see the note below).
 
 ### Building images for Flatcar
 
@@ -102,4 +102,20 @@ export PROXMOX_STORAGE_POOL="local-lvm"
 
 ```bash
 make build-proxmox-ubuntu-2204
+```
+
+### Note on disk formats
+
+Depending on what storage type you are using, you will need to change the default disk
+format from `qcow2` to something else.
+Go to [Proxmox Storage Documentation](https://pve.proxmox.com/wiki/Storage#_see_also) and
+look into the documentation of the storage type backing your selected storage pool to see which
+disk formats are supported. If the storage type does not list `qcow2` in in the supported
+image formats, you will need to change the packer variable `disk_format` to a supported format.
+
+For example when using the ZFS storage type, which does not support `qcow2`, you can use the
+`raw` disk format.
+
+```sh
+export PROXMOX_STORAGE_POOL="local-zfs" PACKER_FLAGS="-var disk_format=raw"
 ```

--- a/images/capi/packer/proxmox/packer.json.tmpl
+++ b/images/capi/packer/proxmox/packer.json.tmpl
@@ -13,7 +13,7 @@
       "disks": [
         {
           "disk_size": "{{user `disk_size`}}",
-          "format": "qcow2",
+          "format": "{{user `disk_format`}}",
           "storage_pool": "{{user `storage_pool`}}",
           "storage_pool_type": "{{user `storage_pool_type`}}",
           "type": "scsi"
@@ -182,6 +182,7 @@
     "cores": "2",
     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
     "crictl_version": null,
+    "disk_format": "qcow2",
     "disk_size": "20G",
     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
     "http_directory": "./packer/proxmox/linux/{{user `distro_name`}}/http/",

--- a/images/capi/packer/proxmox/packer.json.tmpl
+++ b/images/capi/packer/proxmox/packer.json.tmpl
@@ -36,6 +36,7 @@
         }
       ],
       "node": "{{ user `node` }}",
+      "numa": "{{ user `numa` }}",
       "sockets": "{{user `sockets`}}",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "2h",
@@ -209,6 +210,8 @@
     "mtu": "{{env `PROXMOX_MTU`}}",
     "node": "{{env `PROXMOX_NODE`}}",
     "oem_id": "{{ user `oem_id` }}",
+    "numa": "false",
+    "oem_id": {{ user `oem_id` }},
     "proxmox_url": "{{env `PROXMOX_URL`}}",
     "sockets": "2",
     "ssh_password": "$SSH_PASSWORD",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This PR adds two new configuration variables to the Proxmox packer configuration:

- `disk_format`:
  - Depending on the storage backend configured qcow2 may not be available (e.g. ZFS storage pools only support raw disk images)
  - There is already a similar PR, which wants to change the disk format to raw permanently
    - #1636
    - In contrast, this PR only makes the disk format configurable while not changing the default value (qcow2)
- `numa`:
  - Depending on the hardware, enabling numa on the template may be preferred

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
