### PR TITLE
Fixes the Windows update categories are not correctly set

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/defaults/main.yml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-windows_updates_kbs_numbers: "{{ windows_updates_kbs.split() if (windows_updates_kbs is defined) and (windows_updates_kbs | length > 0) else [] }}"
-windows_updates_category_names: >
-  {{ windows_updates_categories.split() if (windows_updates_categories is defined)
-    and (windows_updates_categories | length > 0) else [] }}"
+windows_updates_kbs_numbers: "{{ (windows_updates_kbs | default('')) | split | select('string') | list }}"
+windows_updates_category_names: "{{ (windows_updates_categories | default('')) | split | select('string') | list }}"
 ssh_source_url: "{{ ssh_source_url if ssh_source_url is defined else '' }}"

--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -71,7 +71,7 @@
 # will skip this task.
 - name: Install Windows updates based on KB numbers
   ansible.windows.win_updates:
-    whitelist: "{{ windows_updates_kbs_numbers }}"
+    accept_list: "{{ windows_updates_kbs_numbers }}"
     reboot: true
     category_names:
       - Application


### PR DESCRIPTION


## Change description
Fixes the Windows update categories are not correctly set

win_updates module expects a list while string is passed to the module.



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1667



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
