### PR TITLE
Almalinux 9 image on Outscale.

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -375,7 +375,7 @@ DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204 do-ubuntu-2404
 
 OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-flatcar
 
-OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204 osc-almaLinux-9-2024
+OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204 osc-almaLinux-9
 
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2304 qemu-ubuntu-2404 qemu-ubuntu-2404-efi qemu-ubuntu-2204-efi qemu-centos-7 qemu-centos-9 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rhel-9 qemu-rockylinux-8 qemu-rockylinux-8-cloudimg qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
 
@@ -845,7 +845,7 @@ build-oci-all: $(OCI_BUILD_TARGETS) ## Builds all OCI image
 
 build-osc-ubuntu-2004: ## Builds Ubuntu 20.04 Outscale Snapshot
 build-osc-ubuntu-2204: ## Builds Ubuntu 22.04 Outscale Snapshot
-build-osc-almaLinux-9-2024:
+build-osc-almaLinux-9: ## Builds AlmaLinux 9 Outscale Snapshot
 build-osc-all: $(OSC_BUILD_TARGETS) ## Builds all Outscale Snapshot
 
 build-nutanix-ubuntu-2004: ## Builds the Nutanix ubuntu-2004 image
@@ -1024,7 +1024,7 @@ validate-oci-all: $(OCI_VALIDATE_TARGETS) ## Validates all OCI image packer conf
 
 validate-osc-ubuntu-2004: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config
 validate-osc-ubuntu-2204: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config
-validate-osc-almaLinux-9-2024:
+validate-osc-almaLinux-9: ## Validates AlmaLinux 9 Outscale Snapshot Packer config
 validate-osc-all: $(OSC_VALIDATE_TARGETS) ## Validates all Outscale Snapshot Packer config
 
 validate-powervs-centos-8: ## Validates the PowerVS CentOS 8 image packer config

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -375,7 +375,7 @@ DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204 do-ubuntu-2404
 
 OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-flatcar
 
-OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204
+OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204 osc-almaLinux-9-2024
 
 QEMU_BUILD_NAMES			?=	qemu-ubuntu-2004 qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2304 qemu-ubuntu-2404 qemu-ubuntu-2404-efi qemu-ubuntu-2204-efi qemu-centos-7 qemu-centos-9 qemu-ubuntu-2004-efi qemu-rhel-8 qemu-rhel-9 qemu-rockylinux-8 qemu-rockylinux-8-cloudimg qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
 
@@ -845,6 +845,7 @@ build-oci-all: $(OCI_BUILD_TARGETS) ## Builds all OCI image
 
 build-osc-ubuntu-2004: ## Builds Ubuntu 20.04 Outscale Snapshot
 build-osc-ubuntu-2204: ## Builds Ubuntu 22.04 Outscale Snapshot
+build-osc-almaLinux-9-2024:
 build-osc-all: $(OSC_BUILD_TARGETS) ## Builds all Outscale Snapshot
 
 build-nutanix-ubuntu-2004: ## Builds the Nutanix ubuntu-2004 image
@@ -1023,6 +1024,7 @@ validate-oci-all: $(OCI_VALIDATE_TARGETS) ## Validates all OCI image packer conf
 
 validate-osc-ubuntu-2004: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config
 validate-osc-ubuntu-2204: ## Validates Ubuntu 20.04 Outscale Snapshot Packer config
+validate-osc-almaLinux-9-2024:
 validate-osc-all: $(OSC_VALIDATE_TARGETS) ## Validates all Outscale Snapshot Packer config
 
 validate-powervs-centos-8: ## Validates the PowerVS CentOS 8 image packer config

--- a/images/capi/ansible/roles/providers/tasks/outscale.yml
+++ b/images/capi/ansible/roles/providers/tasks/outscale.yml
@@ -10,3 +10,15 @@
       - cloud-guest-utils
       - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
+  when: ansible_os_family == "Debian"
+
+- name: Install cloud-init packages
+  ansible.builtin.yum:
+    name: "{{ packages }}"
+    state: present
+  vars:
+    packages:
+      - cloud-init
+      - cloud-utils-growpart
+  when: ansible_os_family == "RedHat"
+

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -15,8 +15,8 @@
 debs: ""
 extra_debs: ""
 pinned_debs: []
-https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpmredhat_epel_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-epel_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
+redhat_epel_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+epel_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 rpms: ""
 extra_rpms: ""
 

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -15,8 +15,8 @@
 debs: ""
 extra_debs: ""
 pinned_debs: []
-redhat_epel_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-epel_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpmredhat_epel_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+epel_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9
 rpms: ""
 extra_rpms: ""
 

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -690,3 +690,9 @@ windows:
         filetype: file
         contains:
         - "metadata_services=cloudbaseinit.metadata.services.base.EmptyMetadataService"
+almalinux:
+  common-package: *common_rpms
+  outscale:
+    package:
+      cloud-init:
+      cloud-utils-growpart:

--- a/images/capi/packer/outscale/almaLinux-9-2024.json
+++ b/images/capi/packer/outscale/almaLinux-9-2024.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "almalinux-9-2024",
+  "distribution": "almalinux",
+  "distribution_release": "almalinux",
+  "distribution_version": "9",
+  "image_name": "AlmaLinux-9-2024.02.16-0",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+}

--- a/images/capi/packer/outscale/almaLinux-9-2024.json
+++ b/images/capi/packer/outscale/almaLinux-9-2024.json
@@ -1,5 +1,5 @@
 {
-  "build_name": "almalinux-9-2024",
+  "build_name": "almalinux-9",
   "distribution": "almalinux",
   "distribution_release": "almalinux",
   "distribution_version": "9",

--- a/images/capi/packer/outscale/config.pkr.hcl
+++ b/images/capi/packer/outscale/config.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     outscale = {
       source =  "github.com/outscale/outscale"
-      version = "~> 1.2.0"
+      version = "~> 1.3.0"
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
This PR adds the necessaries to build an image based on almalinux 9 on Outscale. It also bump the outscale packer module from 1.2.0 to 1.3.0 (latest).


## Additional context
The resulting image has been tested and works for me (No reason why not, it uses redhat based playbooks from other cloud provider) but won't be supported by outscale (I suppose). Proposing the PR just in case.

