### PR TITLE
Support customize Windows admin password when building OVA

### DIFF
--- a/images/capi/hack/windows-ova-unattend.py
+++ b/images/capi/hack/windows-ova-unattend.py
@@ -64,16 +64,22 @@ def main():
     
     root = unattend.getroot()
 
-    if data["unattend_timezone"] != "":
+    if data.get("unattend_timezone"):
       modified=1
       setting = set_xmlstring(root, ".//*[@pass='oobeSystem']/*[@name='Microsoft-Windows-Shell-Setup']",'{urn:schemas-microsoft-com:unattend}TimeZone', data["unattend_timezone"])
       print("windows-ova-unattend: Setting Timezone to %s" % data["unattend_timezone"])
     
+    admin_password = data.get("admin_password")
+    if admin_password:
+      modified=1
+      set_xmlstring(root, ".//*[@pass='oobeSystem']/*[@name='Microsoft-Windows-Shell-Setup']/{*}UserAccounts/{*}AdministratorPassword",'{urn:schemas-microsoft-com:unattend}Value', admin_password)
+      set_xmlstring(root, ".//*[@pass='oobeSystem']/*[@name='Microsoft-Windows-Shell-Setup']/{*}AutoLogon/{*}Password",'{urn:schemas-microsoft-com:unattend}Value', admin_password)
+      print("windows-ova-unattend: Setting Administrator Password")
+
     if modified == 1:
       print("windows-ova-unattend: Updating %s ..." % args.unattend_file)
       unattend.write(args.unattend_file)
-    
-    if modified == 0:
+    else:
       print("windows-ova-unattend: skipping...")
 
 if __name__ == "__main__":

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -1,7 +1,7 @@
 {
   "builders": [
     {
-      "content": "{\n \"unattend_timezone\" : \"{{user `unattend_timezone`}}\"\n}",
+      "content": "{\n \"unattend_timezone\" : \"{{user `unattend_timezone`}}\"\n, \"admin_password\" : \"{{user `windows_admin_password`}}\"\n}",
       "target": "./packer_cache/unattend.json",
       "type": "file"
     },
@@ -42,7 +42,7 @@
         "numvcpus": "4",
         "scsi0.virtualDev": "pvscsi"
       },
-      "winrm_password": "S3cr3t0!",
+      "winrm_password": "{{user `windows_admin_password`}}",
       "winrm_timeout": "4h",
       "winrm_username": "Administrator"
     },
@@ -105,7 +105,7 @@
       "vm_name": "{{user `build_version`}}",
       "vm_version": "{{user `vmx_version`}}",
       "winrm_insecure": true,
-      "winrm_password": "S3cr3t0!",
+      "winrm_password": "{{user `windows_admin_password`}}",
       "winrm_timeout": "4h",
       "winrm_username": "Administrator"
     }
@@ -262,6 +262,7 @@
     "output_dir": "./output/{{user `build_version`}}",
     "prepull": null,
     "unattend_timezone": "Pacific Standard Time",
+    "windows_admin_password": "S3cr3t0!",
     "windows_service_manager": null,
     "windows_updates_categories": null,
     "windows_updates_kbs": null


### PR DESCRIPTION
## Change description
Allow user to specify password other than a hardcoded one when building Windows


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1672



## Additional context
User may set admin password in the variable JSON

```
{
   "windows_admin_password": "mypa33w0rd"
}
```