### PR TITLE
fix: added nvidia_ceph default values to the gpu role

### DIFF
--- a/images/capi/ansible/roles/gpu/README.md
+++ b/images/capi/ansible/roles/gpu/README.md
@@ -19,7 +19,7 @@ _This role currently doesn't support installing the publicly available drivers._
 An example of the fields you need are defined below. Make sure to review and change any fields where required.
 If the gridd configuration or licensing .tok file are not required then you can omit the `gridd_feature_type`
 and `nvidia_tok_location` respectively.
-If you're using CEPH S3 add `nvidia_ceph=true` in the `ansible_user_vars` field.
+If you're using CEPH S3 add `gpu_nvidia_ceph=true` in the `ansible_user_vars` field.
 
 ```json
 {

--- a/images/capi/ansible/roles/gpu/README.md
+++ b/images/capi/ansible/roles/gpu/README.md
@@ -8,7 +8,7 @@ is installed after the kernel has been installed. To get around this, we install
 # NVIDIA vGPU
 
 To install the NVIDIA vGPU driver as part of the image build process, you must have a `.run` file and `.tok` file from
-NVIDIA ready and available from an S3 endpoint.
+NVIDIA ready and available from an S3 endpoint. 
 Once done you need to reference those files in your packer file.
 
 _This is because NVIDIA place the vGPU drivers behind a licensing wall which means you can't just use the standard
@@ -19,6 +19,7 @@ _This role currently doesn't support installing the publicly available drivers._
 An example of the fields you need are defined below. Make sure to review and change any fields where required.
 If the gridd configuration or licensing .tok file are not required then you can omit the `gridd_feature_type`
 and `nvidia_tok_location` respectively.
+If you're using CEPH S3 add `nvidia_ceph=true` in the `ansible_user_vars` field.
 
 ```json
 {

--- a/images/capi/ansible/roles/gpu/defaults/main.yml
+++ b/images/capi/ansible/roles/gpu/defaults/main.yml
@@ -17,3 +17,4 @@ gpu_amd_usecase: dkms
 gpu_block_nouveau_loading: false
 gpu_systemd_networkd_update_initramfs: >-
   {%- if ansible_os_family == 'VMware Photon OS' -%} dracut -f{%- elif ansible_os_family == 'Debian' -%} update-initramfs -u{%- endif -%}
+nvidia_ceph: false

--- a/images/capi/ansible/roles/gpu/defaults/main.yml
+++ b/images/capi/ansible/roles/gpu/defaults/main.yml
@@ -17,4 +17,4 @@ gpu_amd_usecase: dkms
 gpu_block_nouveau_loading: false
 gpu_systemd_networkd_update_initramfs: >-
   {%- if ansible_os_family == 'VMware Photon OS' -%} dracut -f{%- elif ansible_os_family == 'Debian' -%} update-initramfs -u{%- endif -%}
-nvidia_ceph: false
+gpu_nvidia_ceph: false

--- a/images/capi/ansible/roles/gpu/tasks/nvidia.yml
+++ b/images/capi/ansible/roles/gpu/tasks/nvidia.yml
@@ -58,7 +58,7 @@
     object: "{{ nvidia_tok_location }}"
     dest: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
     mode: get
-    ceph: "{{ nvidia_ceph }}"
+    ceph: "{{ gpu_nvidia_ceph }}"
   retries: 5
   delay: 3
   when: nvidia_tok_location is defined
@@ -89,7 +89,7 @@
     object: "{{ nvidia_installer_location }}"
     dest: /tmp/NVIDIA-Linux.run
     mode: get
-    ceph: "{{ nvidia_ceph }}"
+    ceph: "{{ gpu_nvidia_ceph }}"
   retries: 5
   delay: 3
 


### PR DESCRIPTION
## Change description
Set nvidia_ceph to false as default value for GPU task.  



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1666 
