### PR TITLE
feat(ansible): add management for multipath.conf file

### DIFF
--- a/images/capi/ansible/roles/multipathd/README.md
+++ b/images/capi/ansible/roles/multipathd/README.md
@@ -1,0 +1,24 @@
+# Multipath Configuration
+
+This role is designed to configure the Multipath service on the system, ensuring that the configuration file (`/etc/multipath.conf`) is properly managed.
+
+## Usage
+
+The environment variable `PACKER_FLAGS` is used to set a Packer variable named `ansible_extra_vars`. In Ansible, the variable `custom_role_names` must be set to the role name, which in this case is `multipathd`. 
+
+Additionally, another variable, `multipathd_custom_conf_file_path`, must be defined. This variable specifies the path to the configuration file that you want to include in the image.
+
+At first glance, this setup might seem a bit complex, but it can be summarized as follows:
+
+```bash
+export PACKER_FLAGS="--var 'ansible_extra_vars=custom_role_names=multipathd multipathd_custom_conf_file_path=path/to/multipath.conf'"
+```
+
+## Behavior
+If you only set the Ansible variable `custom_role_names=multipathd`, a default configuration file will be copied (which contains minimal configuration) with the following content:
+
+```
+defaults {
+    user_friendly_names yes
+}
+```

--- a/images/capi/ansible/roles/multipathd/defaults/main.yml
+++ b/images/capi/ansible/roles/multipathd/defaults/main.yml
@@ -1,0 +1,16 @@
+# Copyright 2025 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The path to the custom multipath.conf file
+multipathd_custom_conf_file_path: ""

--- a/images/capi/ansible/roles/multipathd/files/multipath.conf
+++ b/images/capi/ansible/roles/multipathd/files/multipath.conf
@@ -1,0 +1,18 @@
+# Copyright 2025 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default value. This file was created because you did not set the variable 'multipathd_custom_conf_file_path'.
+defaults {
+    user_friendly_names yes
+}

--- a/images/capi/ansible/roles/multipathd/tasks/main.yml
+++ b/images/capi/ansible/roles/multipathd/tasks/main.yml
@@ -1,0 +1,19 @@
+# Copyright 2025 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Copy Custom multipath.conf File
+  ansible.builtin.copy:
+    src: "{{ multipathd_custom_conf_file_path if multipathd_custom_conf_file_path | length > 0 else 'files/multipath.conf' }}"
+    dest: /etc/multipath.conf
+    mode: "0644"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
    Add custom multipath.conf management to Ansible roles
    
    - Introduced a new role for managing multipathd:
      - Added `defaults/main.yml` with a variable `custom_multipath_conf_path` to allow customization of the multipath.conf file path.
      - Included a default `multipath.conf` file in `files/multipath.conf` with basic configuration.
      - Created a task in `tasks/main.yml` to copy the custom or default multipath.conf file to `/etc/multipath.conf`.



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1676



## Additional context
The flag can be enabled using:
```
PACKER_FLAGS="--var 'ansible_extra_vars=custom_role_names=multipathd custom_multipath_conf_path=/home/vasartori/multipath.conf'"

```

<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
