### PR TITLE
Set proxmox oem-id for flatcar

### DIFF
--- a/docs/book/src/capi/providers/proxmox.md
+++ b/docs/book/src/capi/providers/proxmox.md
@@ -73,6 +73,16 @@ Then the user (not token) must be given the following permissions on the path `/
 
 *We suggest creating a new role, since no built-in PVE roles covers just these.*
 
+Note that you might have to change disk format from `qcow2` to `raw` in `images/capi/packer/proxmox/packer.json.tmpl` if the storage for the VM disk is block only.
+
+### Building images for Flatcar
+
+The default metadata source for Flatcar is set to `proxmoxve` (userdata via config drive). If you need to set a [different OEM](https://coreos.github.io/ignition/supported-platforms/) you need to overwrite packer flag `oem_id`, e.g. 
+
+```bash
+export PACKER_FLAGS="--var 'oem_id=qemu'"
+make build-proxmox-flatcar
+```
 
 ### Example
 
@@ -88,7 +98,7 @@ export PROXMOX_BRIDGE="vmbr0"
 export PROXMOX_STORAGE_POOL="local-lvm"
 ```
 
-Build ubuntu 2204 template:
+- Build ubuntu 2204 template:
 
 ```bash
 make build-proxmox-ubuntu-2204

--- a/images/capi/packer/proxmox/README.md
+++ b/images/capi/packer/proxmox/README.md
@@ -17,7 +17,7 @@ export ISO_FILE="local:iso/ubuntu-24.04.1-live-server-amd64.iso"
 
 ## Flatcar for Proxmox
 
-Proxmox support is available on Flatcar from version 4152.
+Proxmox support is available on Flatcar from version `4152`.
 * https://www.flatcar.org/releases#alpha-release
 * https://github.com/coreos/fedora-coreos-tracker/issues/1652
 
@@ -33,10 +33,3 @@ export PROXMOX_NODE="pve1"
 export PROXMOX_ISO_POOL="local"
 export PROXMOX_BRIDGE="vmbr1"
 export PROXMOX_STORAGE_POOL="ceph_pool"
-
-## flatcar version
-export FLATCAR_VERSION=4152.1.0
-export FLATCAR_CHANNEL=beta
-
-export OEM_ID=proxmoxve # make sure to choose OEM_ID=proxmoxve
-```

--- a/images/capi/packer/proxmox/flatcar.json
+++ b/images/capi/packer/proxmox/flatcar.json
@@ -16,7 +16,7 @@
   "iso_url": "https://{{env `FLATCAR_CHANNEL`}}.release.flatcar-linux.net/amd64-usr/{{env `FLATCAR_VERSION`}}/flatcar_production_iso_image.iso",
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
-  "oem_id": "{{env `OEM_ID`}}",
+  "oem_id": "proxmoxve",
   "os_display_name": "Flatcar Container Linux ({{env `FLATCAR_CHANNEL`}} channel release {{env `FLATCAR_VERSION`}})",
   "python_path": "/opt/bin/builder-env/site-packages",
   "release_version": "{{env `FLATCAR_VERSION`}}",

--- a/images/capi/packer/proxmox/packer.json.tmpl
+++ b/images/capi/packer/proxmox/packer.json.tmpl
@@ -207,6 +207,7 @@
     "memory": "2048",
     "mtu": "{{env `PROXMOX_MTU`}}",
     "node": "{{env `PROXMOX_NODE`}}",
+    "oem_id": {{ user `oem_id` }},
     "proxmox_url": "{{env `PROXMOX_URL`}}",
     "sockets": "2",
     "ssh_password": "$SSH_PASSWORD",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

At the moment, `export OEM_ID=proxmoxve` is required for flatcar to look for metadata in the right place. Otherwise it is set to `qemu` by default and ignition cannot find metadata. The documentation for this is buried in [packer/proxmox](https://github.com/kubernetes-sigs/image-builder/blob/826a2d7e05288b72870ae45797e9d64efc101d07/images/capi/packer/proxmox/README.md#flatcar-for-proxmox).

Unless there is a good reason for this, it would be simpler to have it set statically for `flatcar-proxmox` overall.

Tested without `export OEM_ID=proxmoxve` and it works.

---

✅ This is not a breaking change if:

- You use `export OEM_ID=proxmoxve` in your workflows. In this case you can remove it.

⚠️ This is a breaking change if:

- You don't use `export OEM_ID=proxmoxve` in your workflows, meaning you use `qemu` oem (default before this PR). In this case, set `export PACKER_FLAGS="--var 'oem_id=qemu'"`
- You use `export OEM_ID=<oem>` in your workflows where `<oem>` is anything else than `proxmoxve`. In this case, set `export PACKER_FLAGS="--var 'oem_id=<oem>'"` and remove `export OEM_ID=<oem>`.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
