### PR TITLE
fix: Error building Rocky Linux 9 Image (QEMU)

### DIFF
--- a/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg.tmpl
+++ b/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg.tmpl
@@ -1,5 +1,6 @@
 # Use CDROM installation media
 repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/"
+repo --name="kickstart" --baseurl="http://download.rockylinux.org/pub/rocky/9/devel/x86_64/kickstart/"
 cdrom
 
 # Use text install
@@ -46,6 +47,7 @@ open-vm-tools
 sudo
 sed
 python3
+cloud-utils
 
 # unnecessary firmware
 -aic94xx-firmware


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Fixes the build of Rocky Linux 9

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1651 



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
