### PR TITLE
kubeReserved bugfix for instances >130GiB memory

### DIFF
--- a/images/capi/ansible/roles/kubernetes/files/usr/libexec/kubernetes/kubelet-resource-sizing.sh
+++ b/images/capi/ansible/roles/kubernetes/files/usr/libexec/kubernetes/kubelet-resource-sizing.sh
@@ -72,6 +72,7 @@ memory_reservation_mebibytes() {
   fi
 
   # Reserve 2% of any remaining memory
+  memory_reserved_mebibytes=$((memory_reserved_mebibytes + 7004))
   memory_remaining_mebibytes=$((memory_remaining_mebibytes - 116736))
   segment_memory_reservation_mebibytes=$(echo $memory_remaining_mebibytes | awk '{result = $1 * 0.02; if (result != int(result)) result++; printf "%d\n", result}')
   memory_reserved_mebibytes=$((memory_reserved_mebibytes + segment_memory_reservation_mebibytes))


### PR DESCRIPTION
## Change description

The function memory_reservation_mebibytes would return 9GiB reserved memory for a 129GiB instance, and only 2.6GiB reserved at 130GiB due to a missing line of code.

## Additional context

Plot of reserved memory values before and after this proposed change:
![reservedmemory](https://github.com/user-attachments/assets/03fcd072-9022-4370-9245-cc0ccc049b2c)
