### PR TITLE
Add 3 regions for replication to Azure pipeline

### DIFF
--- a/images/capi/packer/azure/.pipelines/promote-sig.yaml
+++ b/images/capi/packer/azure/.pipelines/promote-sig.yaml
@@ -74,7 +74,7 @@ jobs:
         GALLERY_DESCRIPTION=${GALLERY_DESCRIPTION:-"Shared image gallery for Cluster API Provider Azure"}
         GALLERY_NAME=${GALLERY_NAME:-community_gallery}
         PUBLIC_NAME_PREFIX=${PUBLIC_NAME_PREFIX:-ClusterAPI}
-        REPLICATED_REGIONS="${REPLICATED_REGIONS:-${MANAGED_IMAGE_LOCATION} australiaeast canadacentral francecentral germanywestcentral northeurope switzerlandnorth uksouth westeurope}"
+        REPLICATED_REGIONS="${REPLICATED_REGIONS:-${MANAGED_IMAGE_LOCATION} australiaeast canadacentral eastus eastus2 eastus2euap francecentral germanywestcentral northeurope switzerlandnorth uksouth westeurope}"
         RESOURCE_GROUP="${RESOURCE_GROUP:-cluster-api-gallery}"
         SIG_OFFER="${SIG_OFFER:-reference-images}"
 


### PR DESCRIPTION
## Change description

Adds `eastus`, `eastus2`, and `eastus2euap` regions to the default replication set in the Azure pipeline script. Several users have requested image availability there.

## Related issues

- Fixes kubernetes-sigs/cluster-api-provider-azure#5467
