### PR TITLE
Update hcloud-config.json, remove containerd_wasm_shims_runtimes

### DIFF
--- a/images/capi/packer/hcloud/hcloud-config.json
+++ b/images/capi/packer/hcloud/hcloud-config.json
@@ -1,5 +1,4 @@
 {
-  "containerd_wasm_shims_runtimes": "spin,slight",
   "hcloud_location": "{{env `HCLOUD_LOCATION`}}",
   "image_name": "cluster-api-{{user `build_name`}}-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
   "server_type": "cx22",


### PR DESCRIPTION
The goss tests for the wasm runtimes failed. See #1701

## Change description
<!-- What this PR does / why we need it. -->



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1702

