### PR TITLE
Adding RockyLinux to openstack

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -380,7 +380,7 @@ OCI_BUILD_NAMES				?= oci-ubuntu-2004 oci-ubuntu-2204 oci-oracle-linux-8 oci-ora
 
 DO_BUILD_NAMES 				?=	do-centos-7 do-ubuntu-2004 do-ubuntu-2204 do-ubuntu-2404
 
-OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-flatcar
+OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2004 openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-flatcar openstack-rockylinux-9
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2004 osc-ubuntu-2204
 
@@ -825,6 +825,7 @@ build-node-ova-local-base-ubuntu-2004: ## Builds Ubuntu 20.04 Base Node OVA w lo
 build-openstack-ubuntu-2004: ## Builds Ubuntu 20.04 OpenStack image
 build-openstack-ubuntu-2204: ## Builds Ubuntu 22.04 OpenStack image
 build-openstack-ubuntu-2404: ## Builds Ubuntu 24.04 OpenStack image
+build-openstack-rockylinux-9: ## Builds RockyLinux 9 OpenStack image
 build-openstack-flatcar: ## Builds Flatcar OpenStack image
 build-openstack-all: $(OPENSTACK_BUILD_TARGETS)
 
@@ -962,6 +963,7 @@ validate-do-all: $(DO_VALIDATE_TARGETS) ## Validates all DigitalOcean Snapshot P
 validate-openstack-ubuntu-2004: ## Validates Ubuntu 20.04 Openstack Image Packer config
 validate-openstack-ubuntu-2204: ## Validates Ubuntu 22.04 Openstack Image Packer config
 validate-openstack-ubuntu-2404: ## Validates Ubuntu 22.04 Openstack Image Packer config
+validate-openstack-rocky-9: ## Validates Rocky 9 Openstack Image Packer config
 validate-openstack-flatcar: ## Validates Flatcar Openstack Image Packer config
 validate-openstack-all: $(OPENSTACK_VALIDATE_TARGETS) ## Validates all Openstack Glance Image Packer config
 

--- a/images/capi/ansible/roles/security/tasks/falco.yml
+++ b/images/capi/ansible/roles/security/tasks/falco.yml
@@ -14,44 +14,70 @@
 
 ---
 
-- name: Add Falco package signing key
-  ansible.builtin.apt_key:
-    url: https://falco.org/repo/falcosecurity-packages.asc
-    state: present
+- name: Install Falco on Debian based systems
   when: ansible_os_family == "Debian"
+  block:
+    - name: Add Falco package signing key
+      ansible.builtin.apt_key:
+        url: https://falco.org/repo/falcosecurity-packages.asc
+        state: present
 
-- name: Add Falco apt repo
-  ansible.builtin.apt_repository:
-    repo: deb https://download.falco.org/packages/deb stable main
-    state: present
-    filename: falcosecurity
-  when: ansible_os_family == "Debian"
+    - name: Add Falco apt repo
+      ansible.builtin.apt_repository:
+        repo: deb https://download.falco.org/packages/deb stable main
+        state: present
+        filename: falcosecurity
 
-- name: Install Falco requirements
-  ansible.builtin.apt:
-    pkg:
-      - dkms
-      - make
-      - "linux-headers-{{ ansible_kernel }}"
-      - clang
-      - llvm
-    update_cache: true
-    state: present
-  ignore_errors: true
-  register: pkg_result
-  until: pkg_result is success
-  when: ansible_os_family == "Debian"
+    - name: Install Falco requirements
+      ansible.builtin.apt:
+        pkg:
+          - dkms
+          - make
+          - "linux-headers-{{ ansible_kernel }}"
+          - clang
+          - llvm
+        update_cache: true
+        state: present
+      ignore_errors: true
+      register: pkg_result
+      until: pkg_result is success
+
+- name: Install Falco on RedHat based systems
+  when: ansible_os_family == "RedHat"
+  block:
+    - name: Add Falco YUM repo
+      ansible.builtin.yum_repository:
+        name: Falco repository
+        description: Falco YUM repo
+        file: falcosecurity
+        baseurl: https://falco.org/repo/falcosecurity-rpm.repo
+        gpgcheck: true
+        enabled: true
+        gpgkey: https://falco.org/repo/falcosecurity-packages.asc
+
+    - name: Install Falco requirements
+      ansible.builtin.dnf:
+        pkg:
+          - dkms
+          - make
+          - "kernel-devel-{{ ansible_kernel }}"
+          - clang
+          - llvm
+          - dialog
+        state: present
+      ignore_errors: true
+      register: pkg_result
+      until: pkg_result is success
 
 - name: Install Falco
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name: falco
-    update_cache: true
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
 
 - name: Enable Falco Modern eBPF
   ansible.builtin.service:
     name: falco-modern-bpf
     state: started
     enabled: true
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"

--- a/images/capi/ansible/roles/security/tasks/trivy.yml
+++ b/images/capi/ansible/roles/security/tasks/trivy.yml
@@ -14,27 +14,42 @@
 
 ---
 
-- name: Add Trivy package signing key
-  ansible.builtin.apt_key:
-    url: https://aquasecurity.github.io/trivy-repo/deb/public.key
-    state: present
+- name: Install Trivy on Debian based systems
   when: ansible_os_family == "Debian"
+  block:
+    - name: Add Trivy package signing key
+      ansible.builtin.apt_key:
+        url: https://aquasecurity.github.io/trivy-repo/deb/public.key
+        state: present
 
-- name: Add Trivy apt repo
-  ansible.builtin.apt_repository:
-    repo: "deb https://aquasecurity.github.io/trivy-repo/deb {{ansible_distribution_release}} main"
-    state: present
-    filename: trivy
-  when: ansible_os_family == "Debian"
+    - name: Add Trivy apt repo
+      ansible.builtin.apt_repository:
+        repo: "deb https://aquasecurity.github.io/trivy-repo/deb {{ansible_distribution_release}} main"
+        state: present
+        filename: trivy
+
+- name: Install Trivy on RedHat based systems
+  when: ansible_os_family == "RedHat"
+  block:
+    - name: Add Trivy rpm repo
+      ansible.builtin.yum_repository:
+        name: Trivy repository
+        description: Trivy YUM repo
+        file: trivy
+        baseurl: https://aquasecurity.github.io/trivy-repo/rpm/releases/{{ ansible_distribution_release }}/{{ ansible_architecture }}/
+        gpgcheck: true
+        enabled: true
+        gpgkey: https://aquasecurity.github.io/trivy-repo/rpm/public.keyy
 
 - name: Install Trivy
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name: trivy
     update_cache: true
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
 
 - name: Update Trivy DB to ensure latest records are available as of now
   ansible.builtin.command: trivy rootfs --download-db-only
   args:
     creates: ~/.cache/trivy/db/trivy.db
+  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -331,6 +331,14 @@ rockylinux:
     - distro_version: "8"
       package:
         <<: *rh8_rpms
+  openstack:
+    package:
+      cloud-init:
+      cloud-utils-growpart:
+    os_version:
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
 rhel:
   common-package: *common_rpms
   amazon:
@@ -546,6 +554,18 @@ ubuntu:
       linux-tools-generic:
   huaweicloud:
     package: {}
+  openstack:
+    service:
+      networkd-dispatcher:
+        enabled: true
+        running: true
+    package:
+      linux-cloud-tools-virtual:
+      linux-tools-virtual:
+      open-vm-tools:
+      cloud-guest-utils:
+      cloud-initramfs-copymods:
+      cloud-initramfs-dyn-netconf:
 
 oracle linux:
   common-kernel-param:

--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -92,7 +92,7 @@
         "ARCH": "amd64",
         "OS": "{{user `distro_name` | lower}}",
         "OS_VERSION": "{{user `os_version`}}",
-        "PROVIDER": "qemu",
+        "PROVIDER": "openstack",
         "containerd_version": "{{user `containerd_version`}}",
         "kubernetes_cni_deb_version": "{{ user `kubernetes_cni_deb_version` }}",
         "kubernetes_cni_rpm_version": "{{ split (user `kubernetes_cni_rpm_version`) \"-\" 0 }}",

--- a/images/capi/packer/openstack/rockylinux-9.json
+++ b/images/capi/packer/openstack/rockylinux-9.json
@@ -1,0 +1,8 @@
+{
+  "build_name": "rockylinux-9",
+  "distro_name": "rockylinux",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "os_version": "9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "ssh_username": "rocky"
+}


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
This change introduces a RockyLinux target for the OpenStack builder - finally 😆

To do this I've also added an OpenStack goss var for RockyLinux & Ubuntu builds for OpenStack to prevent it failing when looking for `cloud-utils` in RockyLinux (it was just set to qemu all this time, evidently was fine for Ubuntu ¯\\\_(ツ)\_/¯ ).
The `security` role has been adjusted too so that Debian or Redhat based tasks are performed together within a `block`.
