### PR TITLE
Update Packer VM hardware version for RHEL 9 OVA builds

### DIFF
--- a/images/capi/hack/image-build-ova.py
+++ b/images/capi/hack/image-build-ova.py
@@ -112,6 +112,7 @@ def main():
                  "centos8-64": {"id": "107", "version": "8", "type": "centos8_64Guest"},
                  "rhel7-64": {"id": "80", "version": "7", "type": "rhel7_64Guest"},
                  "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64Guest"},
+                 "rhel9-64": {"id": "80", "version": "9", "type": "rhel9_64Guest"},
                  "rockylinux-64": {"id": "80", "version": "", "type": "rockylinux_64Guest"},
                  "ubuntu-64": {"id": "94", "version": "", "type": "ubuntu64Guest"},
                  "flatcar-64": {"id": "100", "version": "", "type": "other4xLinux64Guest"},

--- a/images/capi/packer/ova/rhel-9.json
+++ b/images/capi/packer/ova/rhel-9.json
@@ -16,5 +16,6 @@
   "os_display_name": "RHEL 9",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "shutdown -P now",
+  "vmx_version": "18",
   "vsphere_guest_os_type": "rhel9_64Guest"
 }


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->

This PR overrides the VM hardware version to 18 for RHEL 9 OVA builds, and adds RHEL 9 to the OS ID mapping in the OVA build script. The RHEL 9 Guest OS type was introduced in vSphere API release 7.0.1.0 ([source](https://developer.broadcom.com/xapis/vsphere-web-services-api/8.0u3/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)), which is compatible with virtual machine hardware version 18 ([source](https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html)). But image-builder [hardcodes the VM hardware version](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/ova/packer-common.json.tmpl#L32) to 15, so we need to override it to 18 for RHEL 9 OVA builds.

Fixes the following error in RHEL 9 OVA builds:
<img width="876" alt="Screenshot 2025-04-02 at 2 24 29 PM" src="https://github.com/user-attachments/assets/b3d637bf-ef39-4fd7-9c87-3781778e2549" />
