### PR TITLE
Update VMware tools to latest 12.5.1 for VMware OVA configuration

### DIFF
--- a/images/capi/packer/ova/windows-2019-efi.json
+++ b/images/capi/packer/ova/windows-2019-efi.json
@@ -13,8 +13,8 @@
   "os_display_name": "Windows Server 2019",
   "os_iso_path": "[datastore] ISO/en_windows_server_2019_x64_dvd_4cb967d8.iso",
   "os_iso_url": "file:/path/en_windows_server_2019_x64_dvd_4cb967d8.iso",
-  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-11.1.5.iso",
-  "vmtools_iso_url": "file:/path/VMware-tools-windows-11.1.5-16724464.iso",
+  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-12.5.1.iso",
+  "vmtools_iso_url": "file:/path/VMware-tools-windows-12.5.1-24649672.iso",
   "vmx_version": "18",
   "vsphere_guest_os_type": "windows2019srv_64Guest"
 }

--- a/images/capi/packer/ova/windows-2019.json
+++ b/images/capi/packer/ova/windows-2019.json
@@ -10,8 +10,8 @@
   "os_display_name": "Windows Server 2019",
   "os_iso_path": "[datastore] ISO/en_windows_server_2019_x64_dvd_4cb967d8.iso",
   "os_iso_url": "file:/path/en_windows_server_2019_x64_dvd_4cb967d8.iso",
-  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-11.1.5.iso",
-  "vmtools_iso_url": "file:/path/VMware-tools-windows-11.1.5-16724464.iso",
+  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-12.5.1.iso",
+  "vmtools_iso_url": "file:/path/VMware-tools-windows-12.5.1-24649672.iso",
   "vmx_version": "18",
   "vsphere_guest_os_type": "windows2019srv_64Guest"
 }

--- a/images/capi/packer/ova/windows-2022-efi.json
+++ b/images/capi/packer/ova/windows-2022-efi.json
@@ -13,8 +13,8 @@
   "os_display_name": "Windows Server 2022",
   "os_iso_path": "[datastore] ISO/en-us_windows_server_2022_x64_dvd_620d7eac.iso",
   "os_iso_url": "file:/path/en-us_windows_server_2022_x64_dvd_620d7eac.iso",
-  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-11.1.5.iso",
-  "vmtools_iso_url": "file:/path/VMware-tools-windows-11.1.5-16724464.iso",
+  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-12.5.1.iso",
+  "vmtools_iso_url": "file:/path/VMware-tools-windows-12.5.1-24649672.iso",
   "vmx_version": "18",
   "vsphere_guest_os_type": "windows2019srvNext_64Guest"
 }

--- a/images/capi/packer/ova/windows-2022.json
+++ b/images/capi/packer/ova/windows-2022.json
@@ -10,8 +10,8 @@
   "os_display_name": "Windows Server 2022",
   "os_iso_path": "[datastore] ISO/en-us_windows_server_2022_x64_dvd_620d7eac.iso",
   "os_iso_url": "file:/path/en-us_windows_server_2022_x64_dvd_620d7eac.iso",
-  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-11.1.5.iso",
-  "vmtools_iso_url": "file:/path/VMware-tools-windows-11.1.5-16724464.iso",
+  "vmtools_iso_path": "[datastore] ISO/vmtools/windows-12.5.1.iso",
+  "vmtools_iso_url": "file:/path/VMware-tools-windows-12.5.1-24649672.iso",
   "vmx_version": "18",
   "vsphere_guest_os_type": "windows2019srvNext_64Guest"
 }

--- a/images/capi/packer/ova/windows/windows-2019-efi/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019-efi/autounattend.xml
@@ -132,7 +132,7 @@ Installation Notes:
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>e:\setup.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
                     <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>

--- a/images/capi/packer/ova/windows/windows-2019/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019/autounattend.xml
@@ -124,7 +124,7 @@ Installation Notes:
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>e:\setup.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
                     <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>

--- a/images/capi/packer/ova/windows/windows-2022-efi/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022-efi/autounattend.xml
@@ -132,7 +132,7 @@ Installation Notes:
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>e:\setup.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
                     <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>

--- a/images/capi/packer/ova/windows/windows-2022/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022/autounattend.xml
@@ -124,7 +124,7 @@ Installation Notes:
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <WillReboot>Always</WillReboot>
-                    <Path>e:\setup64.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
+                    <Path>e:\setup.exe /s /v "/qb REBOOT=R ADDLOCAL=ALL"</Path>
                     <Order>2</Order>
                 </RunSynchronousCommand>
             </RunSynchronous>


### PR DESCRIPTION
## Change description
setup64.exe is renamed to setup.exe after 32 bit installer is removed according to
https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/tools/12-5-0/release-notes/vmware-tools-1251-release-notes.html
This PR makes sure the auto-unattended files reflect the latest changes.

## Related issues
- Fixes #



## Additional context
