### PR TITLE
Fix Flatcar ansible_python_interpreter

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
@@ -10,12 +10,6 @@
   tags:
     - facts
 
-- name: Set the ansible_python_interpreter fact
-  ansible.builtin.set_fact:
-    ansible_python_interpreter: "{{ external_binary_path }}/python"
-  tags:
-    - facts
-
 # Some tasks are not compatible with Flatcar, so to centralize and deduplicate the logic of checking
 # if we run on Flatcar, we define it here.
 #


### PR DESCRIPTION
## Change description
Drop the old workaround, which overwrites Python path to OS python, while Ansible depends on Python 3.6, installed by as pypy in python role. The proper path is defined in Packer variables, as `/opt/pypy/bin/pypy`

## Related issues
- Fixes #1709 

## Additional context

_Copied from issue_

Flatcar build fails for hcloud _(maybe for others)_ with
> ... SyntaxError: future feature annotations is not defined ... "The following modules failed to execute: ansible.legacy.setup

This happens because ansible uses OS Python (3.9), instead of PyPy (3.6) provisioned by the python role.
The "Set the ansible_python_interpreter fact" overwrites proper `/opt/pypy/bin/pypy` path with `{{ external_binary_path }}/python`

The removed step forces Ansible to use system Python, by overwriting the `ansible_python_interpreter` fact, and causing the error.

Alternatively to deletion, we can hardcode a new `/opt/pypy/bin/pypy` path.

