### PR TITLE
Add LimitNOFILE configuration for Flatcar OS

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -137,7 +137,7 @@
     dest: /etc/systemd/system/containerd.service.d/limit-nofile.conf
     src: etc/systemd/system/containerd.service.d/limit-nofile.conf
     mode: "0644"
-  when: ansible_os_family in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_os_family in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux"]
 
 - name: Create containerd http proxy conf file if needed
   ansible.builtin.template:


### PR DESCRIPTION
When running containerd on Flatcar OS without proper file descriptor limits, 
services like Squid proxy or MySQL exhibit extremely long startup times. 

This occurs because containerd's default LimitNOFILE is set to infinity, which can lead to 
resource management issues and negatively impact application startup performance.

While this change is expected at some point in a future Flatcar release, 
the timeline for when that will happen remains unclear. 

This PR provides the necessary fix in the meantime to ensure consistent behaviour across our supported platforms.