### PR TITLE
Remove cdrom from vsphere-iso after build

### DIFF
--- a/images/capi/packer/ova/packer-node.json
+++ b/images/capi/packer/ova/packer-node.json
@@ -188,7 +188,9 @@
       "username": "{{user `username`}}",
       "vcenter_server": "{{user `vcenter_server`}}",
       "vm_name": "{{user `base_build_version`}}",
-      "vm_version": "{{user `vmx_version`}}"
+      "vm_version": "{{user `vmx_version`}}",
+      "remove_cdrom": "true",
+      "remote_cache_cleanup": "true"
     },
     {
       "CPUs": "{{user `cpu`}}",
@@ -254,7 +256,9 @@
       "username": "{{user `username`}}",
       "vcenter_server": "{{user `vcenter_server`}}",
       "vm_name": "{{user `build_version`}}",
-      "vm_version": "{{user `vmx_version`}}"
+      "vm_version": "{{user `vmx_version`}}",
+      "remove_cdrom": "true",
+      "remote_cache_cleanup": "true"
     },
     {
       "CPUs": "{{user `cpu`}}",


### PR DESCRIPTION
## Change description
remove cdrom from vsphere-iso VM after build
remove packerXXXXXX.iso from packer_cache on the vSphere storage

## Additional context
tested with image-builder v0.1.42 on vSphere 6.7/7.x/8.x