### PR TITLE
extend vmware-tools/tools.conf

### DIFF
--- a/images/capi/ansible/roles/providers/files/etc/vmware-tools/tools.conf
+++ b/images/capi/ansible/roles/providers/files/etc/vmware-tools/tools.conf
@@ -1,3 +1,22 @@
+[logging]
+## Disables core dumps on fatal errors; they're enabled by default.
+enableCoreDump = false
+## Setup file rotation - keep 3 files
+vmsvc.maxOldLogFiles = 3
+## Max log file size kept: 1 MB
+vmsvc.maxLogSize = 1
+
 [guestinfo]
 exclude-nics=antrea-*,cali*,cilium*,lxc*,ovs-system,br*,flannel*,veth*,vxlan_sys_*,genev_sys_*,gre_sys_*,stt_sys_*,????????-??????
+## This configuration ensures that any address in the interfaces matching en* is sorted on top of the list of IP addresses.
+primary-nics=en*
+
+## The configuration will exclude all interfaces with the names matching the patterns specified from GuestInfo.
+exclude-nics=antrea-*,br*,cali*,cbr*,cilium*,cni*,docker*,dummy*,flannel*,genev_sys_*,gre_sys_*,kube-ipvs*,lo,lxc*,nodelocaldns*,ovs-system,stt_sys_*,tunl*,veth*,virbr*,vxlan_sys_*,wg*,????????-??????
+
+## https://github.com/vmware/open-vm-tools/commit/065f09b94e09f1127901db29e73cc9b9f36df4fc
+# max-ipv4-routes: Max IPv4 routes to gather. Set 0 to disable gathering.
+# max-ipv6-routes: Max IPv6 routes to gather. Set 0 to disable gathering.
+max-ipv4-routes=0
+max-ipv6-routes=0
 


### PR DESCRIPTION
## Change description
- disable CoreDump
- set maxOldLogFiles
- set maxLogSize
- add primary-nics filter
- extend exclude-nics man (7) systemd.net-naming-scheme
- set max-ipv4-routes, max-ipv6-routes

## Additional context
tested with open-vm-tools 12.3.5
check before and after with
```sh
govc vm.info -r -json <vmName> | jq '(.virtualMachines[].guest.ipStack[].ipRouteConfig)'
```
