### PR TITLE
fix(ansible/sysprep/tasks/debian) : step name typo

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -115,7 +115,7 @@
     - Update debian grub
   when: _stat_update_grub.stat.exists
 
-- name: Remvoing subiquity disable disable cloud-init networking config
+- name: Removing subiquity disable cloud-init networking config
   ansible.builtin.file:
     path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
     state: absent


### PR DESCRIPTION
Noticed this typo in the output while trying to build an ARM64 based image for CAPZ.