### PR TITLE
Populate the AMIs 'Name' tag with the build name

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -47,6 +47,7 @@
       "ssh_username": "{{user `ssh_username`}}",
       "subnet_id": "{{ user `subnet_id` }}",
       "tags": {
+        "Name": "{{user `build_name`}}",
         "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",
         "containerd_version": "{{user `containerd_version`}}",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Currently the AMIs are built without a `Name` tag defined, only the `AMI Name` property. This change include the `Name` tag (note the capital N is correct so that it shows in the Name column in the UI) so that it can be used for filtering / searching logic - such as that used by Karpenter.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

N/A



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
