### PR TITLE
install packer-plugin-vsphere

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -107,6 +107,7 @@ deps-ova: deps-common
 	hack/ensure-ansible-windows.sh
 	hack/ensure-ovftool.sh
 	$(PACKER) init packer/config.pkr.hcl
+	$(PACKER) init packer/ova/config.pkr.hcl
 
 .PHONY: deps-openstack
 deps-openstack: ## Installs/checks dependencies for OpenStack builds

--- a/images/capi/packer/ova/config.pkr.hcl
+++ b/images/capi/packer/ova/config.pkr.hcl
@@ -1,0 +1,9 @@
+packer {
+  required_version = ">= 1.7.0"
+  required_plugins {
+    vsphere = {
+      version = ">= 1.4.2"
+      source  = "github.com/hashicorp/vsphere"
+    }
+  }
+}


### PR DESCRIPTION
## Change description
install packer-plugin-vsphere

## Additional context
The vSphere plugin bundled in packer 1.9.5 lacks many features e.g. to load images from storage.
E.g iso_paths: [ "[storage] /path/to/iso"] required for air-gapped installation is not supported 
