### PR TITLE
Ansible: stop rsyslog only if installed

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -53,10 +53,14 @@
     state: absent
   when: http_proxy is defined or https_proxy is defined
 
+- name: Get installed service
+  ansible.builtin.service_facts:
+
 - name: Stop auditing
   ansible.builtin.service:
     name: rsyslog
     state: stopped
+  when: "'rsyslog' in services"
 
 - name: Remove apt package caches
   ansible.builtin.apt:


### PR DESCRIPTION
## Change description
This patch is required e.g. for ubuntu-server-minimal because there is no rsyslog installed 

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context

Snippet from modified user-data.tmpl
```yaml
autoinstall:
  version: 1
  kernel:
    package: linux-virtual
  source:
    id: ubuntu-server-minimal
```

Without this patch the build ends with status

```txt
vsphere-iso.vsphere: TASK [sysprep : Stop auditing] *************************************************
vsphere-iso.vsphere: fatal: [default]: FAILED! => {"changed": false, "msg": "Could not find the requested service rsyslog: host"}
...
Build 'vsphere-iso.vsphere' errored after xx minutes xx seconds: Error executing Ansible: Non-zero exit status: exit status 2
```

