### PR TITLE
fix: ssh handshake failed error for RAW and QEMU target

### DIFF
--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -104,6 +104,7 @@
       "type": "shell"
     },
     {
+      "pause_before": "30s",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
         "KUBEVIRT={{user `kubevirt`}}"

--- a/images/capi/packer/raw/packer.json.tmpl
+++ b/images/capi/packer/raw/packer.json.tmpl
@@ -94,6 +94,7 @@
       "type": "shell"
     },
     {
+      "pause_before": "30s",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'"
       ],


### PR DESCRIPTION
## Change description
In RAW and QEMU targets there is a shell type provisioner that reboots the VM after the first Ansible provisioner finishes, the VM reboot causes the second Ansible provisioner to fail with the error 'qemu: ssh: handshake failed: EOF'. 
This PR adds a 30 second pause before the second Ansible provisioner is executed, giving the VM a chance to complete the boot process.

## Related issues

- Fixes #1631
