### PR TITLE
Make kubelet starting as a windows service

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/defaults/main.yml
@@ -16,3 +16,4 @@ kubernetes_bins:
   - kubeadm
   - kubectl
   - kubelet
+  - kube-log-runner

--- a/images/capi/ansible/windows/roles/kubernetes/tasks/sc.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/sc.yml
@@ -18,14 +18,20 @@
 - name: Install kubelet as service
   ansible.windows.win_service:
     name: kubelet
-    start_mode: manual
+    start_mode: auto
     path: >
-      {{ kubernetes_install_path }}\kubelet.exe --windows-service
+      "{{ kubernetes_install_path }}\kube-log-runner.exe" --log-file={{ systemdrive.stdout | trim }}/var/log/kubelet/kubelet.log
+      {{kubernetes_install_path }}\kubelet.exe --windows-service
       --cert-dir={{ systemdrive.stdout | trim }}/var/lib/kubelet/pki
       --config={{ systemdrive.stdout | trim }}/var/lib/kubelet/config.yaml
       --bootstrap-kubeconfig={{ systemdrive.stdout | trim }}/etc/kubernetes/bootstrap-kubelet.conf
       --kubeconfig={{ systemdrive.stdout | trim }}/etc/kubernetes/kubelet.conf
-      --hostname-override=$(hostname) --pod-infra-container-image=`"{{ pause_image }}`"
-      --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`"
-      --resolv-conf=`"`" --log-dir={{ systemdrive.stdout | trim }}/var/log/kubelet
-      --logtostderr=false {{ additional_kubelet_args if additional_kubelet_args is defined }}
+      --pod-infra-container-image="{{ pause_image }}"
+      --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=""
+      --container-runtime-endpoint="npipe:////./pipe/containerd-containerd"
+      --resolv-conf=""
+
+- name: Create file to restart kubelet as a windows service
+  ansible.windows.win_template:
+    src: templates/RestartKubelet.ps1
+    dest: "{{ kubernetes_install_path }}\\RestartKubelet.ps1"

--- a/images/capi/ansible/windows/roles/kubernetes/templates/RestartKubelet.ps1
+++ b/images/capi/ansible/windows/roles/kubernetes/templates/RestartKubelet.ps1
@@ -1,0 +1,54 @@
+# Copyright 2025 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Need to keep sync with StartKubelet.ps1
+$FileContent = Get-Content -Path "$env:SYSTEMDRIVE/var/lib/kubelet/kubeadm-flags.env"
+$kubeAdmArgs = $FileContent.TrimStart('KUBELET_KUBEADM_ARGS=').Trim('"')
+
+$args = "--cert-dir=$env:SYSTEMDRIVE/var/lib/kubelet/pki",
+        "--config=$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml",
+        "--bootstrap-kubeconfig=$env:SYSTEMDRIVE/etc/kubernetes/bootstrap-kubelet.conf",
+        "--kubeconfig=$env:SYSTEMDRIVE/etc/kubernetes/kubelet.conf",
+        "--hostname-override=$(hostname)",
+        "--pod-infra-container-image=`"{{ pause_image }}`"",
+        "--enable-debugging-handlers",
+        "--cgroups-per-qos=false",
+        "--enforce-node-allocatable=`"`"",
+        "--resolv-conf=`"`"",
+        "--windows-service"
+
+$KubeletArgListStr = ($args -join " ") + " $kubeAdmArgs"
+$KubeletArgListStr = $KubeletArgListStr.Replace("`"", "\`"")
+# Used by sc.exe to create the service 
+$KubeletCommandLine =  "`"" + "\`"" + "$env:SYSTEMDRIVE\k\kube-log-runner.exe" + "\`" " + "--log-file=/var/log/kubelet/kubelet.log " + "$env:SYSTEMDRIVE\k\kubelet.exe " + $KubeletArgListStr + "`""
+
+# Write-Output $kubeletCommandLine
+$null = sc.exe stop kubelet
+$null = sc.exe delete kubelet
+for ($i = 0; $i -lt 10; $i++) {
+	$service = Get-Service -Name kubelet -ErrorAction SilentlyContinue
+	if ($null -eq $service) {
+		Write-Host "kubelet service deleted successfully, restarting"
+		sc.exe create kubelet binPath= $KubeletCommandLine start= auto depend= containerd
+		sc.exe start kubelet
+		return
+	}
+	else {
+		Write-Host "Waiting for service to be fully deleted... (attempt $($i + 1)/10)"
+	}
+	Start-Sleep -Seconds 3
+}
+
+
+Write-Host "kubelet service failed to restart."


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
To support features such as windows graceful shutdown, we will need to make kubelet (itself) running as a windows service. this means we will have to remove the dependency on nssm which will hijack the call SCM made to the running executable. However, the benefit of using nssm is that it can load the envs/config changes dynamically so that without updating the service itself, through the control of config files, the service will run differently. This was used in the CAPZ set up for kublet to dynamically adopt the changes passed from kubeadm. With this PR, we still use nssm to start kubelet in the beginning to apply dynamic changes made through kubeadm. but we will stop/delete the service and re-install/restart the kubelet with the same parameters through SCM, in this way, the kubelet itself will be running as windows service. that's the reason we will need to stop and delete the original service and re-install a new one because the service will be different (except the same service name of "kubelet")

Ideally, we should totally remove the dependency of nssm, maybe this is still the future direction, but I have tried quite a few times and had difficulties to make kubelet (started from SC) fit well with the cloud-init and join the CAPZ cluster. I believe it is achievable, but it probably will make things trickier so maybe this could be a future direction that we can target with.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
