### PR TITLE
Allow overriding buildkit syntax

### DIFF
--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.14
-
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -208,6 +208,7 @@ CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
 ARCH ?= amd64
 BASE_IMAGE ?= docker.io/library/ubuntu:jammy
+BUILDKIT_SYNTAX ?= docker/dockerfile:1.14
 
 ## --------------------------------------
 ## Packer flags
@@ -1158,12 +1159,12 @@ clean-packer-cache:
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
 	# We must pre-pull images https://github.com/moby/buildkit/issues/1271
-	docker pull docker/dockerfile:1.14
+	docker pull $(BUILDKIT_SYNTAX)
 	docker pull $(BASE_IMAGE)
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the Docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_SYNTAX=$(BUILDKIT_SYNTAX) --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the Docker image


### PR DESCRIPTION
## Change description
This PR allows overriding the buildkit syntax file. Defaults to `docker/dockerfile:1.14` but allows to override using variable `BUILDKIT_SYNTAX`


## Related issues
- Fixes #1754 

## Additional context
- Log output
```
>>> BASE_IMAGE=ubuntu:24.04 BUILDKIT_SYNTAX=docker/dockerfile:1.1 make docker-build -C images/capi
# We must pre-pull images https://github.com/moby/buildkit/issues/1271
docker pull docker/dockerfile:1.1
1.1: Pulling from docker/dockerfile
Digest: sha256:080bd74d8778f83e7b670de193362d8c593c8b14f5c8fb919d28ee8feda0d069
Status: Image is up to date for docker/dockerfile:1.1
docker.io/docker/dockerfile:1.1
docker pull ubuntu:24.04
24.04: Pulling from library/ubuntu
Digest: sha256:6015f66923d7afbc53558d7ccffd325d43b4e249f41a6e93eef074c9505d2233
Status: Downloaded newer image for ubuntu:24.04
docker.io/library/ubuntu:24.04
DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_SYNTAX=docker/dockerfile:1.1 --build-arg PASSED_IB_VERSION=v0.1.43-3-g96f34a8cb --build-arg ARCH=amd64 --build-arg BASE_IMAGE=ubuntu:24.04 --build-arg TAG=dev . -t gcr.io/prow-tkg-build/cluster-node-image-builder-amd64:dev
[+] Building 620.4s (18/19)                                                                                                                                                                                                                                                                                                            docker:colima
[+] Building 643.7s (19/19) FINISHED                                                                                                                                                                                                                                                                                                   docker:colima
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                            0.1s
 => => transferring dockerfile: 2.04kB                                                                                                                                                                                                                                                                                                          0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1.1                                                                                                                                                                                                                                                                     0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1.1                                                                                                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                               0.0s
 => => transferring context: 34B                                                                                                                                                                                                                                                                                                                0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                            0.1s
 => => transferring dockerfile: 32B                                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                                                                                                                                                                                 0.0s
 => [ 1/11] FROM docker.io/library/ubuntu:24.04                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                               0.4s
 => => transferring context: 57.46kB                                                                                                                                                                                                                                                                                                            0.3s
 => CACHED [ 2/11] RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y  apt-transport-https  build-essential  ca-certificates  curl  git  jq  python3-pip  rsync  unzip  vim  wget  qemu-system-x86  qemu-kvm  xorriso  && useradd -ms /bin/bash imagebuilder  && apt-get purge --auto-remove -y  && rm -rf /var/lib/apt/l  0.0s
 => CACHED [ 3/11] WORKDIR /home/imagebuilder/                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [ 4/11] COPY --chown=imagebuilder:imagebuilder ansible ansible/                                                                                                                                                                                                                                                                      0.0s
 => CACHED [ 5/11] COPY --chown=imagebuilder:imagebuilder ansible.cfg ansible.cfg                                                                                                                                                                                                                                                               0.0s
 => CACHED [ 6/11] COPY --chown=imagebuilder:imagebuilder cloudinit cloudinit/                                                                                                                                                                                                                                                                  0.0s
 => CACHED [ 7/11] COPY --chown=imagebuilder:imagebuilder hack hack/                                                                                                                                                                                                                                                                            0.0s
 => CACHED [ 8/11] COPY --chown=imagebuilder:imagebuilder packer packer/                                                                                                                                                                                                                                                                        0.0s
 => CACHED [ 9/11] COPY --chown=imagebuilder:imagebuilder Makefile Makefile                                                                                                                                                                                                                                                                     0.0s
 => CACHED [10/11] COPY --chown=imagebuilder:imagebuilder azure_targets.sh azure_targets.sh                                                                                                                                                                                                                                                     0.0s
 => [11/11] RUN make deps                                                                                                                                                                                                                                                                                                                     533.0s
 => exporting to image                                                                                                                                                                                                                                                                                                                        109.6s
 => => exporting layers                                                                                                                                                                                                                                                                                                                       109.6s
 => => writing image sha256:825710c6aa7664b3f6b59fef24d6b91a36d2e923b4f128ae1bc777a0ac98067e                                                                                                                                                                                                                                                    0.0s
 => => naming to gcr.io/prow-tkg-build/cluster-node-image-builder-amd64:dev
```
