### PR TITLE
Use correct user value for AMI Name tag

### DIFF
--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -47,7 +47,7 @@
       "ssh_username": "{{user `ssh_username`}}",
       "subnet_id": "{{ user `subnet_id` }}",
       "tags": {
-        "Name": "{{user `build_name`}}",
+        "Name": "{{user `image_name` | clean_resource_name}}",
         "arch": "{{ user `arch` }}",
         "build_date": "{{isotime}}",
         "build_timestamp": "{{user `build_timestamp`}}",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
I used the wrong user value in https://github.com/kubernetes-sigs/image-builder/pull/1744 so the Name tag was actually being populate by something like `flatcar_stable` rather than the full value that is used for the AMI name. 🤦  This PR fixes that and uses the same as the `ami_name` property like it should.



## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
