### PR TITLE
Remove Ubuntu 20.04 from GCP provider

### DIFF
--- a/docs/book/src/capi/providers/gcp.md
+++ b/docs/book/src/capi/providers/gcp.md
@@ -48,7 +48,6 @@ The `gce` sub-directory inside `images/capi/packer` stores JSON configuration fi
 
 | File | Description
 | -------- | --------
-| `ubuntu-2004.json`     | Settings for Ubuntu 20.04 image     |
 | `ubuntu-2204.json`     | Settings for Ubuntu 22.04 image     |
 | `ubuntu-2404.json`     | Settings for Ubuntu 24.04 image     |
 | `rhel-8.json`     | Settings for RHEL 8 image     |
@@ -79,7 +78,6 @@ $ gcloud compute images list --project ${GCP_PROJECT_ID} --no-standard-images
 
 NAME                                         PROJECT            FAMILY                      DEPRECATED  STATUS
 cluster-api-ubuntu-2404-v1-17-11-1603233313  myregistry-292303  capi-ubuntu-2404-k8s-v1-17              READY
-cluster-api-ubuntu-2004-v1-17-11-1603233874  myregistry-292303  capi-ubuntu-2004-k8s-v1-17              READY
 ```
 
 ### Delete Images

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -366,7 +366,7 @@ NODE_OVA_VSPHERE_CLONE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-clone-,$(PLA
 
 AMI_BUILD_NAMES			   ?= ami-centos-7 ami-ubuntu-2004 ami-ubuntu-2204 ami-ubuntu-2404 ami-amazon-2 ami-amazon-2023 ami-flatcar ami-flatcar-arm64 ami-windows-2019 ami-rockylinux-8 ami-rhel-8
 HUAWEICLOUD_BUILD_NAMES ?= huaweicloud-ubuntu-2204
-GCE_BUILD_NAMES			   ?= gce-ubuntu-2004 gce-ubuntu-2204 gce-ubuntu-2404 gce-rhel-8
+GCE_BUILD_NAMES			   ?= gce-ubuntu-2204 gce-ubuntu-2404 gce-rhel-8
 
 # Make needs these lists to be space delimited, no quotes
 VHD_TARGETS := $(shell grep VHD_TARGETS azure_targets.sh | sed 's/VHD_TARGETS=//' | tr -d \")
@@ -739,7 +739,6 @@ build-do-ubuntu-2404: ## Builds Ubuntu 24.04 DigitalOcean Snapshot
 build-do-centos-7: ## Builds Centos 7 DigitalOcean Snapshot
 build-do-all: $(DO_BUILD_TARGETS) ## Builds all DigitalOcean Snapshot
 
-build-gce-ubuntu-2004: ## Builds the GCE ubuntu-2004 image
 build-gce-ubuntu-2204: ## Builds the GCE ubuntu-2204 image
 build-gce-ubuntu-2404: ## Builds the GCE ubuntu-2404 image
 build-gce-rhel-8: ## Builds the GCE rhel-8 image
@@ -990,7 +989,6 @@ validate-openstack-rocky-9: ## Validates Rocky 9 Openstack Image Packer config
 validate-openstack-flatcar: ## Validates Flatcar Openstack Image Packer config
 validate-openstack-all: $(OPENSTACK_VALIDATE_TARGETS) ## Validates all Openstack Glance Image Packer config
 
-validate-gce-ubuntu-2004: ## Validates Ubuntu 20.04 GCE Snapshot Packer config
 validate-gce-ubuntu-2204: ## Validates Ubuntu 22.04 GCE Snapshot Packer config
 validate-gce-ubuntu-2404: ## Validates Ubuntu 24.04 GCE Snapshot Packer config
 validate-gce-rhel-8: ## Validates RHEL 8 GCE Snapshot Packer config

--- a/images/capi/packer/gce/ubuntu-2004.json
+++ b/images/capi/packer/gce/ubuntu-2004.json
@@ -1,9 +1,0 @@
-{
-  "build_name": "ubuntu-2004",
-  "distribution": "ubuntu",
-  "distribution_release": "focal",
-  "distribution_version": "2004",
-  "source_image_family": "ubuntu-2004-lts",
-  "ssh_username": "ubuntu",
-  "zone": "us-central1-a"
-}


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

Ubuntu 20.04 is now EOL and seems to have been removed from GCP so no longer works from image-builder.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

N/A

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

/assign @drew-viles @mboersma @jsturtevant 