### PR TITLE
Increas task_timeout for large ISOs or slow Proxmox Servers

### DIFF
--- a/images/capi/packer/proxmox/packer.json.tmpl
+++ b/images/capi/packer/proxmox/packer.json.tmpl
@@ -7,6 +7,7 @@
         "{{user `boot_command_suffix`}}"
       ],
       "boot_wait": "{{user `boot_wait`}}",
+      "task_timeout": "10m",
       "bios": "{{user `bios`}}",
       "communicator": "ssh",
       "cores": "{{user `cores`}}",


### PR DESCRIPTION
Helps with this Issue:
https://github.com/hashicorp/packer-plugin-proxmox/issues/313

## Change description
I get this error in my proxmox:
```
==> proxmox-iso.ubuntu-2204: Wait timeout for:UPID:node01:00003558:071F1869:6857C4E4:imgcopy::caprox1@pve!capi:
Build 'proxmox-iso.ubuntu-2204' errored after 4 minutes 9 seconds: Wait timeout for:UPID:node01:00003558:071F1869:6857C4E4:imgcopy::caprox1@pve!capi:
```

Packer is not waiting long enough for the copy of the ISO.
