### PR TITLE
MAAS: Support both UEFI and BIOS boot modes in setup-bootloader

### DIFF
--- a/images/capi/ansible/roles/providers/files/maas/curtin/curtin-hooks
+++ b/images/capi/ansible/roles/providers/files/maas/curtin/curtin-hooks
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 #
-# This script was copied as-is from:
+# This original script was copied from:
 # Source: https://github.com/canonical/packer-maas
 # Original Author: Alexsander de Souza <alexsander.souza@canonical.com>
-#
+# and modified by the image-builder team
 
 
 import os

--- a/images/capi/ansible/roles/providers/files/maas/curtin/setup-bootloader
+++ b/images/capi/ansible/roles/providers/files/maas/curtin/setup-bootloader
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 #
-# This script was copied as-is from:
+# This script was based on:
 # Source: https://github.com/canonical/packer-maas
 # Original Author: Alexsander de Souza <alexsander.souza@canonical.com>
+# and modified by the image-builder team
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -12,19 +13,27 @@ dpkg --configure -a
 
 # Update the package lists before attempting to install the kernel
 apt-get update
-# Ensure the existence of linux-image-generic for non-cloudimg images.
-#apt-get -y install linux-image-generic
 
-dpkg-reconfigure grub-efi-amd64
-update-grub
+if [ -d /sys/firmware/efi ]; then
+    echo "EFI MODE!"
+    dpkg-reconfigure grub-efi-amd64
+    update-grub
 
-grub-install \
-    --target=x86_64-efi \
-    --efi-directory=/boot/efi \
-    --bootloader-id=ubuntu \
-    --recheck
-
-update-initramfs -uk all
-
-efibootmgr -v
-
+    grub-install \
+        --target=x86_64-efi \
+        --efi-directory=/boot/efi \
+        --bootloader-id=ubuntu \
+        --recheck
+    update-initramfs -uk all
+    efibootmgr -v
+else
+    echo "BIOS MODE!"
+    apt-get remove -y --allow-change-held-packages --allow-remove-essential grub-efi-amd64 grub-efi-amd64-signed shim-signed
+    apt-get install -y grub-pc
+    dpkg-reconfigure grub-pc
+    update-grub
+    DEVICE=$(findmnt -no SOURCE "/")
+    BOOT_DISK=$(lsblk -no PKNAME "$DEVICE")
+    grub-install /dev/"$BOOT_DISK"
+    update-initramfs -uk all
+fi


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Add support for both UEFI and BIOS boot modes in setup-bootloader only in **MAAS Provider**

This change updates the setup-bootloader script to detect the system's
firmware type (UEFI or BIOS) and install the appropriate GRUB bootloader.

- If UEFI is detected, grub-efi is configured and installed.
- If BIOS is detected, grub-efi is removed, grub-pc is installed, and GRUB is installed to the appropriate disk.
- Improved script comments to reflect modifications by the image-builder team.
- Maintains compatibility with systems lacking UEFI support.

This ensures broader hardware compatibility for the generated images.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
