### PR TITLE
Introduce hack to avoid rm failing with not found

### DIFF
--- a/images/capi/hack/set-ssh-password.sh
+++ b/images/capi/hack/set-ssh-password.sh
@@ -47,7 +47,11 @@ export ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt $SALT -stdin <<<
 
 for file in $(find $PACKER_DIR -type f -name "*.tmpl"); do
   if [ -f "${file%.*}" ]; then
-    rm ${file%.*}
+    # HACK: There seems to be a case where this can actually
+    # fail with the file not being found, leading to test failures.
+    # If we fail to remove the file we just continue and assume
+    # that the file was already removed.
+    rm ${file%.*} || true
   fi
   sed -e "s|\$SSH_PASSWORD|$SSH_PASSWORD|g" -e "s|\$ENCRYPTED_SSH_PASSWORD|$ENCRYPTED_SSH_PASSWORD|g" $file | tee ${file%.*}
 done


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

We seen some flakey test failures on PRs where the `rm` command seems to fail due to the file not existing.

For example:
```
rm: cannot remove '/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/packer/ova/linux/rhel/http/7/ks.cfg': No such file or directory
```
Taken from https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_image-builder/1783/pull-ova-all/1939613496043900928/artifacts/flatcar.log

It's not clear how this occurs as the if statement should ensure the file exists before attempting to remove it. 

As this file being missing isn't critical enough to fail the tests (as we're deleting it anyway) this hack ignored failures deleting the file and allows the test to continue as normal.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
