### PR TITLE
Force setting windows_admin_password for OVA and Nutanix

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -467,7 +467,7 @@ SCALEWAY_VALIDATE_TARGETS	:= $(addprefix validate-,$(SCALEWAY_BUILD_NAMES))
 $(NODE_OVA_LOCAL_BUILD_TARGETS): deps-ova set-ssh-password
     # This uses a packer file builder to input unattend variables into a JSON file to be consumed by the python script before running the vmware-iso provisioner
 	$(if $(findstring windows,$@),$(PACKER) build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-windows.json,)
-	$(if $(findstring windows,$@),hack/windows-ova-unattend.py --unattend-file='./packer/ova/windows/$(subst build-node-ova-local-,,$@)/autounattend.xml',)
+	$(if $(findstring windows,$@),hack/windows-unattend.py --unattend-file='./packer/ova/windows/$(subst build-node-ova-local-,,$@)/autounattend.xml',)
 	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-,,$@).json)" -except=vsphere -only=vmware-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
 
 .PHONY: $(NODE_OVA_LOCAL_VALIDATE_TARGETS)
@@ -486,7 +486,7 @@ $(NODE_OVA_LOCAL_BASE_BUILD_TARGETS): deps-ova set-ssh-password
 $(NODE_OVA_VSPHERE_BUILD_TARGETS): deps-ova set-ssh-password
     # This uses a packer file builder to input unattend variables into a JSON file to be consumed by the python script before running the vsphere provisioner
 	$(if $(findstring windows,$@),$(PACKER) build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-windows.json,)
-	$(if $(findstring windows,$@),hack/windows-ova-unattend.py --unattend-file='./packer/ova/windows/$(subst build-node-ova-vsphere-,,$@)/autounattend.xml',)
+	$(if $(findstring windows,$@),hack/windows-unattend.py --unattend-file='./packer/ova/windows/$(subst build-node-ova-vsphere-,,$@)/autounattend.xml',)
 	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS))  -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json"  -except=local -only=vsphere-iso $(ABSOLUTE_PACKER_VAR_FILES) -only=vsphere packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
 
 .PHONY: $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS)
@@ -624,6 +624,8 @@ $(NUTANIX_BUILD_TARGETS): deps-nutanix set-ssh-password
 	$(eval NUTANIX_USERDATA:=$(shell cat $(abspath packer/nutanix/linux/cloud-init/$(subst -,/,$(if $(findstring ubuntu,$@),$(call GET_UBUNTU_DOTTED_SEMVER,$(subst build-nutanix-,,$@)),$(subst build-nutanix-,,$@)))/user-data) | base64 -w0))
 	$(eval NUTANIX_VAR_FILE:=$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json))
 	jq '.user_data = "$(NUTANIX_USERDATA)"' $(NUTANIX_VAR_FILE) > $(NUTANIX_VAR_FILE).templated && mv $(NUTANIX_VAR_FILE).templated $(NUTANIX_VAR_FILE)
+	# This uses a packer file builder to input unattend variables into a JSON file to be consumed by the python script before running the nutanix provisioner
+	$(if $(findstring windows,$@),hack/windows-unattend.py --unattend-file='./packer/nutanix/windows/$(subst build-nutanix-,,$@)/autounattend.xml',)
 	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer$(if $(findstring windows,$@),-windows,).json
 
 .PHONY: $(NUTANIX_VALIDATE_TARGETS)

--- a/images/capi/packer/nutanix/packer-windows.json
+++ b/images/capi/packer/nutanix/packer-windows.json
@@ -45,7 +45,7 @@
         "subnet_name": "{{user `nutanix_subnet_name`}}"
       },
       "winrm_insecure": true,
-      "winrm_password": "S3cr3t0!",
+      "winrm_password": "{{user `windows_admin_password`}}",
       "winrm_port": 5986,
       "winrm_timeout": "4h",
       "winrm_use_ssl": true,

--- a/images/capi/packer/nutanix/windows/windows-2022/autounattend.xml
+++ b/images/capi/packer/nutanix/windows/windows-2022/autounattend.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--*************************************************
 Windows Server 2019 Answer File Generator
 Created using Windows AFG found at:
@@ -6,8 +7,6 @@ Created using Windows AFG found at:
 Installation Notes:
 - This file need to be adapted based on your needs
 **************************************************-->
-
-<?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
@@ -141,7 +140,7 @@ Installation Notes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
@@ -248,7 +247,7 @@ Installation Notes:
             <TimeZone>Pacific Standard Time</TimeZone>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -261,7 +261,7 @@
     "output_dir": "./output/{{user `build_version`}}",
     "prepull": null,
     "unattend_timezone": "Pacific Standard Time",
-    "windows_admin_password": "S3cr3t0!",
+    "windows_admin_password": "{{user `windows_admin_password`}}",
     "windows_service_manager": null,
     "windows_updates_categories": null,
     "windows_updates_kbs": null

--- a/images/capi/packer/ova/windows/windows-2019-efi/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019-efi/autounattend.xml
@@ -121,7 +121,7 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
@@ -169,7 +169,7 @@ Installation Notes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
@@ -251,7 +251,7 @@ Installation Notes:
             <TimeZone>Pacific Standard Time</TimeZone>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>

--- a/images/capi/packer/ova/windows/windows-2019/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2019/autounattend.xml
@@ -113,7 +113,7 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
@@ -161,7 +161,7 @@ Installation Notes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
@@ -243,7 +243,7 @@ Installation Notes:
             <TimeZone>Pacific Standard Time</TimeZone>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>

--- a/images/capi/packer/ova/windows/windows-2022-efi/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022-efi/autounattend.xml
@@ -121,7 +121,7 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
@@ -169,7 +169,7 @@ Installation Notes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
@@ -251,7 +251,7 @@ Installation Notes:
             <TimeZone>Pacific Standard Time</TimeZone>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>

--- a/images/capi/packer/ova/windows/windows-2022/autounattend.xml
+++ b/images/capi/packer/ova/windows/windows-2022/autounattend.xml
@@ -113,7 +113,7 @@ Installation Notes:
         </component>
     </settings>
     <settings pass="specialize">
-        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" 
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
             xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
@@ -161,7 +161,7 @@ Installation Notes:
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <AutoLogon>
                 <Password>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
@@ -243,7 +243,7 @@ Installation Notes:
             <TimeZone>Pacific Standard Time</TimeZone>
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>S3cr3t0!</Value>
+                    <Value></Value>
                     <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>


### PR DESCRIPTION
## Change description

Forces users to set the environment variable `WINDOWS_ADMIN_PASSWORD` or the json variable `admin_password` when building a Windows image for OVA or Nutanix.

## Related issues

- Refs #1673
- See also #1596

## Additional context

