### PR TITLE
Updated Azure CI tests to automatically detect targets

### DIFF
--- a/images/capi/azure_targets.sh
+++ b/images/capi/azure_targets.sh
@@ -1,8 +1,4 @@
 VHD_TARGETS="ubuntu-2004 ubuntu-2204 ubuntu-2404 azurelinux-3 rhel-8 windows-2019-containerd windows-2022-containerd"
-VHD_CI_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 windows-2022-containerd"
 SIG_TARGETS="ubuntu-2004 ubuntu-2204 ubuntu-2404 azurelinux-3 rhel-8 windows-2019-containerd windows-2022-containerd windows-2025-containerd flatcar"
-SIG_CI_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 windows-2022-containerd windows-2025-containerd flatcar"
 SIG_GEN2_TARGETS="ubuntu-2004 ubuntu-2204 ubuntu-2404 azurelinux-3 flatcar"
-SIG_GEN2_CI_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 flatcar"
 SIG_CVM_TARGETS="ubuntu-2004 ubuntu-2204 ubuntu-2404 windows-2019-containerd windows-2022-containerd"
-SIG_CVM_CI_TARGETS="ubuntu-2204 ubuntu-2404 windows-2022-containerd"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Updates the Azure test script to dynamically detect target OSs we support and run tests for those.

We also filter out the following:

* Any RHEL targets (because of subscription requirements)

In addition to the targets current being tested this will also add Ubuntu 20.04 and Windows 2019.

### Before:

VHD:
![Screenshot 2025-07-04 at 10 18 47 AM](https://github.com/user-attachments/assets/5be32f4f-cc8c-45d0-9759-34d09411d051)

SIG:
![Screenshot 2025-07-04 at 10 20 00 AM](https://github.com/user-attachments/assets/62a351a2-fc0f-4f96-89b3-d7701723a6eb)

### After:

VHD:
![Screenshot 2025-07-04 at 10 18 59 AM](https://github.com/user-attachments/assets/e14753d1-9952-4e15-aaa1-9ecf92ac6ff6)

SIG:
![Screenshot 2025-07-04 at 11 58 57 AM](https://github.com/user-attachments/assets/3a7f750b-6e00-4a15-bfd1-70ae0432cff4)


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Towards improving https://github.com/kubernetes-sigs/image-builder/issues/1605



## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
