### PR TITLE
Add wait for reboot

### DIFF
--- a/images/capi/packer/maas/packer.json.tmpl
+++ b/images/capi/packer/maas/packer.json.tmpl
@@ -95,6 +95,7 @@
       "type": "shell"
     },
     {
+      "pause_before": "30s",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
         "KUBEVIRT={{user `kubevirt`}}"


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->
This PR add the fix from issue #1631 to the maas set, so that Ubuntu builds do not fail when the QEMU VM reboots.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) ____
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1631 (for MaaS)
