### PR TITLE
Exclude grub packages from apt-mark hold

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -20,10 +20,19 @@
 - name: Pin all installed packages with apt-mark
   ansible.builtin.shell: |
     set -o pipefail
-    dpkg-query -f '${binary:Package}\n' -W | grep -v grub | xargs apt-mark hold
+    dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
 
   args:
     executable: /bin/bash
+
+- name: Unpin grub packages with apt-mark for MaaS
+  ansible.builtin.shell: |
+    set -o pipefail
+    dpkg-query -f '${binary:Package}\n' -W | grep grub | xargs apt-mark unhold
+
+  args:
+    executable: /bin/bash
+  when: provider == "maas"
 
 - name: Remove extra repos
   ansible.builtin.file:

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -20,7 +20,7 @@
 - name: Pin all installed packages with apt-mark
   ansible.builtin.shell: |
     set -o pipefail
-    dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
+    dpkg-query -f '${binary:Package}\n' -W | grep -v grub | xargs apt-mark hold
 
   args:
     executable: /bin/bash

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -32,7 +32,7 @@
 
   args:
     executable: /bin/bash
-  when: provider == "maas"
+  when: provider is defined and provider is search('maas')
 
 - name: Remove extra repos
   ansible.builtin.file:


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Fixes the problem of MaaS not being able to update the `grub` packages during deployment, as documented [here](https://discourse.maas.io/t/curtin-command-fails-due-to-grub-efi-amd64-pkg-conflicts/7475/3)

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) __n__