### PR TITLE
Allow users to pass custom Packer GitHub API token value

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -13,6 +13,12 @@ Run the docker build target of Makefile
    make docker-build
    ```
 
+To avoid hitting API rate limit issues when Packer tries to pull plugins from GitHub, `PACKER_GITHUB_API_TOKEN` variable can be passed during the `docker-build`
+
+  ```commandline
+  PACKER_GITHUB_API_TOKEN=<github api token>  make docker-build
+  ```
+
 ## Using a Container Image
 
 The latest image-builder container image release is available here:

--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -59,6 +59,7 @@ ENV PACKER_ARGS=''
 ENV PACKER_VAR_FILES=''
 ENV IB_VERSION="${PASSED_IB_VERSION}"
 
-RUN make deps
+RUN --mount=type=secret,id=packer-github-token,env=PACKER_GITHUB_API_TOKEN \
+	make deps
 
 ENTRYPOINT [ "/usr/bin/make" ]

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -1152,7 +1152,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the Docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_SYNTAX=$(BUILDKIT_SYNTAX) --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_SYNTAX=$(BUILDKIT_SYNTAX) --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) --secret id=packer-github-token,env=PACKER_GITHUB_API_TOKEN . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the Docker image


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->
This PR allows users to pass GitHub API token to the docker build process so that `make deps` target does not fail due to Gihub API rate limits.

## Related issues

- Fixes # [1815](https://github.com/kubernetes-sigs/image-builder/issues/1815)

## Additional context
Command issued:
```
PACKER_GITHUB_API_TOKEN=$GITHUB_TOKEN  make docker-build
```

Build Log output

```
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                            0.0s
 => => transferring dockerfile: 2.11kB                                                                                                                                                                                                                                                                                                          0.0s
 => resolve image config for docker-image://dockerhub.packages.vcfd.broadcom.net/docker/dockerfile:1.14                                                                                                                                                                                                                                         0.0s
 => CACHED docker-image://dockerhub.packages.vcfd.broadcom.net/docker/dockerfile:1.14                                                                                                                                                                                                                                                           0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for vsphere-docker-virtual.packages.vcfd.broadcom.net/library/ubuntu:24.04                                                                                                                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                               0.1s
 => => transferring context: 150B                                                                                                                                                                                                                                                                                                               0.0s
 => [stage-0  1/11] FROM vsphere-docker-virtual.packages.vcfd.broadcom.net/library/ubuntu:24.04                                                                                                                                                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                               0.4s
 => => transferring context: 155.31kB                                                                                                                                                                                                                                                                                                           0.3s
 => CACHED [stage-0  2/11] RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y  apt-transport-https  build-essential  ca-certificates  curl  git  jq  python3-pip  rsync  unzip  vim  wget  qemu-system-x86  qemu-kvm  xorriso  && useradd -ms /bin/bash imagebuilder  && apt-get purge --auto-remove -y  && rm -rf /var/l  0.0s
 => CACHED [stage-0  3/11] WORKDIR /home/imagebuilder/                                                                                                                                                                                                                                                                                          0.0s
 => CACHED [stage-0  4/11] COPY --chown=imagebuilder:imagebuilder ansible ansible/                                                                                                                                                                                                                                                              0.0s
 => CACHED [stage-0  5/11] COPY --chown=imagebuilder:imagebuilder ansible.cfg ansible.cfg                                                                                                                                                                                                                                                       0.0s
 => CACHED [stage-0  6/11] COPY --chown=imagebuilder:imagebuilder cloudinit cloudinit/                                                                                                                                                                                                                                                          0.0s
 => CACHED [stage-0  7/11] COPY --chown=imagebuilder:imagebuilder hack hack/                                                                                                                                                                                                                                                                    0.0s
 => [stage-0  8/11] COPY --chown=imagebuilder:imagebuilder packer packer/                                                                                                                                                                                                                                                                       0.4s
 => [stage-0  9/11] COPY --chown=imagebuilder:imagebuilder Makefile Makefile                                                                                                                                                                                                                                                                    0.2s
 => [stage-0 10/11] COPY --chown=imagebuilder:imagebuilder azure_targets.sh azure_targets.sh                                                                                                                                                                                                                                                    0.1s
 => [stage-0 11/11] RUN --mount=type=secret,id=packer-github-token,env=PACKER_GITHUB_API_TOKEN  make deps                                                                                                                                                                                                                                     528.3s
 => exporting to image                                                                                                                                                                                                                                                                                                                        104.4s
 => => exporting layers                                                                                                                                                                                                                                                                                                                       104.4s
 => => writing image sha256:ca46b69beeee18cde465224533d09a62e9c27d7b4ba5fdee9461d296d80b905c                                                                                                                                                                                                                                                    0.0s
 => => naming to gcr.io/prow-tkg-build/cluster-node-image-builder-amd64:dev
```
