### PR TITLE
Update security contacts to current maintainers

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,6 +10,8 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-timothysc
-justinsb
-luxas
+AverageMarcus
+jsturtevant
+kkeshavamurthy
+mboersma
+drew-viles


### PR DESCRIPTION
## Change description

Updates the aliases in `SECURITY_CONTACTS` to match the current set of maintainers.

## Related issues

- Fixes #

## Additional context

/cc @ritazh 
