### PR TITLE
Add NFS client packages (nfs-utils, nfs-common) to support NFS mounts in Kubernetes

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -21,6 +21,7 @@ common_rpms:
   - python3-pip
   - socat
   - sysstat
+  - nfs-utils
 
 # Used for AmazonLinux-2 distributions
 al2_rpms:
@@ -75,6 +76,7 @@ common_debs:
   - python3-netifaces
   - python3-pip
   - socat
+  - nfs-common
 
 common_photon_rpms:
   - audit


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Enable NFS volume mounts in Kubernetes by adding NFS client packages

