### PR TITLE
Add ntnx-psirt to cluster-api-nutanix-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -81,6 +81,7 @@ aliases:
     - tuxtof
   cluster-api-nutanix-reviewers:
     - tuxtof
+    - ntnx-psirt
   cluster-api-maas-maintainers:
     - vasartori
   cluster-api-maas-reviewers:


### PR DESCRIPTION
This pull request updates the `OWNERS_ALIASES` file to include a new alias for the `cluster-api-nutanix-reviewers` group.

* [`OWNERS_ALIASES`](diffhunk://#diff-4985b733677adf9dda6b5187397d4700868248ef646d64aecfb66c1ced575499R84): Added `ntnx-psirt` to the `cluster-api-nutanix-reviewers` group.