### PR TITLE
fix: make lint failing consistently

### DIFF
--- a/images/capi/hack/ensure-ansible-lint.sh
+++ b/images/capi/hack/ensure-ansible-lint.sh
@@ -32,6 +32,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 if ! command -v ansible-lint >/dev/null 2>&1; then
-    pip3_install "ansible-lint==${_version}"
+    pip3_install "ansible-lint==${_version}" "ansible-core==${_version_ansible_core}"
     ensure_py3_bin ansible-lint
 fi

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -22,9 +22,6 @@ set -o pipefail
 
 source hack/utils.sh
 
-# Note: ansible-core v2.16.x requires Python >= 3.10.
-_version="2.15.13"
-
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
@@ -33,18 +30,18 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 if ! command -v ansible >/dev/null 2>&1; then
-    pip3_install "ansible-core==${_version}"
+    pip3_install "ansible-core==${_version_ansible_core}"
     ensure_py3_bin ansible
     ensure_py3_bin ansible-playbook
 fi
 
 ansible_version=""
 IFS=" " read -ra ansible_version <<< "$(ansible --version)"
-if [[ "${_version}" != $(echo -e "${_version}\n${ansible_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${ansible_version[2]}" != "devel" ]]; then
+if [[ "${_version_ansible_core}" != $(echo -e "${_version_ansible_core}\n${ansible_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${ansible_version[2]}" != "devel" ]]; then
   cat <<EOF
 Detected ansible version: ${ansible_version[*]}.
-Image builder requires ${_version} or greater.
-Please install ${_version} or later.
+Image builder requires ${_version_ansible_core} or greater.
+Please install ${_version_ansible_core} or later.
 EOF
   exit 2
 fi

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Note: ansible-core v2.16.x requires Python >= 3.10.
+_version_ansible_core="2.15.13"
+
 case "${OSTYPE}" in
 linux*)
   HOSTOS=linux


### PR DESCRIPTION
## Change description
Looks like in the latest version of ansible-core there is a bug that is causing make lint to fail with 'ModuleNotFoundError: No module named 'ansible.parsing.yaml.constructor' error.

In this PR I hard coded ansibile-core version to 2.15.13 in the ensure-ansible-lint.sh script. I used the same version present in the ensure-ansible-lint.sh script, so as to have a consistent environment.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1823