### PR TITLE
Disable hardcoded MaaS curtin scripts

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/maas-ubuntu.yml
+++ b/images/capi/ansible/roles/providers/tasks/maas-ubuntu.yml
@@ -4,12 +4,13 @@
     state: directory
     mode: "0775"
 
-- name: Copy curtin scripts to /curtin
-  ansible.builtin.copy:
-    src: "files/maas/curtin/{{ item }}"
-    dest: "/curtin/{{ item }}"
-    mode: "0750"
-  loop:
-    - curtin-hooks
-    - install-custom-packages
-    - setup-bootloader
+# Don't copy in hard-coded scripts as modern MaaS already has builtin tasks that are more flexible and powerful
+# - name: Copy curtin scripts to /curtin
+#   ansible.builtin.copy:
+#     src: "files/maas/curtin/{{ item }}"
+#     dest: "/curtin/{{ item }}"
+#     mode: "0750"
+#   loop:
+#     - curtin-hooks
+#     - install-custom-packages
+#     - setup-bootloader


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
The MaaS support added to image-builder contained hardcoded hooks and scripts for curtin. However, MaaS has since evolved and now included all those steps (and more) already builtin. The builtin steps are more powerful & flexible, and should be used instead. For example, the builtin properly reconfigures the UEFI boot order (to keep PXE at the top) and handles situations where the MaaS proxy should be used for APT package updates.

Hence, this PR comments out the copying of the hardcoded curtin files for MaaS, so that the standard curtin hooks from MaaS can be used instead.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) __n__

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes issues with the UEFI boot order not getting repaired, and MaaS proxy scenarios not working for custom MaaS images generated by this builder.

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
