### PR TITLE
Fix pypy installer on Flatcar Azure 

### DIFF
--- a/images/capi/ansible/roles/python/defaults/main.yml
+++ b/images/capi/ansible/roles/python/defaults/main.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-pypy_python_version: "3.6"
-pypy_version: 7.2.0
+pypy_python_version: "3.9"
+pypy_version: 7.3.16
 pypy_download_path: /tmp/pypy.tar.bz2
 pypy_install_path: /opt

--- a/images/capi/ansible/roles/python/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/python/tasks/flatcar.yml
@@ -20,14 +20,14 @@
   when:
     - pypy_installed.stdout_lines[0] == "false"
   vars:
-    pypy_url_base: https://github.com/squeaky-pl/portable-pypy/releases/download/pypy{{ pypy_python_version }}-{{ pypy_version }}
-    pypy_url_path: pypy{{ pypy_python_version }}-{{ pypy_version }}-linux_x86_64-portable.tar.bz2
+    pypy_url_base: https://downloads.python.org/pypy
+    pypy_url_path: pypy{{ pypy_python_version }}-v{{ pypy_version }}-linux64.tar.bz2
   block:
     - name: Download pypy archive
       ansible.builtin.raw: curl {{ pypy_url_base }}/{{ pypy_url_path }} -L --output {{ pypy_download_path }}
     - name: Extract archive
       ansible.builtin.raw: tar -xjf {{ pypy_download_path }} -C {{ pypy_install_path }}
     - name: Rename pypy folder
-      ansible.builtin.raw: mv {{ pypy_install_path }}/pypy{{ pypy_python_version }}-{{ pypy_version }}-linux_x86_64-portable/ {{ pypy_install_path }}/pypy
+      ansible.builtin.raw: mv {{ pypy_install_path }}/pypy{{ pypy_python_version }}-v{{ pypy_version }}-linux64/ {{ pypy_install_path }}/pypy
     - name: Delete downloaded archive
       ansible.builtin.raw: rm -f {{ pypy_download_path }}


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

On ansible python installation, it is using by default python 3.6 what is deprecated, I've updated it to use python 3.9. 

Also I've hit issues when building Azure images which doesn't have python 3.9. It seems like the URL used to install pypy is not maintained([last version released was 3.6](https://github.com/squeaky-pl/portable-pypy/releases/tag/pypy3.6-7.2.0)). Thats why I've replaced it with the official downloads URL.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
