### PR TITLE
fix: builder user remenants should not be present in node images

### DIFF
--- a/images/capi/packer/maas/packer.json.tmpl
+++ b/images/capi/packer/maas/packer.json.tmpl
@@ -29,7 +29,7 @@
       "net_device": "virtio-net",
       "output_directory": "{{user `output_directory`}}",
       "qemu_binary": "{{user `qemu_binary`}}",
-      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && rm -f /etc/sudoers.d/90-cloud-init-users && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",

--- a/images/capi/packer/nutanix/packer.json.tmpl
+++ b/images/capi/packer/nutanix/packer.json.tmpl
@@ -16,7 +16,7 @@
       "nutanix_port": "{{user `nutanix_port`}}",
       "nutanix_username": "{{user `nutanix_username`}}",
       "os_type": "{{user `guest_os_type`}}",
-      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && rm -f /etc/sudoers.d/90-cloud-init-users && {{user `shutdown_command`}}'",
       "ssh_handshake_attempts": "100",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "20m",

--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -29,7 +29,7 @@
       "net_device": "virtio-net",
       "output_directory": "{{user `output_directory`}}",
       "qemu_binary": "{{user `qemu_binary`}}",
-      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && rm -f /etc/sudoers.d/90-cloud-init-users && {{user `shutdown_command`}}'",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",

--- a/images/capi/packer/raw/packer.json.tmpl
+++ b/images/capi/packer/raw/packer.json.tmpl
@@ -30,7 +30,7 @@
           "virtio"
         ]
       ],
-      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
+      "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && rm -f /etc/sudoers.d/90-cloud-init-users && {{user `shutdown_command`}}'",
       "ssh_handshake_attempts": "100",
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "2h",


### PR DESCRIPTION
## Change description
Currently the builder user is not deleted, just locked, which could pose security risks for qemu, raw, nutanix and maas. So based on the suggestions, cleaning up the user just like in the case of ova.

## Related issues
- Fixes #1837 

## Additional context
This changeset has been introduced on the basis of the discussions that happened as part of [PR](https://github.com/kubernetes-sigs/image-builder/pull/1830). 