### PR TITLE
Revert "fix: 🐛 Allow users to pass custom Packer GitHub API token value"

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -13,12 +13,6 @@ Run the docker build target of Makefile
    make docker-build
    ```
 
-To avoid hitting API rate limit issues when Packer tries to pull plugins from GitHub, `PACKER_GITHUB_API_TOKEN` variable can be passed during the `docker-build`
-
-  ```commandline
-  PACKER_GITHUB_API_TOKEN=<github api token>  make docker-build
-  ```
-
 ## Using a Container Image
 
 The latest image-builder container image release is available here:

--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -61,7 +61,6 @@ ENV PACKER_ARGS=''
 ENV PACKER_VAR_FILES=''
 ENV IB_VERSION="${PASSED_IB_VERSION}"
 
-RUN --mount=type=secret,id=packer-github-token,env=PACKER_GITHUB_API_TOKEN \
-	make deps
+RUN make deps
 
 ENTRYPOINT [ "/usr/bin/make" ]

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -1104,7 +1104,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the Docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_SYNTAX=$(BUILDKIT_SYNTAX) --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) --secret id=packer-github-token,env=PACKER_GITHUB_API_TOKEN . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_SYNTAX=$(BUILDKIT_SYNTAX) --build-arg PASSED_IB_VERSION=$(IB_VERSION) --build-arg ARCH=$(ARCH) --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg TAG=$(TAG) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: docker-push
 docker-push: ## Push the Docker image


### PR DESCRIPTION
and "docs: ✏️ Update docs on how to by pass GitHub API rate limits during container image builds"

This reverts commits a2e676da995e3857dcad85edf4219de0b81e1952 and 02a5e40ec1511648c007aefce173984c6588721c.

## Change description

This reverts the changes in #1816, because it turns out that the Kubernetes image promotion pipeline doesn't have a new enough version of Docker to support the `-secret` syntax:

```
ERROR: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: \
failed with build-arg:BUILDKIT_SYNTAX = docker/dockerfile:1.14: failed to solve with frontend gateway.v0: \
rpc error: code = Unknown desc = \
requested experimental feature exec.secretenv  is not supported by build server, please update docker
```

Without reverting this, image-builder can't do a project release.

We should investigate how to reinstate the GitHub API token changes in a way that's compatible with the older Docker, or if it's possible to get Docker updated on the build nodes.

## Related issues

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
