### PR TITLE
fix: adding defaults and type check to some bool checks and making a few 'and' statements into lists

### DIFF
--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -89,21 +89,12 @@
 
 - name: Configure auditd rules for containerd
   ansible.builtin.copy:
-    src: etc/audit/rules.d/containerd.rules
+    src: "etc/audit/rules.d/containerd.rules{{ '-flatcar' if ansible_os_family == 'Flatcar' else '' }}"
     dest: /etc/audit/rules.d/containerd.rules
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family != "Flatcar" and enable_containerd_audit
-
-- name: Configure auditd rules for containerd (Flatcar)
-  ansible.builtin.copy:
-    src: etc/audit/rules.d/containerd.rules-flatcar
-    dest: /etc/audit/rules.d/containerd.rules
-    owner: root
-    group: root
-    mode: "0644"
-  when: ansible_os_family == "Flatcar" and enable_containerd_audit
+  when: enable_containerd_audit|default(false)|bool
 
 - name: Ensure reverse packet filtering is set as strict
   ansible.posix.sysctl:

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -39,7 +39,9 @@
     path: /etc/apt/sources.list.d/{{ item | basename }}
     state: absent
   loop: "{{ extra_repos.split() }}"
-  when: remove_extra_repos and extra_repos != ""
+  when:
+    - remove_extra_repos|default(false)|bool
+    - extra_repos != ""
 
 - name: Find disabled repo files
   ansible.builtin.find:

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -37,7 +37,9 @@
   ansible.builtin.file:
     path: /etc/pip.conf
     state: absent
-  when: remove_extra_repos and pip_conf_file != ""
+  when:
+    - remove_extra_repos|default(false)|bool
+    - pip_conf_file != ""
 
 - name: Truncate machine id
   ansible.builtin.file:

--- a/images/capi/ansible/roles/sysprep/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/rpm_repos.yml
@@ -17,7 +17,9 @@
     path: /etc/yum.repos.d/{{ item | basename }}
     state: absent
   loop: "{{ extra_repos.split() }}"
-  when: remove_extra_repos and extra_repos != ""
+  when:
+    - remove_extra_repos|default(false)|bool
+    - extra_repos != ""
 
 - name: Find disabled repo files
   ansible.builtin.find:


### PR DESCRIPTION
## Change description
This PR adds some type checks into a few boolean variables that did not have it. On newer versions of ansible an empty value is no longer considered 'false' and so these checks now fail:

```==> openstack: TASK [node : Ensure auditd is running and comes on at reboot] ******************
==> openstack: ok: [default]
==> openstack:
==> openstack: TASK [node : debug] ************************************************************
==> openstack: ok: [default] => {
==> openstack:     "msg": "family: Debian audit: "
==> openstack: }
==> openstack:
==> openstack: TASK [node : Configure auditd rules for containerd] ****************************
==> openstack: [ERROR]: Task failed: Conditional result was '' of type 'str', which evaluates to False. Conditionals must have a boolean result.
==> openstack:
==> openstack: Task failed.
==> openstack: Origin: /mnt/c/Users/viles/git/github.com/drew-viles/image-builder/images/capi/ansible/roles/node/tasks/main.yml:94:3
==> openstack:
==> openstack: 92     msg: "family: {{ ansible_os_family }} audit: {{ enable_containerd_audit }}"
==> openstack: 93
==> openstack: 94 - name: Configure auditd rules for containerd
==> openstack:      ^ column 3
==> openstack:
==> openstack: <<< caused by >>>
==> openstack:
==> openstack: Conditional result was '' of type 'str', which evaluates to False. Conditionals must have a boolean result.
==> openstack: Origin: /mnt/c/Users/viles/git/github.com/drew-viles/image-builder/images/capi/ansible/roles/node/tasks/main.yml:103:7
==> openstack:
==> openstack: 101   when:
==> openstack: 102     - ansible_os_family != "Flatcar"
==> openstack: 103     - enable_containerd_audit
==> openstack:           ^ column 7
==> openstack:
==> openstack: Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
==> openstack:
==> openstack: fatal: [default]: FAILED! => {"changed": false, "msg": "Task failed: Conditional result was '' of type 'str', which evaluates to False. Conditionals must have a boolean result."}
==> openstack:
==> openstack: PLAY RECAP *********************************************************************
==> openstack: default                    : ok=16   changed=7    unreachable=0    failed=1    skipped=305  rescued=0    ignored=
```

On top of this, because it's easier to see how the conditional works in a list (imho ofc), I've made those and statements into a list under the `when` clause.

- Is this change including a new Provider or a new OS? (y/n) N