### PR TITLE
chore: adding an option to bypass sysprep task that copies the grub file

### DIFF
--- a/images/capi/ansible/roles/sysprep/defaults/main.yml
+++ b/images/capi/ansible/roles/sysprep/defaults/main.yml
@@ -16,3 +16,4 @@ extra_repos: ""
 pip_conf_file: ""
 remove_extra_repos: false
 flatcar_disable_autologin: false
+sysprep_require_grub_file: true

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -126,7 +126,9 @@
     mode: "0644"
   notify:
     - Update debian grub
-  when: _stat_update_grub.stat.exists
+  when:
+    - _stat_update_grub.stat.exists
+    - sysprep_require_grub_file|default(true)|bool
 
 - name: Removing subiquity disable cloud-init networking config
   ansible.builtin.file:


### PR DESCRIPTION
## Change description

This may be required by users who are using a custom source image and not using one straight form an ISO, for example building in OpenStack. By providing a "false" flag, the process will skip over the sysprep task "Configure grub for non graphical consoles" which copies the grup file into place and causes any existing one to become redundant.

- Is this change including a new Provider or a new OS? (y/n) N