### PR TITLE
fix: Windows support with Nutanix builder

### DIFF
--- a/docs/book/src/capi/goss/goss.md
+++ b/docs/book/src/capi/goss/goss.md
@@ -10,15 +10,15 @@ to test if the images have all requisite components to work with cluster API.
 ### Support Matrix 
 *For stock server-specs shipped with repo
 
-| OS                      | Builder              |
-|-------------------------|----------------------|
-| Amazon Linux            | aws                  |
-| Azure Linux             | azure                |
-| CentOS                  | aws, ova             |
-| Flatcar Container Linux | aws, azure, ova      |
-| PhotonOS                | ova                  |
-| Ubuntu                  | aws, azure, gcp, ova |
-| Windows                 | aws, azure, ova      |
+| OS                      | Builder                       |
+|-------------------------|-------------------------------|
+| Amazon Linux            | aws                           |
+| Azure Linux             | azure                         |
+| CentOS                  | aws, nutanix, ova             |
+| Flatcar Container Linux | aws, azure, nutanix, ova      |
+| PhotonOS                | ova                           |
+| Ubuntu                  | aws, azure, gcp, nutanix, ova |
+| Windows                 | aws, azure, nutanix, ova      |
 
 
 ### Prerequisites for Running Goss

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -620,10 +620,11 @@ $(POWERVS_VALIDATE_TARGETS): deps-powervs
 
 .PHONY: $(NUTANIX_BUILD_TARGETS)
 $(NUTANIX_BUILD_TARGETS): deps-nutanix set-ssh-password
-	$(eval NUTANIX_USERDATA:=$(shell cat $(abspath packer/nutanix/linux/cloud-init/$(subst -,/,$(if $(findstring ubuntu,$@),$(call GET_UBUNTU_DOTTED_SEMVER,$(subst build-nutanix-,,$@)),$(subst build-nutanix-,,$@)))/user-data) | base64 -w0))
-	$(eval NUTANIX_VAR_FILE:=$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json))
-	jq '.user_data = "$(NUTANIX_USERDATA)"' $(NUTANIX_VAR_FILE) > $(NUTANIX_VAR_FILE).templated && mv $(NUTANIX_VAR_FILE).templated $(NUTANIX_VAR_FILE)
+	$(if $(findstring windows,$@),,$(eval NUTANIX_USERDATA:=$(shell cat $(abspath packer/nutanix/linux/cloud-init/$(subst -,/,$(if $(findstring ubuntu,$@),$(call GET_UBUNTU_DOTTED_SEMVER,$(subst build-nutanix-,,$@)),$(subst build-nutanix-,,$@)))/user-data) | base64 -w0)))
+	$(if $(findstring windows,$@),,$(eval NUTANIX_VAR_FILE:=$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)))
+	$(if $(findstring windows,$@),,jq '.user_data = "$(NUTANIX_USERDATA)"' $(NUTANIX_VAR_FILE) > $(NUTANIX_VAR_FILE).templated && mv $(NUTANIX_VAR_FILE).templated $(NUTANIX_VAR_FILE))
 	# This uses a packer file builder to input unattend variables into a JSON file to be consumed by the python script before running the nutanix provisioner
+	$(if $(findstring windows,$@),$(PACKER) build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer$(if $(findstring windows,$@),-windows,).json,)
 	$(if $(findstring windows,$@),hack/windows-unattend.py --unattend-file='./packer/nutanix/windows/$(subst build-nutanix-,,$@)/autounattend.xml',)
 	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer$(if $(findstring windows,$@),-windows,).json
 

--- a/images/capi/packer/nutanix/packer-windows.json
+++ b/images/capi/packer/nutanix/packer-windows.json
@@ -1,6 +1,11 @@
 {
   "builders": [
     {
+      "content": "{\n \"unattend_timezone\" : \"{{user `unattend_timezone`}}\"\n, \"admin_password\" : \"{{user `windows_admin_password`}}\"\n}",
+      "target": "./packer_cache/unattend.json",
+      "type": "file"
+    },
+    {
       "boot_type": "{{user `boot_type`}}",
       "cd_files": [
         "./packer/nutanix/windows/{{user `build_name`}}/autounattend.xml",
@@ -54,6 +59,7 @@
   ],
   "provisioners": [
     {
+      "except": "file",
       "extra_arguments": [
         "-e",
         "ansible_winrm_server_cert_validation=ignore",
@@ -70,12 +76,14 @@
       "user": "Administrator"
     },
     {
+      "except": "file",
       "restart_timeout": "10m",
       "type": "windows-restart"
     },
     {
       "arch": "{{user `goss_arch`}}",
       "download_path": "{{user `goss_download_path`}}",
+      "except": "file",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
       "goss_file": "{{user `goss_entry_file`}}",
@@ -91,7 +99,8 @@
       "url": "{{user `goss_url`}}",
       "use_sudo": false,
       "vars_env": {
-        "GOSS_MAX_CONCURRENT": "1"
+        "GOSS_MAX_CONCURRENT": "1",
+        "GOSS_USE_ALPHA": "1"
       },
       "vars_file": "{{user `goss_vars_file`}}",
       "vars_inline": {
@@ -107,6 +116,7 @@
       "version": "{{user `goss_version`}}"
     },
     {
+      "except": "file",
       "inline": [
         "rm -Force -Recurse C:\\var\\log\\kubelet\\*"
       ],
@@ -155,6 +165,7 @@
     "nutanix_subnet_name": "{{env `NUTANIX_SUBNET_NAME`}}",
     "nutanix_username": "{{env `NUTANIX_USERNAME`}}",
     "scp_extra_vars": "",
-    "vm_force_delete": "false"
+    "vm_force_delete": "false",
+    "windows_admin_password": "{{env `WINDOWS_ADMIN_PASSWORD`}}"
   }
 }

--- a/images/capi/packer/nutanix/windows-2022.json
+++ b/images/capi/packer/nutanix/windows-2022.json
@@ -6,5 +6,5 @@
   "runtime": "containerd",
   "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
   "source_image_name": "en-us_windows_server_2022_x64_dvd_620d7eac",
-  "virtio_image_name": "Nutanix-VirtIO-1.2.1"
+  "virtio_image_name": "Nutanix-VirtIO-1.2.5"
 }


### PR DESCRIPTION
This pull request fixes the Nutanix Windows image build process in the CAPI images pipeline. 

The key changes add support for injecting Windows-specific variables during image creation, update the handling of build targets for Windows, and bump the VirtIO driver version for Windows Server 2022. 

**Windows image build improvements:**

* Added a `file` builder to `packer-windows.json` to generate an `unattend.json` file with Windows-specific variables such as `unattend_timezone` and `windows_admin_password`.
* Updated provisioners in `packer-windows.json` to exclude the new `file` builder, ensuring correct execution order for Windows-specific provisioning steps. [[1]](diffhunk://#diff-a17d01f10ded92a416dbbf1d24b77881b92dd2188b715d9033433f38d6115216R62) [[2]](diffhunk://#diff-a17d01f10ded92a416dbbf1d24b77881b92dd2188b715d9033433f38d6115216R79-R84) [[3]](diffhunk://#diff-a17d01f10ded92a416dbbf1d24b77881b92dd2188b715d9033433f38d6115216R119)
* Added the environment variable `WINDOWS_ADMIN_PASSWORD` to the user variables in `packer-windows.json` for secure password injection.
* Set `GOSS_USE_ALPHA` in the Goss provisioner to enable alpha features during Windows image validation.

**Build target and driver updates:**

* Modified the Nutanix build targets in `Makefile` to properly handle Windows builds by conditionally running Windows-specific steps and skipping Linux-specific user data injection for Windows targets.
* Updated the Nutanix VirtIO driver version to `1.2.5` for Windows Server 2022 images in `windows-2022.json`, improving compatibility and performance.