### PR TITLE
Add ca-certificates-legacy to Azure Linux builds

### DIFF
--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -40,6 +40,7 @@ al2023_rpms:
 
 # Used for Azure Linux distributions
 azurelinux_rpms:
+  - ca-certificates-legacy
   - curl
   - yum-utils
   - lsof


### PR DESCRIPTION
## Change description

Adds the `ca-certificates-legacy` package to Azure Linux 3 builds.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

- Refs kubernetes-sigs/cluster-api-provider-azure#5829

## Additional context

We already install `ca-certificates`, and if I'm reading things correctly, the `update-ca-trust` command to expand certs and create symlinks is run as part of the RPM installation. So I think this is the only thing we want to bake in to the Azure Linux 3 images.
