### PR TITLE
Fix broken URL links and filenames

### DIFF
--- a/docs/book/src/capi/providers/aws.md
+++ b/docs/book/src/capi/providers/aws.md
@@ -173,11 +173,11 @@ As root:
 
 ```sh
 mkdir -p /etc/cni/net.d
-wget -q https://github.com/containernetworking/cni/releases/download/v0.7.0/cni-amd64-v0.7.0.tgz
-tar -xzf cni-amd64-v0.7.0.tgz --directory /etc/cni/net.d
+wget -q https://github.com/containernetworking/plugins/releases/download/v0.7.0/cni-plugins-amd64-v0.7.0.tgz
+tar -xzf cni-plugins-amd64-v0.7.0.tgz --directory /etc/cni/net.d
 cat >/etc/cni/net.d/10-mynet.conf <<EOF
 {
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.7.0",
     "name": "mynet",
     "type": "bridge",
     "bridge": "cni0",
@@ -194,7 +194,7 @@ cat >/etc/cni/net.d/10-mynet.conf <<EOF
 EOF
 cat >/etc/cni/net.d/99-loopback.conf <<EOF
 {
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.7.0",
     "name": "lo",
     "type": "loopback"
 }
@@ -206,8 +206,8 @@ EOF
 As a non-root user:
 
 ```sh
-wget https://dl.k8s.io/$(< /etc/kubernetes_community_ami_version)/kubernetes-test.tar.gz
-tar -zxvf kubernetes-test.tar.gz kubernetes/platforms/linux/amd64
+wget https://cdn.dl.k8s.io/release/$(< /etc/kubernetes_version)/kubernetes-test-linux-amd64.tar.gz
+tar -zxvf kubernetes-test-linux-amd64.tar.gz kubernetes/platforms/linux/amd64
 cd kubernetes/platforms/linux/amd64
 sudo ./ginkgo --nodes=8 --flakeAttempts=2 --focus="\[Conformance\]" --skip="\[Flaky\]|\[Serial\]|\[sig-network\]|Container Lifecycle Hook" ./e2e_node.test -- --k8s-bin-dir=/usr/bin --container-runtime=remote --container-runtime-endpoint unix:///var/run/containerd/containerd.sock --container-runtime-process-name /usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"
 ```


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Fix broken URL links and filenames:
1. Updates URL to https://github.com/containernetworking/plugins/releases/download/v0.7.0/cni-plugins-amd64-v0.7.0.tgz
2. Updates URL to  https://cdn.dl.k8s.io/release/$(< /etc/kubernetes_version)/kubernetes-test-linux-amd64.tar.gz


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1650 

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
While I've verified files inside the .tar.gz files from new links, which looks all good, I didn't try out the steps mentioned in the doc as I'm not familiar with creating a k8s cluster in AWS for testing. 

