### PR TITLE
feat: flatcar disable usb

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -231,3 +231,15 @@ Put the Ansible role files in the `ansible/roles` directory.
 ```
 
 Note, for backwards compatibility reasons, the variable `custom_role_names` is still accepted as an alternative to `node_custom_roles_post`, and they are functionally equivalent.
+
+##### Reenabling Flatcar USB devices
+
+Flatcar usb devices are disabled by default for security reasons.
+See [flatcar documentation](https://www.flatcar.org/docs/latest/setup/security/hardening-guide/#disable-usb) for more information.
+To reenable them, set the following variable:
+
+```json
+{
+  "ansible_user_vars": "disable_flatcar_usb=false"
+}
+```

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -131,3 +131,7 @@ external_binary_path: "{{ '/opt/bin' if ansible_os_family == 'Flatcar' else '/us
 
 # Enable containerd trace audit in auditd, default: false.
 enable_containerd_audit: false
+
+# Disable flatcar usb devices, default: true
+# See hardening guide: https://www.flatcar.org/docs/latest/setup/security/hardening-guide/#disable-usb
+disable_flatcar_usb: true

--- a/images/capi/ansible/roles/node/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/node/tasks/flatcar.yml
@@ -1,0 +1,40 @@
+# Copyright 2025 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# See hardening guide: https://www.flatcar.org/docs/latest/setup/security/hardening-guide/#disable-usb
+- name: Create /etc/modprobe.d directory
+  ansible.builtin.file:
+    path: /etc/modprobe.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: disable_flatcar_usb
+
+- name: Blacklist usb-storage module
+  ansible.builtin.copy:
+    dest: /etc/modprobe.d/blacklist.conf
+    content: |
+      blacklist usb-storage
+    owner: root
+    group: root
+    mode: '0644'
+  when: disable_flatcar_usb
+
+# sed is used here instead of the ansible.builtin.lineinfile module
+# because of the read-only filesystem on Flatcar in /etc.
+- name: Set default HOME_MODE in login.defs
+  ansible.builtin.shell: sed -ri "s/^#?HOME_MODE\>.*/HOME_MODE 0700/" /etc/login.defs
+  tags:
+    - skip_ansible_lint

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -26,6 +26,9 @@
   tags:
     - facts
 
+- ansible.builtin.import_tasks: flatcar.yml
+  when: ansible_os_family == "Flatcar"
+
 - name: Ensure overlay module is present
   community.general.modprobe:
     name: overlay
@@ -124,7 +127,3 @@
     src: usr/local/bin/etcd-network-tuning.sh
     dest: "{{ external_binary_path }}/etcd-network-tuning.sh"
     mode: "0755"
-
-- name: Set default HOME_MODE in login.defs (Flatcar)
-  ansible.builtin.shell: sed -ri "s/^#?HOME_MODE\>.*/HOME_MODE 0700/" /etc/login.defs
-  when: ansible_os_family == "Flatcar"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

This PR disables usb devices for Flatcar as described in their [hardening guide](https://www.flatcar.org/docs/latest/setup/security/hardening-guide/#disable-usb).

Default value is false to keep the current behavior. But a user can disable usb devices in flatcar by setting `disable_flatcar_usb` to true.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) -
- If adding a new provider, are you a representative of that provider? (y/n) -

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

none

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

none
