### PR TITLE
Fix infinite recursion in `DataSourceEc2KubernetesLocal`

### DIFF
--- a/images/capi/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
+++ b/images/capi/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
@@ -117,7 +117,7 @@ class DataSourceEc2Kubernetes(DataSourceEc2.DataSourceEc2):
 
 class DataSourceEc2KubernetesLocal(DataSourceEc2Kubernetes):
     def _get_data(self):
-        return super(DataSourceEc2KubernetesLocal, self).get_data()
+        return super(DataSourceEc2KubernetesLocal, self)._get_data()
 
 
 # Used to match classes to dependencies


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
Fixes infinite recursion in `DataSourceEc2KubernetesLocal` by calling parent method


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1715

## Additional context
`DataSourceEc2KubernetesLocal._get_data()` was calling `super.get_data()`, which calls `self._check_and_get_data()`, which calls `self._get_data()` in an infinite loop. This PR calls the parent method `super()._get_data()` instead.

I've reproduced this bug in a [fork of `cloud-init`](https://github.com/canonical/cloud-init/compare/main...joshfrench:cloud-init:ec2-k8s-datasource-repro#diff-327741c4ca3f63452f196f714bca8cf0611c0d43f7b89fb2a4801017e1e250e0R120) (it's over there just to make testing easier).  Here's the test case I used. The existing data source fails with a recursion error.
```py
#!/usr/bin/env python3

from unittest import mock

import pytest

from cloudinit.sources.DataSourceEc2Kubernetes import (
    DataSourceEc2Kubernetes,
    DataSourceEc2KubernetesLocal,
)


def test_no_recursion_in_get_data():
    ds = DataSourceEc2KubernetesLocal(sys_cfg={}, distro=None, paths=None)

    with mock.patch.object(
        DataSourceEc2Kubernetes, "_get_data", return_value=True
    ) as mock_parent_get_data:
        try:
            result = ds._get_data()
        except RecursionError as e:
            pytest.fail(f"RecursionError occurred: {e}")
```