### PR TITLE
Remove trailing newline from Windows kubelet service definition

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/tasks/sc.yml
+++ b/images/capi/ansible/windows/roles/kubernetes/tasks/sc.yml
@@ -19,7 +19,7 @@
   ansible.windows.win_service:
     name: kubelet
     start_mode: auto
-    path: >
+    path: >-
       "{{ kubernetes_install_path }}\kube-log-runner.exe" --log-file={{ systemdrive.stdout | trim }}/var/log/kubelet/kubelet.log
       {{ kubernetes_install_path }}\kubelet.exe --windows-service
       --cert-dir={{ systemdrive.stdout | trim }}/var/lib/kubelet/pki


### PR DESCRIPTION
## Change description

Changes the YAML multiline string processing operator from `>` to `>-` so the final newline is removed.

## Related issues

- Fixes #

## Additional context

This fixes a bug that was preventing the kubelet service from starting on Windows images built recently. From `kubelet.log`:

```
E1020 21:38:40.556774    4936 pod_workers.go:1301] "Error syncing pod, skipping" err="failed to \"CreatePodSandbox\" for \"cloud-node-manager-windows-p8hg5_kube-system(f7b6b4a3-6d22-4e4f-9224-92ee685291db)\" with CreatePodSandboxError: \"Failed to generate sandbox config for pod \\\"cloud-node-manager-windows-p8hg5_kube-system(f7b6b4a3-6d22-4e4f-9224-92ee685291db)\\\": Unexpected error while getting os.Stat for \\\"\\n\\\" resolver config. Error: CreateFile \\n: The filename, directory name, or volume label syntax is incorrect.\"" pod="kube-system/cloud-node-manager-windows-p8hg5" podUID="f7b6b4a3-6d22-4e4f-9224-92ee685291db"
E1020 21:38:42.556608    4936 dns_windows.go:88] "Cannot get host DNS Configuration." err=<
        Unexpected error while getting os.Stat for "
        " resolver config. Error: CreateFile
        : The filename, directory name, or volume label syntax is incorrect.
```

When I inspected the service definition on a failing node built from a new Azure image-builder image (using `sc.exe qc kubelet` for future reference), the final `--resolv-conf=""` argument was missing the empty quotes and the trailing newline was interpreted as the value. Changing the YAML operator fixes it in my testing.
