### PR TITLE
introduce feature DiskControllerTypes to allow nvme disks

### DIFF
--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -56,6 +56,8 @@ az sig create --resource-group ${RESOURCE_GROUP_NAME} --gallery-name ${GALLERY_N
 
 SECURITY_TYPE_CVM_SUPPORTED_FEATURE="SecurityType=ConfidentialVmSupported"
 
+DISK_CONTROLLER_TYPES_FEATURE="DiskControllerTypes=SCSI,NVMe"
+
 SIG_TARGET=$1
 
 # Accept Azure VM image terms if available and required
@@ -126,6 +128,12 @@ accept_image_terms
 # Create a shared image gallery image definition if it does not exist
 create_image_definition() {
   if ! az sig image-definition show --gallery-name ${GALLERY_NAME} --gallery-image-definition ${SIG_IMAGE_DEFINITION:-capi-${SIG_SKU:-$1}} --resource-group ${RESOURCE_GROUP_NAME} -o none 2>/dev/null; then
+    
+    local FEATURES=("$DISK_CONTROLLER_TYPES_FEATURE")
+    if [[ -n "$2" ]]; then
+      FEATURES+=("$2")
+    fi
+
     az sig image-definition create \
       --resource-group ${RESOURCE_GROUP_NAME} \
       --gallery-name ${GALLERY_NAME} \
@@ -135,7 +143,7 @@ create_image_definition() {
       --sku ${SIG_SKU:-$2} \
       --hyper-v-generation ${3} \
       --os-type ${4} \
-      --features ${5:-''} \
+      --features "${FEATURES[@]}" \
       "${plan_args[@]}" # TODO: Delete this line after the image is GA
   fi
 }

--- a/images/capi/packer/azure/scripts/init-sig.sh
+++ b/images/capi/packer/azure/scripts/init-sig.sh
@@ -130,8 +130,8 @@ create_image_definition() {
   if ! az sig image-definition show --gallery-name ${GALLERY_NAME} --gallery-image-definition ${SIG_IMAGE_DEFINITION:-capi-${SIG_SKU:-$1}} --resource-group ${RESOURCE_GROUP_NAME} -o none 2>/dev/null; then
     
     local FEATURES=("$DISK_CONTROLLER_TYPES_FEATURE")
-    if [[ -n "$2" ]]; then
-      FEATURES+=("$2")
+    if [[ -n "$5" ]]; then
+      FEATURES+=("$5")
     fi
 
     az sig image-definition create \


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Azure v6 machines are using root NVMe disks, this is not supported by default by image definitions. This PR introduces the necessary feature to allow NVMe root disks for all azure builds as indicated [here](https://github.com/hashicorp/packer-plugin-azure/issues/521#issuecomment-3332431023).

We faced the following error on CAPZ
```
--------------------------------------------------------------------------------
RESPONSE 400: 400 Bad Request
ERROR CODE: InvalidParameter
--------------------------------------------------------------------------------
{
  "error": {
    "code": "InvalidParameter",
    "message": "The VM size 'Standard_D8s_v6' cannot boot with OS image or disk. Please check that disk controller types supported by the OS image or disk is one of the supported disk controller types for the VM size 'Standard_D8s_v6'. Please query sku api at https://aka.ms/azure-compute-skus  to determine supported disk controller types for the VM size.",
    "target": "vmSize"
  }
}
--------------------------------------------------------------------------------
```

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
