### PR TITLE
 Remove --pod-infra-container-image default argument

### DIFF
--- a/images/capi/ansible/roles/kubernetes/defaults/main.yml
+++ b/images/capi/ansible/roles/kubernetes/defaults/main.yml
@@ -43,6 +43,6 @@ kubernetes_cni_http_checksum: sha256:{{ kubernetes_cni_http_source }}/{{ kuberne
 
 kubeadm_template: etc/kubeadm.yml
 
-kubelet_extra_args: --pod-infra-container-image={{ pause_image }}
+kubelet_extra_args: ""
 
 kubernetes_enable_automatic_resource_sizing: false


### PR DESCRIPTION
## Change description

Removes the remaining instance of the `--pod-infra-container-image` kubelet flag.

We thought kubeadm might remove this deprecated flag at runtime, but testing with k8s 1.35 shows that's not the case. This has been deprecated since before k8s 1.30 and implemented as a no-op since then, so I think it is safe to remove it in image-builder now.

## Related issues

- See #1866

## Additional context

