### PR TITLE
Expose network tags for GCE builder

### DIFF
--- a/images/capi/packer/gce/packer.json
+++ b/images/capi/packer/gce/packer.json
@@ -19,6 +19,7 @@
       "service_account_email": "{{ user `service_account_email` }}",
       "source_image_family": "{{ user `source_image_family` }}",
       "ssh_username": "{{user `ssh_username`}}",
+      "tags": "{{ user `tags` }}",
       "type": "googlecompute",
       "use_internal_ip": "{{ user `use_internal_ip`}}",
       "zone": "{{ user `zone` }}"


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
This PR exposes network tags for the GCE builder. See [reference](https://developer.hashicorp.com/packer/integrations/hashicorp/googlecompute/latest/components/builder/googlecompute) for `tags` usage.

This can be consumed from user set variables, with a comma separated list, see [reference](https://developer.hashicorp.com/packer/docs/templates/legacy_json_templates/user-variables#use-array-values).

For example:

```json
{
  "tags": "packer,foo,bar"
}
```

This is a small quality of life change to facilitate network management.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? No

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
