### PR TITLE
fix(azure): remove public_ip_sku from hardcoded parameters to build image in existing vnet

### DIFF
--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -69,7 +69,6 @@
       },
       "polling_duration_timeout": "60m",
       "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
-      "public_ip_sku": "Standard",
       "shared_gallery_image_version_exclude_from_latest": "{{ user `exclude_from_latest` }}",
       "shared_image_gallery": {
         "community_gallery_image_id": "{{ user `community_gallery_image_id` }}",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
This PR fixes the image building on Azure when an existing VNet is used. This is useful when building in private environments where teams do not have permissions to use public IPs.

More precisely, the flag `public_ip_sku` by default is set to `Standard` by default, but if `virtual_network_name` is specified, `public_ip_sku` cannot be specified. So it is better to not always specify it.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1697

## Additional context

PR code tested in private environment, but only when specifying the VNet.
