### PR TITLE
Skip OVA rockylinux-8 and photon-5 builds in CI

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -29,10 +29,14 @@ export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 # The following are currently having issues running in the
 # test environment so are specifically excluded for now
 # - Photon-4
+# - Photon-5
+# - RockyLinux-8
 TARGETS=( $(make build-node-ova-vsphere-all --recon -d | grep "Must remake" | \
   grep -v build-node-ova-vsphere-all | \
   grep -E -v 'rhel|windows|efi' | \
   grep -v build-node-ova-vsphere-photon-4 | \
+  grep -v build-node-ova-vsphere-photon-5 | \
+  grep -v build-node-ova-vsphere-rockylinux-8 | \
   grep -E -o 'build-node-ova-vsphere-[a-zA-Z0-9\-]+' ) )
 
 export BOSKOS_RESOURCE_OWNER=image-builder


### PR DESCRIPTION
## Change description

Removes the rockylinux-8 and photon-5 OVA builds from those run by default in CI, since they're broken.

## Related issues

- See #1881

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
