### PR TITLE
Require promotion approval in Azure image pipeline

### DIFF
--- a/images/capi/packer/azure/.pipelines/promote-sig.yaml
+++ b/images/capi/packer/azure/.pipelines/promote-sig.yaml
@@ -14,7 +14,16 @@
 # - SIG_OFFER - the name of the offer to attach to image definitions, defaults to `reference-images`
 
 jobs:
+- deployment: approve_promotion
+  displayName: 'Approve Image Promotion'
+  environment: 'image-promotion-approval'
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - script: echo "Approved for promotion"
 - job: publish_to_sig
+  dependsOn: approve_promotion
   timeoutInMinutes: 120
   strategy:
     maxParallel: 0


### PR DESCRIPTION
## Change description

Adds a manual approval step to the Azure DevOps pipeline before the promotion step.

## Related issues

- Refs kubernetes-sigs/windows-testing#528

## Additional context

I've tested this in the actual pipeline and it seems to work. The `ManualApproval@0` step is an alternative but it didn't work in this context.
