### PR TITLE
nutanix: pass ansible scp extra args to provisioner

### DIFF
--- a/images/capi/packer/nutanix/packer-windows.json
+++ b/images/capi/packer/nutanix/packer-windows.json
@@ -161,7 +161,7 @@
     "nutanix_port": "{{env `NUTANIX_PORT`}}",
     "nutanix_subnet_name": "{{env `NUTANIX_SUBNET_NAME`}}",
     "nutanix_username": "{{env `NUTANIX_USERNAME`}}",
-    "scp_extra_vars": "",
+    "scp_extra_vars": "{{user `ansible_scp_extra_args`}}",
     "vm_force_delete": "false",
     "windows_admin_password": "{{env `WINDOWS_ADMIN_PASSWORD`}}"
   }

--- a/images/capi/packer/nutanix/packer.json.tmpl
+++ b/images/capi/packer/nutanix/packer.json.tmpl
@@ -155,7 +155,7 @@
     "nutanix_subnet_name": "{{env `NUTANIX_SUBNET_NAME`}}",
     "nutanix_username": "{{env `NUTANIX_USERNAME`}}",
     "python_path": "",
-    "scp_extra_vars": "",
+    "scp_extra_vars": "{{user `ansible_scp_extra_args`}}",
     "source_image_delete": "false",
     "source_image_force": "false",
     "ssh_password": "$SSH_PASSWORD",


### PR DESCRIPTION
## Change description
What this PR does & Why its needed ?
Forward Nutanix template’s `scp_extra_vars` to `ansible_scp_extra_args` , so the Ansible provisioner passes through whatever
`ANSIBLE_SCP_EXTRA_ARGS ` the Makefile exports. With OpenSSH 9 the default `scp`  implementation switches to SFTP, which Nutanix cloud images do not support (they lack sftp-server), so Ansible fails to upload its modules during “Gathering Facts.” The Makefile already detects OpenSSH ≥ 9 and sets `ANSIBLE_SCP_EXTRA_ARGS="-O"` to force legacy scp; this patch simply wires that value into: 

- packer.json.tmpl
- packer-windows.json

And then the Nutanix builds succeed. 

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues
- Fixes #1885 

## Additional context

Failure before the patch (make build-nutanix-ubuntu-2204):

```
… scp: Connection closed
bash: line 1: /usr/lib/sftp-server: No such file or directory
fatal: [default]: FAILED! => {"msg": "failed to transfer file … AnsiballZ_setup.py"}
```

After wiring `--scp-extra-args={{user 'scp_extra_vars'}}` and mapping `scp_extra_vars `to `ansible_scp_extra_args`, the Makefile-provided `ANSIBLE_SCP_EXTRA_ARGS="-O"` reaches Ansible, forcing legacy scp and allowing the file upload.

**Validation**: `DEBUG=1 ON_ERROR_ASK=1 FOREGROUND=1 make build-nutanix-ubuntu-2204` (and make build-nutanix-ubuntu-2404) complete successfully.

