### PR TITLE
Pin ansible community.general before 12.0.0

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -49,7 +49,7 @@ fi
 echo ${ansible_version[*]}
 
 ansible-galaxy collection install \
-  community.general \
+  'community.general:<12.0.0' \
   ansible.posix \
   'ansible.windows:>=1.7.0' \
   community.windows


### PR DESCRIPTION
## Change description

Pins the ansible `community.general` collection before v12.0.0, to avoid requiring Python 3.7.

## Related issues

- Fixes #1888

## Additional context

All credit goes to @bhampl for pointing out the issue!