### PR TITLE
test(ova): Re-enable CI for photon-5 OVA builds

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -29,13 +29,11 @@ export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 # The following are currently having issues running in the
 # test environment so are specifically excluded for now
 # - Photon-4
-# - Photon-5
 # - RockyLinux-8
 TARGETS=( $(make build-node-ova-vsphere-all --recon -d | grep "Must remake" | \
   grep -v build-node-ova-vsphere-all | \
   grep -E -v 'rhel|windows|efi' | \
   grep -v build-node-ova-vsphere-photon-4 | \
-  grep -v build-node-ova-vsphere-photon-5 | \
   grep -v build-node-ova-vsphere-rockylinux-8 | \
   grep -E -o 'build-node-ova-vsphere-[a-zA-Z0-9\-]+' ) )
 


### PR DESCRIPTION
## Change description
This changeset re-enables the photon-5 CI builds for OVA

## Related issues
- Fixes #1881 

## Additional context
Photon team had hardened the OS and changed permissions for the /tmp resulting the issue. The changes has been reversed now and hence the CI builds for Photon-5 should proceed smoothly.
