### PR TITLE
remove AWS_DEFAULT_REGION from example env file

### DIFF
--- a/docs/book/src/capi/container-image.md
+++ b/docs/book/src/capi/container-image.md
@@ -34,7 +34,6 @@ docker pull registry.k8s.io/scl-image-builder/cluster-node-image-builder-amd64:v
       ```commandline
       AWS_ACCESS_KEY_ID=xxxxxxx
       AWS_SECRET_ACCESS_KEY=xxxxxxxx
-      AWS_DEFAULT_REGION=xxxxxx
       ```
 
     ```commandline


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

Documentation mentions AWS env file with key `AWS_DEFAULT_REGION`. However, it is not used anywhere in image-builder and could be confusing that it will be used for underlaying packer. I myself had it set and I was wondering why packer uses different region.


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) N
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) N
- If adding a new provider, are you a representative of that provider? (y/n) N

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
```
 grep -ir "AWS_DEFAULT_REGION"
docs/book/src/capi/container-image.md:      AWS_DEFAULT_REGION=xxxxxx
```
