### PR TITLE
Upgrade ansible to v2.20.0 to support Python 3.14

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Note: ansible-core v2.16 supports Python 3.10-3.12.
-_version_ansible_core="2.16.16"
+_version_ansible_core="2.20.0"
 
 case "${OSTYPE}" in
 linux*)


### PR DESCRIPTION
## Change description

Otherwise, with newer Python versions, we get the error `Invalid conditional detected: module 'ast' has no attribute 'Str'` in playbook runs.

Python 3.14, released in October 2025, [removes](https://docs.python.org/3.13/whatsnew/3.13.html#pending-removal-in-python-3-14) `ast.Str`. Upgrading Ansible to a newer version ensures this isn't used anymore – I didn't look for the exact changelog item for that since we should anyway upgrade Ansible.



<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->
n/a