### PR TITLE
Fix MAAS Deploy "in memory"

### DIFF
--- a/images/capi/packer/maas/packer.json.tmpl
+++ b/images/capi/packer/maas/packer.json.tmpl
@@ -115,6 +115,13 @@
       "user": "builder"
     },
     {
+      "inline": [
+        "sudo rm -f /etc/fstab"
+      ],
+      "inline_shebang": "/bin/bash -e",
+      "type": "shell"
+    },
+    {
       "arch": "{{user `goss_arch`}}",
       "format": "{{user `goss_format`}}",
       "format_options": "{{user `goss_format_options`}}",
@@ -160,7 +167,7 @@
     "containerd_version": null,
     "cpus": "1",
     "crictl_version": null,
-    "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",    
+    "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
     "disk_compression": "false",
     "disk_discard": "unmap",
     "disk_image": "false",
@@ -188,7 +195,7 @@
     "kubernetes_series": null,
     "kubernetes_source_type": null,
     "runc_url": "https://github.com/opencontainers/runc/releases/download/v{{user `runc_version`}}/runc.amd64",
-    "runc_version": null,    
+    "runc_version": null,
     "machine_id_mode": "444",
     "memory": "2048",
     "oem_id": "",


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Machines deployed in memory raise an error, leaving users stuck in "emergency mode"

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

Related to issue: canonical/packer-maas/issues/362

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
