### PR TITLE
Fix chrony configuration issues

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -39,6 +39,13 @@
     enabled: true
   when: ansible_os_family == "Debian"
 
+- name: Create directory for DHCP chrony server files
+  ansible.builtin.file:
+    path: /var/lib/dhcp
+    state: directory
+    mode: '0755'
+  when: ansible_os_family == "Debian"
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
     src: "{{ item.src }}"

--- a/images/capi/ansible/roles/providers/tasks/proxmox.yml
+++ b/images/capi/ansible/roles/providers/tasks/proxmox.yml
@@ -42,6 +42,13 @@
     enabled: false
   when: ansible_os_family == "Debian"
 
+- name: Create directory for DHCP chrony server files
+  ansible.builtin.file:
+    path: /var/lib/dhcp
+    state: directory
+    mode: '0755'
+  when: ansible_os_family == "Debian"
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
     src: "{{ item.src }}"

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -42,6 +42,13 @@
     enabled: false
   when: ansible_os_family == "Debian"
 
+- name: Create directory for DHCP chrony server files
+  ansible.builtin.file:
+    path: /var/lib/dhcp
+    state: directory
+    mode: '0755'
+  when: ansible_os_family == "Debian"
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
     src: "{{ item.src }}"

--- a/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
@@ -58,6 +58,12 @@
     state: started
     enabled: true
 
+- name: Create directory for DHCP chrony server files
+  ansible.builtin.file:
+    path: /var/lib/dhclient
+    state: directory
+    mode: '0755'
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
     src: "{{ item.src }}"

--- a/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
@@ -42,6 +42,12 @@
     state: started
     enabled: true
 
+- name: Create directory for DHCP chrony server files
+  ansible.builtin.file:
+    path: /var/lib/dhcp
+    state: directory
+    mode: '0755'
+
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
     src: "{{ item.src }}"
@@ -49,7 +55,7 @@
     mode: a+x
   vars:
     server_dir: /var/lib/dhcp
-    chrony_helper_dir: /usr/lib/chrony
+    chrony_helper_dir: "{{ '/usr/libexec/chrony' if ansible_distribution_version is version('22.04', '>=') else '/usr/lib/chrony' }}"
   loop:
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->
The image-builder repository has two issues affecting chrony NTP configuration:

server_dir not created: The networkd-dispatcher scripts reference {{ server_dir }}/chrony.servers.$IFACE (e.g., /var/lib/dhcp/chrony.servers.$IFACE), but the directory is never created, causing script failures when writing DHCP-provided NTP servers.
Wrong chrony-helper path for Ubuntu 22.04 and later : The [vmware-ubuntu.yml](vscode-file://vscode-app/c:/Users/bmurugan/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml) file uses /usr/lib/chrony for chrony_helper_dir, but Ubuntu 22.04 moved this to /usr/libexec/chrony.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) y
- If adding a new provider, are you a representative of that provider? (y/n) NA

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
When we check for the chrony sources, it points to internet NTP servers instead of our local NTP servers in the enterprise. 
When we make the changes locally, it fixed the problem for us. 

$chronyc sources -v

  .-- Source mode  '^' = server, '=' = peer, '#' = local clock.
 / .- Source state '*' = current best, '+' = combined, '-' = not combined,
| /             'x' = may be in error, '~' = too variable, '?' = unusable.
||                                                 .- xxxx [ yyyy ] +/- zzzz
||      Reachability register (octal) -.           |  xxxx = adjusted offset,
||      Log2(Polling interval) --.      |          |  yyyy = measured offset,
||                                \     |          |  zzzz = estimated error.
||                                 |    |           \
MS Name/IP address         Stratum Poll Reach LastRx Last sample               
===============================================================================
^+ alphyn.canonical.com          2  10   377   933   +926us[ +926us] +/-   41ms
^+ prod-ntp-4.ntp1.ps5.cano>     2  10   377   586  +1090us[+1090us] +/-   53ms
^+ prod-ntp-3.ntp1.ps5.cano>     2  10   377   835   -637us[ -637us] +/-   51ms
^+ prod-ntp-5.ntp1.ps5.cano>     2  10   377   981   -506us[ -506us] +/-   52ms
^* lax2.us.ntp.li                2  10   377  1082   -476us[ -435us] +/-   35ms
^+ 24.144.88.190                 2  10   377   797  +6889us[+6889us] +/-   79ms
^+ 163-123-153-14.ip4.evals>     4  10   377    60  +1632us[+1632us] +/-   44ms
^+ 23.186.168.132                2  10   377   150   +225us[ +225us] +/-   56ms
-->
