### PR TITLE
fix package list on Debian for Outscale provider

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/outscale.yml
+++ b/images/capi/ansible/roles/providers/tasks/outscale.yml
@@ -8,5 +8,16 @@
     packages:
       - cloud-init
       - cloud-guest-utils
-      - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
+
+- name: Install Debian specific packages
+  ansible.builtin.apt:
+    name: cloud-initramfs-dyn-netconf
+    state: present
+  when: ansible_distribution == 'Debian'
+
+- name: Install Ubuntu specific packages
+  ansible.builtin.apt:
+    name: cloud-initramfs-copymods
+    state: present
+  when: ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
## Change description

This PR fixes the Ansible linter errors from #1851 for the Outscale provider.

Fixed Ansible linter violations in `images/capi/ansible/roles/providers/tasks/outscale.yml`:
- Capitalized task names (lines 13, 19)  
- Added newline at end of file

Original implementation by @lde in #1851, as suggested by maintainers in #1897.

- Is this change including a new Provider or a new OS? (y/n) **No**
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) **N/A**
- If adding a new provider, are you a representative of that provider? (y/n) **N/A**

## Related issues

Closes #1897  
Supersedes #1851

## Additional context

This PR continues the work from #1851 which was not completed. The original implementation was correct but failed CI due to trivial Ansible linting issues. All linter errors have now been fixed.