### PR TITLE
Update CAPC OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -18,8 +18,10 @@ aliases:
   image-builder-openstack-maintainers:
     - yankcrime
   image-builder-cloudstack-reviewers:
-    - rohityadavcloud
     - davidjumani
+    - vishesh92
+    - weizhouapache
+    - yadvr
   image-builder-scaleway-reviewers:
     - Tomy2e
     - Mia-Cross
@@ -66,9 +68,11 @@ aliases:
     - seanschneeweiss
     - tobiasgiese
   cluster-api-cloudstack-maintainers:
-    - rohityadavcloud
     - davidjumani
     - Pearl1594
+    - vishesh92
+    - weizhouapache
+    - yadvr
   cluster-api-vsphere-maintainers:
     - chrischdi
     - gab-satchi


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Updates OWNERS of Cluster API Provider CloudStack.
Updates Rohit's username from `rohityadavcloud` to `yadvr`.

cc:  @weizhouapache @yadvr