### PR TITLE
fix: update Azure build VM size to a more modern v2 generation

### DIFF
--- a/images/capi/packer/azure/azure-config.json
+++ b/images/capi/packer/azure/azure-config.json
@@ -5,5 +5,5 @@
   "containerd_wasm_shims_runtimes": "lunatic,slight,spin,wws",
   "subscription_id": "{{env `AZURE_SUBSCRIPTION_ID`}}",
   "use_azure_cli_auth": "{{env `USE_AZURE_CLI_AUTH`}}",
-  "vm_size": "Standard_B2ms"
+  "vm_size": "Standard_B2als_v2"
 }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Updates the VM used by the Azure build pipeline to a more modern and widely available v2 generation. B-series (v1) have been deprecated and have restricted availability, resulting in build failure in some regions.

Note that this will increase the cost of performing a build slightly. No exact match for the previous B2ms size is widely available.


## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

n/a

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
See https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/bv1-series?tabs=sizebasic and https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/retirement/retirement-overview#capacity-limited.