### PR TITLE
Add Kubernetes-version to the proxmox-template as a proxmox-VM-Tag

### DIFF
--- a/images/capi/packer/proxmox/packer.json.tmpl
+++ b/images/capi/packer/proxmox/packer.json.tmpl
@@ -48,6 +48,7 @@
       "ssh_password": "{{user `ssh_password`}}",
       "ssh_timeout": "2h",
       "ssh_username": "{{user `ssh_username`}}",
+      "tags": "{{ user `kubernetes_semver` }}",
       "template_name": "{{ user `artifact_name` }}",
       "type": "proxmox-iso",
       "unmount_iso": "{{user `unmount_iso`}}",


### PR DESCRIPTION
## Change description.
I do not want to add kubernetes version after creation of the template manually or write a script somewhat.
With this change its possible to use this [feature](https://doc.crds.dev/github.com/ionos-cloud/cluster-api-provider-proxmox/infrastructure.cluster.x-k8s.io/ProxmoxMachineTemplate/v1alpha1@v0.7.0#spec-template-spec-templateSelector-matchTags) on default to choose images by there kubernetes version. Which makes the cluster-api workflow on proxmox more straight forward. 

- Fixes 
#1762 

## Additional context
Tests will fail until this is merged and released
https://github.com/hashicorp/packer-plugin-proxmox/pull/340
