### PR TITLE
create ctr symlink after installation

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -196,6 +196,19 @@
     enabled: true
     state: restarted
 
+- name: Symlink cri-tools
+  ansible.builtin.file:
+    src: /usr/local/bin/{{ item }}
+    dest: /usr/bin/{{ item }}
+    mode: "0755"
+    state: link
+    force: true
+  loop:
+    - ctr
+    - crictl
+    - critest
+  when: ansible_os_family != "Flatcar"
+
 - name: Delete containerd tarball
   ansible.builtin.file:
     path: /tmp/{{ containerd_filename }}

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -31,19 +31,6 @@
 # as the cri-containerd tarball also includes crictl.
 - ansible.builtin.import_tasks: crictl-url.yml
 
-- name: Symlink cri-tools
-  ansible.builtin.file:
-    src: /usr/local/bin/{{ item }}
-    dest: /usr/bin/{{ item }}
-    mode: "0755"
-    state: link
-    force: true
-  loop:
-    - ctr
-    - crictl
-    - critest
-  when: ansible_os_family != "Flatcar"
-
 - name: Create kubelet default config file
   ansible.builtin.template:
     src: etc/sysconfig/kubelet


### PR DESCRIPTION
## Change description

This is an attempt at fixing an error that occurs when the [`url` task](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/kubernetes/tasks/main.yml#L27-L28) is called before a symbolic link to `/usr/local/bin/ctr` is [created](https://github.com/kubernetes-sigs/image-builder/blob/f390cca6073f239c2a3b1457ec7d9c2e2dfb3dd3/images/capi/ansible/roles/kubernetes/tasks/main.yml#L34). This task tries to execute `/usr/bin/ctr` before it is available in the path and it fails to build the image.

The issue was identified in the job `periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts` ([Prow job history](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts)), which is one of the recently reported jobs in the Kubernetes organization that have been failing for a long time. 

When building the image for `cluster-api-provider-gcp` with `kubernetes_source_type == "http"` and `kubernetes_cni_source_type == "http"`, the job outputs the following error:
```bash
"/bin/sh: 1: /usr/bin/ctr: not found"
```

A full log can be found [here](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-cluster-api-provider-gcp-make-conformance-main-ci-artifacts/2015133640157040640).

The proposed fix places the creation of the symlink right after `containerd` is installed. If this is not considered the correct approach, we can look for other alternatives to avoid calling tasks that invoke `/usr/bin/ctr` before it is available.

cc @justinsb @damdo @cpanato 

## Related issues

- Fixes #

## Additional context

This originated from @justinsb's investigation https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/1529#issuecomment-3755496281
