### PR TITLE
Install prereqs for new ADO build agents

### DIFF
--- a/images/capi/packer/azure/.pipelines/build-sig.yaml
+++ b/images/capi/packer/azure/.pipelines/build-sig.yaml
@@ -35,6 +35,15 @@ jobs:
       fi
     displayName: Check for Windows kube-proxy image
     condition: and(eq(variables['PREFLIGHT_CHECKS'], 'true'), eq(variables['OS'], 'Windows'))
+  - script: |
+      set -euo pipefail
+      if ! command -v az &> /dev/null; then
+        sudo tdnf install -y azure-cli
+      fi
+      if ! pip3 show pywinrm >/dev/null 2>&1; then
+        sudo pip3 install --disable-pip-version-check pywinrm==0.5.0
+      fi
+    displayName: Install prereqs on Azure Linux 3
   - task: AzureCLI@2
     displayName: Build SIG Image
     inputs:
@@ -47,7 +56,7 @@ jobs:
         [[ -n ${DEBUG:-} ]] && set -o xtrace
 
         # Generate locales properly on Azure Linux or ansible will complain
-        sudo tdnf -y install glibc-i18n
+        sudo tdnf -y install glibc-i18n make unzip
         sudo locale-gen.sh
         export LC_ALL=en_US.UTF-8
 

--- a/images/capi/packer/azure/.pipelines/clean-sig.yaml
+++ b/images/capi/packer/azure/.pipelines/clean-sig.yaml
@@ -30,6 +30,12 @@ jobs:
       echo "##vso[task.setvariable variable=SHARED_IMAGE_GALLERY_IMAGE_NAME]$SHARED_IMAGE_GALLERY_IMAGE_NAME"
       echo "##vso[task.setvariable variable=SHARED_IMAGE_GALLERY_IMAGE_VERSION]$SHARED_IMAGE_GALLERY_IMAGE_VERSION"
     displayName: Import variables from build SIG job
+  - script: |
+      set -euo pipefail
+      if ! command -v az &> /dev/null; then
+        sudo tdnf install -y azure-cli
+      fi
+    displayName: Install prereqs on Azure Linux 3
   - task: AzureCLI@2
     displayName: Clean up staging resources
     inputs:

--- a/images/capi/packer/azure/.pipelines/promote-sig.yaml
+++ b/images/capi/packer/azure/.pipelines/promote-sig.yaml
@@ -68,6 +68,12 @@ jobs:
       echo "##vso[task.setvariable variable=SHARED_IMAGE_GALLERY_IMAGE_VERSION]$SHARED_IMAGE_GALLERY_IMAGE_VERSION"
       echo "##vso[task.setvariable variable=TAGS]$TAGS"
     displayName: Import variables from build SIG job
+  - script: |
+      set -euo pipefail
+      if ! command -v az &> /dev/null; then
+        sudo tdnf install -y azure-cli
+      fi
+    displayName: Install prereqs on Azure Linux 3
   - task: AzureCLI@2
     displayName: Publish to community gallery
     inputs:


### PR DESCRIPTION
## Change description

Installs several prerequisites if necessary before building Azure SIG images.

This is needed because the build agents used to build CAPZ ref images were recently updated, but are now more bare-bones.

## Related issues

- Fixes #

## Additional context

I've tested this in-place on the pipeline and it works.