### PR TITLE
fix: handle missing secret-userdata.txt for MachinePool/ASG nodes

### DIFF
--- a/images/capi/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
+++ b/images/capi/ansible/roles/providers/files/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceEc2Kubernetes.py
@@ -84,6 +84,15 @@ class DataSourceEc2Kubernetes(DataSourceEc2.DataSourceEc2):
         )
         LOG.info("User-data before update:[\n%s]", self.userdata_raw)
         secret_userdata = "/etc/secret-userdata.txt"
+        # Check if secret-userdata.txt exists (written by boothook for MachineDeployment/ControlPlane nodes)
+        # For MachinePool (ASG), this file won't exist as userdata is passed directly via EC2 metadata
+        if not os.path.exists(secret_userdata):
+            LOG.info(
+                "Secret userdata file %s not found. Something might have failed or this is a MachinePool/ASG node."
+                "Using original userdata from EC2 metadata.",
+                secret_userdata,
+            )
+            return True
         # Get the boothook output, save it as user-data
         # TODO: work with upstream to put this somewhere more sensible like:
         # /var/lib/cloud/instances/{{v1.instance_id}}/ec2-kubernetes-userdata.txt


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Fixes #1917 by handling MachinePool/ASG nodes where userdata is passed directly
via EC2 metadata instead of being written to /etc/secret-userdata.txt by the
boothook. Previously the datasource would fail because it expected this file to exist.
The bug was introduced with this [commit](https://github.com/kubernetes-sigs/image-builder/commit/1b84f6144639952ea93e3a7b7ad04a9437a9e994#diff-b98d7ff8f45bbb3bdec9957f0403039792dc90770fbd607924f5a05f50994524)

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context

This may not be the most ideal fix as we are essentially just guessing that the reason the file is missing is the deployment type.
Suggestions are welcome