### PR TITLE
outscale: update base images to v2026-01-12

### DIFF
--- a/images/capi/packer/outscale/ubuntu-2204.json
+++ b/images/capi/packer/outscale/ubuntu-2204.json
@@ -3,5 +3,5 @@
   "distribution": "ubuntu",
   "distribution_release": "ubuntu",
   "distribution_version": "2204",
-  "image_name": "Ubuntu-22.04-2025-10-15"
+  "image_name": "Ubuntu-22.04-2026-01-12"
 }

--- a/images/capi/packer/outscale/ubuntu-2404.json
+++ b/images/capi/packer/outscale/ubuntu-2404.json
@@ -3,5 +3,5 @@
   "distribution": "ubuntu",
   "distribution_release": "ubuntu",
   "distribution_version": "2404",
-  "image_name": "Ubuntu-24.04-2025-10-15"
+  "image_name": "Ubuntu-24.04-2026-01-12"
 }


### PR DESCRIPTION
## Change description

Update Outscale base images to v2026-01-12

## Related issues

## Additional context
