### PR TITLE
Remove windows-2019 from default Azure e2e

### DIFF
--- a/docs/book/src/capi/providers/azure.md
+++ b/docs/book/src/capi/providers/azure.md
@@ -50,8 +50,8 @@ Confidential VMs require specific generation 2 OS images. The naming pattern of 
 # Ubuntu 24.04 LTS for Confidential VMs
 make build-azure-sig-ubuntu-2404-cvm
 
-# Windows 2019 with containerd for Confindential VMs
-make build-azure-sig-windows-2019-containerd-cvm
+# Windows 2022 with containerd for Confindential VMs
+make build-azure-sig-windows-2022-containerd-cvm
 ```
 
 ### Configuration

--- a/images/capi/azure_targets.sh
+++ b/images/capi/azure_targets.sh
@@ -1,4 +1,4 @@
-VHD_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 rhel-8 windows-2019-containerd windows-2022-containerd"
-SIG_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 rhel-8 windows-2019-containerd windows-2022-containerd windows-2025-containerd flatcar"
+VHD_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 rhel-8 windows-2022-containerd"
+SIG_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 rhel-8 windows-2022-containerd windows-2025-containerd flatcar"
 SIG_GEN2_TARGETS="ubuntu-2204 ubuntu-2404 azurelinux-3 flatcar"
-SIG_CVM_TARGETS="ubuntu-2204 ubuntu-2404 windows-2019-containerd windows-2022-containerd"
+SIG_CVM_TARGETS="ubuntu-2204 ubuntu-2404 windows-2022-containerd"


### PR DESCRIPTION
## Change description

Removes Azure -windows-2019 build targets from the default e2e list, since they're long-deprecated. The images can still be built through the `make` targets but it doesn't seem necessary to include them in PR e2e now.

## Related issues

- Fixes #

## Additional context

