### PR TITLE
Make py3_install more flexible

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -107,6 +107,9 @@ pip3_install() {
   ensure_py3
   if output=$(pip3 install --disable-pip-version-check --user "${@}" 2>&1); then
     echo "$output"
+  elif [[ $output == *"Can not perform a '--user' install"* ]]; then
+    >&2 echo "warning: '--user' install failed, retrying pip3 install without --user"
+    pip3 install --disable-pip-version-check "${@}"
   elif [[ $output == *"error: externally-managed-environment"* ]]; then
     >&2 echo "warning: externally-managed-environment, retrying pip3 install with --break-system-packages"
     pip3 install --disable-pip-version-check --user --break-system-packages "${@}"


### PR DESCRIPTION
## Change description

Adds fallback behavior for when `pip3 install --user` raises a specific error we've seen on (for example) Azure Linux.

## Related issues

- Fixes #
