### PR TITLE
Bump ansible to v2.16.16

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Note: ansible-core v2.16.x requires Python >= 3.10.
-_version_ansible_core="2.15.13"
+# Note: ansible-core v2.16 supports Python 3.10-3.12.
+_version_ansible_core="2.16.16"
 
 case "${OSTYPE}" in
 linux*)


### PR DESCRIPTION
## Change description

Updates ansible-core to [v2.16.16](https://pypi.org/project/ansible-core/2.16.16/), supporting Python 3.10-3.12.

## Related issues

See #1653 for prior art.

## Additional context

See also #1894. I think we can get there, but maybe in baby steps...
