### PR TITLE
fix: move extra_kernel_boot_params default variable from setup to sysprep role

### DIFF
--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -19,7 +19,6 @@ redhat_epel_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noa
 epel_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 rpms: ""
 extra_rpms: ""
-extra_kernel_boot_params: ""
 
 disable_public_repos: false
 external_binary_path: "{{ '/opt/bin' if ansible_os_family == 'Flatcar' else '/usr/local/bin' }}"

--- a/images/capi/ansible/roles/sysprep/defaults/main.yml
+++ b/images/capi/ansible/roles/sysprep/defaults/main.yml
@@ -17,3 +17,4 @@ pip_conf_file: ""
 remove_extra_repos: false
 flatcar_disable_autologin: false
 sysprep_require_grub_file: true
+extra_kernel_boot_params: ""


### PR DESCRIPTION
## Change description
Some users are experiencing an undefined variable error caused by the variable "extra_kernel_boot_params " being declared as a default for the wrong ansible role. 
With this PR I moved extra_kernel_boot_params  variable from setup role to sysprep role where this variable is used.

## Additional context
This is the [link](https://github.com/kubernetes-sigs/image-builder/commit/be8da68145f8516571ecf7edbe7da16e089a7aa8#diff-b2a18945cf178a8116d2523dc23d6284dacbe4443e055c522790aded29cb38b8R22) to the commit where the user commented about the issue described above.