### PR TITLE
Apply regkey for windows 2025

### DIFF
--- a/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
+++ b/images/capi/ansible/windows/roles/systemprep/tasks/main.yml
@@ -133,6 +133,16 @@
     type: dword
   when: distribution_version == "2022"
 
+# VPF changes to reduce lock contention
+- name: Apply networking fix for Windows 2025
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides
+    state: present
+    name: 520997518
+    data: 1
+    type: dword
+  when: distribution_version == "2025"
+
 # Apply HNS flags for fixes that need to be enabled via Registry
 # these eventually get turned on automatically and can be removed in future releases
 - name: Apply HNS control Flags 0x40 and 0x10 in 2022-11B patches


### PR DESCRIPTION
Windows 2025 tetst grid is not stable, due to some os level network related issue, this is to enable the feature/fix for it

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) ____
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
