### PR TITLE
fix: validate only configured wasm shims in goss tests

### DIFF
--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -10,27 +10,35 @@ command:
     stdout: []
     stderr: []
     timeout: 0
-{{if ne .Vars.containerd_wasm_shims_runtimes ""}}
+{{if contains "lunatic" .Vars.containerd_wasm_shims_runtimes}}
   containerd-shim-lunatic-v1:
     exit-status: 1
     stdout: [ ]
     stderr: ["io.containerd.lunatic.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
     timeout: 0
+{{end}}
+{{if contains "slight" .Vars.containerd_wasm_shims_runtimes}}
   containerd-shim-slight-v1:
     exit-status: 1
     stdout: [ ]
     stderr: ["io.containerd.slight.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
     timeout: 0
+{{end}}
+{{if contains "spin" .Vars.containerd_wasm_shims_runtimes}}
   containerd-shim-spin-v2:
     exit-status: 1
     stdout: [ ]
     stderr: ["io.containerd.spin.v2: InvalidArgument(\"Shim namespace cannot be empty\")"]
     timeout: 0
+{{end}}
+{{if contains "wws" .Vars.containerd_wasm_shims_runtimes}}
   containerd-shim-wws-v1:
     exit-status: 1
     stdout: [ ]
     stderr: ["io.containerd.wws.v1: InvalidArgument(\"Shim namespace cannot be empty\")"]
     timeout: 0
+{{end}}
+{{if ne .Vars.containerd_wasm_shims_runtimes ""}}
   grep -E 'io\.containerd\.(lunatic|slight|spin|wws)\.v' /etc/containerd/config.toml:
     exit-status: 0
     stdout: [ ]


### PR DESCRIPTION
Previously, if containerd_wasm_shims_runtimes was set to any non-empty value (e.g., "spin,slight"), goss would validate all 4 shims (lunatic, slight, spin, wws), causing failures when only a subset was installed.

This change validates each shim individually based on whether it appears in the containerd_wasm_shims_runtimes variable.

Fixes #1664

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) ____
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
