### PR TITLE
Upgrade CentOS 9 Stream base image on qemu to newer version.

### DIFF
--- a/images/capi/packer/qemu/qemu-centos-9.json
+++ b/images/capi/packer/qemu/qemu-centos-9.json
@@ -10,9 +10,9 @@
   "distro_version": "9",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
   "guest_os_type": "centos9-64",
-  "iso_checksum": "01126d2baac31f520e5b6f20ef0a2d8f2de26c8ffdebbe3ddd0eea99f2c7a765",
+  "iso_checksum": "2282a8ea8b98188d30958b2274548394cc854e0eb64d25abefc65b1d44e2aebf",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20240304.0-x86_64-dvd1.iso",
+  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20260209.0-x86_64-dvd1.iso",
   "os_display_name": "CentOS 9 Stream",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"


### PR DESCRIPTION

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

Old CentOS image is not available on the source mirror. Update the image to the latest available.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) y
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) y
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

- Fixes #

## Additional context

This is a preparation to move to CentOS 10 later ensuring that all tests match both use cases. 
