### PR TITLE
fix: goss validation openstack flatcar

### DIFF
--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -190,6 +190,8 @@ flatcar:
     command:
   hcloud:
     command:
+  openstack:
+    command:
 photon:
   common-service:
     apparmor:


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
Currently the goss validation is failing for openstack flatcar. Adding this change fixes the issue.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) ____
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
log output:
```
==> openstack: 2026/02/19 07:50:45 could not read json data in goss/goss-command.yaml: template: test:113:24: executing "test" at <index .Vars .Vars.OS .Vars.PROVIDER "command">: error calling index: index of nil pointer
```