### PR TITLE
Bump ansible-lint to v25.2.0

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -212,7 +212,7 @@ IMAGE_NAME ?= cluster-node-image-builder
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
 ARCH ?= amd64
-BASE_IMAGE ?= docker.io/library/ubuntu:jammy
+BASE_IMAGE ?= docker.io/library/ubuntu:24.04
 BUILDKIT_SYNTAX ?= docker/dockerfile:1.14
 
 ## --------------------------------------
@@ -1055,19 +1055,19 @@ validate-all: ## Validates the Packer config for all build targets
 lint: ## Runs linters on image-builder code
 sh_files = $(shell find . -type f -name "*.sh")
 lint: deps-lint
-	ansible-lint ansible/
+	ansible-lint --project-dir . ansible/
 # ignore error code since shellcheck exits with Error 1 if problems are found despite running properly
 	-@for f in $(sh_files); do (shellcheck -x $$f); done
 
 .PHONY: lint-fix
 lint-fix: ## Runs linters on image-builder code and fixes issues
 lint-fix: deps-lint
-	ansible-lint --fix=all ansible/
+	ansible-lint --fix=all --project-dir . ansible/
 
 .PHONY: lint-ignore
 lint-ignore: ## Runs linters on image-builder code and creates an "ignore" file
 lint-ignore: deps-lint
-	ansible-lint --generate-ignore ansible/
+	ansible-lint --generate-ignore --project-dir . ansible/
 
 ## --------------------------------------
 ## Clean targets

--- a/images/capi/hack/ensure-ansible-lint.sh
+++ b/images/capi/hack/ensure-ansible-lint.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 source hack/utils.sh
 
-_version="6.21.1"
+_version="25.2.0"
 
 # Change directories to the parent directory of the one in which this
 # script is located.

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -49,7 +49,7 @@ fi
 echo ${ansible_version[*]}
 
 ansible-galaxy collection install \
-  'community.general:<12.0.0' \
-  ansible.posix \
+  'community.general:<=12.0.0' \
+  'ansible.posix' \
   'ansible.windows:>=1.7.0' \
   community.windows


### PR DESCRIPTION
## Change description
Upgrade ansible-lint to a newer version 25.2.0.

There're some rule violations with the new version, some of these are easily fixable, while others should be added to the ignore file.  Do you think these changes should be made in this PR or in a dedicated one? @drew-viles @mboersma 
```
# Rule Violation Summary
  6 command-instead-of-module profile:basic tags:command-shell,idiom
 11 command-instead-of-shell profile:basic tags:command-shell,idiom
  4 jinja profile:basic tags:formatting
  3 schema profile:basic tags:core
 89 name profile:basic tags:idiom
  3 name profile:basic tags:idiom
 86 var-naming profile:basic tags:idiom
 10 yaml profile:basic tags:formatting,yaml
  1 name profile:basic tags:idiom
  5 package-latest profile:basic tags:idempotency
  1 ignore-errors profile:basic tags:unpredictability
 60 no-changed-when profile:basic tags:command-shell,idempotency
```

## Related issues

- Fixes #1928

This is a copy of #1935 that was closed by mistake.