### PR TITLE
fix: Update packer vsphere plugin location for ova

### DIFF
--- a/images/capi/packer/ova/config.pkr.hcl
+++ b/images/capi/packer/ova/config.pkr.hcl
@@ -3,7 +3,7 @@ packer {
   required_plugins {
     vsphere = {
       version = ">= 1.4.2"
-      source  = "github.com/hashicorp/vsphere"
+      source  = "github.com/vmware/vsphere"
     }
   }
 }


### PR DESCRIPTION
## Change description
This PR updates the packer vsphere plugin location.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1940

## Additional context
Previously vpshere plugin used for OVA building resided under hashicorp organization. However due to recent changes, that has been handed/moved to vmware organization. To adjust this, we need to update the plugin url.