### PR TITLE
hack: ensure py3 user local bin is checked and used accordingly

### DIFF
--- a/images/capi/.gitignore
+++ b/images/capi/.gitignore
@@ -8,6 +8,9 @@
 manifest.json
 **.DS_Store
 
+# Ignore script fetched to bootstrap pip3
+get-pip.py
+
 # Goss test droppings
 debug-goss-spec.yaml
 goss-spec.yaml

--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -35,8 +35,11 @@ if ! command -v ansible >/dev/null 2>&1; then
     ensure_py3_bin ansible-playbook
 fi
 
+[ -f "$HOME/.local/bin/ansible" ] && py3_ansible_cmd="$HOME/.local/bin/ansible"
+[ -f "$HOME/.local/bin/ansible-galaxy" ] && py3_ansible_galaxy_cmd="$HOME/.local/bin/ansible-galaxy"
+
 ansible_version=""
-IFS=" " read -ra ansible_version <<< "$(ansible --version)"
+IFS=" " read -ra ansible_version <<< "$($py3_ansible_cmd --version)"
 if [[ "${_version_ansible_core}" != $(echo -e "${_version_ansible_core}\n${ansible_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${ansible_version[2]}" != "devel" ]]; then
   cat <<EOF
 Detected ansible version: ${ansible_version[*]}.
@@ -48,7 +51,7 @@ fi
 
 echo ${ansible_version[*]}
 
-ansible-galaxy collection install \
+$py3_ansible_galaxy_cmd collection install \
   'community.general:<12.0.0' \
   ansible.posix \
   'ansible.windows:>=1.7.0' \

--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -22,6 +22,7 @@ set -o pipefail
 
 # **DO NOT** change the Packer version unless it is available under MPL v2.0.
 _version="1.9.5"
+_packer_dir="$HOME/.local/bin"
 
 # Change directories to the parent directory of the one in which this
 # script is located.
@@ -59,8 +60,8 @@ if (command -v packer) >/dev/null 2>&1; then
   fi
 fi
 
-echo "Installing packer v${_version} in .local/bin"
-mkdir -p .local/bin && cd .local/bin
+echo "Installing packer v${_version} in ${_packer_dir}"
+mkdir -p $_packer_dir 2>/dev/null && cd $_packer_dir
 
 SED="sed"
 if command -v gsed >/dev/null; then
@@ -81,4 +82,4 @@ ${SED} -i -n "/${HOSTOS}_${HOSTARCH}/p" "${_chkfile}"
 checksum_sha256 "${_chkfile}"
 unzip -o "${_zipfile}"
 rm -f "${_chkfile}" "${_zipfile}"
-echo "'packer' has been installed to $(pwd), make sure this directory is in your \$PATH"
+echo "'packer' has been installed to ${_packer_dir}, make sure this directory is in your \$PATH"

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -17,6 +17,12 @@
 # Note: ansible-core v2.16 supports Python 3.10-3.12.
 _version_ansible_core="2.16.16"
 
+# Flags for checking locally available Python commands installed via "pip3 install --user ..."
+py3_ansible_cmd="ansible"
+py3_ansible_galaxy_cmd="ansible-galaxy"
+py3_local_user_bin="false"
+py3_pip_cmd="pip3"
+
 case "${OSTYPE}" in
 linux*)
   HOSTOS=linux
@@ -80,11 +86,12 @@ get_shasum() {
 ensure_py3_bin() {
   # If given executable is not available, the user Python bin dir is not in path
   # This function assumes the executable to be checked was installed with
-  # pip3 install --user ...
-  if ! command -v "${1}" >/dev/null 2>&1; then
+  #     $ pip3 install --user ...
+  # Therefore it also checks binaries under $HOME/.local/bin
+  if ! PATH="$HOME/.local/bin:$PATH" command -v "${1}" >/dev/null 2>&1; then
     echo "User's Python3 binary directory must be in \$PATH" 1>&2
     echo "Location of package is:" 1>&2
-    pip3 show --disable-pip-version-check ${2:-$1} | grep "Location"
+    $py3_pip_cmd show --disable-pip-version-check ${2:-$1} | grep "Location"
     echo "\$PATH is currently: $PATH" 1>&2
     exit 1
   fi
@@ -95,21 +102,33 @@ ensure_py3() {
     echo "python3 binary must be in \$PATH" 1>&2
     exit 1
   fi
-  if ! command -v pip3 >/dev/null 2>&1; then
-    curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-    python3 get-pip.py --user
-    rm -f get-pip.py
+  if ! command -v $py3_pip_cmd >/dev/null 2>&1; then
+    [ ! -f get-pip.py ] && curl -SsL https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    if output=$(python3 get-pip.py --user 2>&1); then
+        echo $output
+    elif [[ $output == *"error: externally-managed-environment"* ]]; then
+	>&2 echo "warning: externally-managed-environment, retrying pip3 install with --break-system-packages if we are not running as root."
+	if [ "$(whoami)" != "root" ]; then
+	    output=$(python3 get-pip.py --user --break-system-packages 2>&1)
+	    >2& echo $output
+	fi
+    else
+	>&2 echo "$output"
+	exit 1
+    fi
+    [ -f "$HOME/.local/bin/pip3" ] && py3_pip_cmd="$HOME/.local/bin/pip3"
     ensure_py3_bin pip3
   fi
 }
 
 pip3_install() {
   ensure_py3
-  if output=$(pip3 install --disable-pip-version-check --user "${@}" 2>&1); then
+  [ "py3_local_user_bin" ] && py3_pip_cmd="$HOME/.local/bin/pip3"
+  if output=$($py3_pip_cmd install --disable-pip-version-check --user "${@}" 2>&1); then
     echo "$output"
   elif [[ $output == *"error: externally-managed-environment"* ]]; then
     >&2 echo "warning: externally-managed-environment, retrying pip3 install with --break-system-packages"
-    pip3 install --disable-pip-version-check --user --break-system-packages "${@}"
+    $py3_pip_cmd install --disable-pip-version-check --user --break-system-packages "${@}"
   else
     >&2 echo "$output"
     exit 1

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -123,7 +123,7 @@ ensure_py3() {
 
 pip3_install() {
   ensure_py3
-  [ "py3_local_user_bin" ] && py3_pip_cmd="$HOME/.local/bin/pip3"
+  ( "$py3_local_user_bin" ) && py3_pip_cmd="$HOME/.local/bin/pip3"
   if output=$($py3_pip_cmd install --disable-pip-version-check --user "${@}" 2>&1); then
     echo "$output"
   elif [[ $output == *"error: externally-managed-environment"* ]]; then


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

by merging these changes, we:
  * ignore artifact downloaded to bootstrap `pip3` under `capi/` in git;
  *  apply changes to allow `make deps` to get a bit further without depending on root privileges;
  * verify if binary is available under `$HOME/.local/bin`, once `pip3_install` used --user parameter already;
  * check that we are NOT running as 'root' before using `--break-system-packages` with `pip3` (not done before);
  * set `ansible` commands as variables, respecting local PATH under `$HOME/.local/bin` if binary exists;
  * get `packer` to be installed under `$HOME/.local/bin` to get a sharp and consistent use of `$PATH`.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
are these changes related to new provider or OS?

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

no issues or PR are affected by these changes

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

there's no need to run `make deps` with **root** privileges. therefore the possibility of installing local user binaries was taking to consideration here.

> tested on Linux and macOS

on top of that, the code in upstream repository would be taking care of setting up dependencies for end users in a more convenient way -- e.g.: they would no longer need additional steps to install `pip3` or `ansible` using `sudo`.

### Next steps

should this be merged:
  - a minor additional documentation should be updated;
  - mention easier way to get dependencies installed and make better use of `PATH` while building images;
  - document the usage of `PATH=$HOME/.local/bin:$PATH make ...`