### PR TITLE
⬆️ Upgrade ContainerD (1.7 -> 2.2) & Runc Version (1.2 -> 1.3)

### DIFF
--- a/images/capi/ansible/roles/containerd/defaults/main.yml
+++ b/images/capi/ansible/roles/containerd/defaults/main.yml
@@ -19,5 +19,5 @@ containerd_baseurl: https://github.com/containerd/containerd/releases/download/v
 containerd_filename: "containerd-{{ containerd_version }}-{{ system }}-{{ arch }}.tar.gz"
 containerd_url: "{{ containerd_baseurl }}/{{ containerd_filename }}"
 containerd_runc_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ arch }}"
-runc_version: "1.2.3"
+runc_version: "1.3.4"
 containerd_runc_checksum_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.sha256sum"

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -3,6 +3,6 @@
   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
   "containerd_gvisor_runtime": "false",
   "containerd_gvisor_version": "latest",
-  "containerd_version": "1.7.29",
-  "runc_version": "1.2.8"
+  "containerd_version": "2.2.2",
+  "runc_version": "1.3.4"
 }

--- a/images/capi/packer/config/ppc64le/containerd.json
+++ b/images/capi/packer/config/ppc64le/containerd.json
@@ -1,4 +1,4 @@
 {
-  "containerd_sha256": "b2d4e44946e55a10835a327cbd98c0c2063011bbdebb95ef8c5e5677312f1d29",
-  "containerd_version": "1.7.25"
+  "containerd_sha256": "8f7a8190f2a635cd0e5580a131408a275ba277f7a04edffba4a4005960093987",
+  "containerd_version": "2.2.2"
 }

--- a/images/capi/packer/goss/goss-command.yaml
+++ b/images/capi/packer/goss/goss-command.yaml
@@ -198,25 +198,65 @@ command:
     - "{{.Vars.containerd_version}}"
     timeout: 30000
   {{ if (semverCompare ">=2.0.0" .Vars.containerd_version) }}
-  Correct Containerd config:
-    exec: "\"/Program Files/containerd/containerd.exe\" config dump"
+  Correct Containerd sandbox config:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'sandbox = \\\"{{.Vars.pause_image}}\\\"'\""
     exit-status: 0
     stdout:
     - "sandbox = \"{{.Vars.pause_image}}\""
+    timeout: 30000
+  Correct Containerd CNI conf_dir:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'conf_dir = \\\"C:/etc/cni/net.d\\\"'\""
+    exit-status: 0
+    stdout:
     - "conf_dir = \"C:/etc/cni/net.d\""
+    timeout: 30000
+  Correct Containerd CNI bin_dir:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'bin_dir = \\\"C:/opt/cni/bin\\\"'\""
+    exit-status: 0
+    stdout:
     - "bin_dir = \"C:/opt/cni/bin\""
+    timeout: 30000
+  Correct Containerd root:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'root = \\\"C:\\\\ProgramData\\\\containerd\\\\root\\\"'\""
+    exit-status: 0
+    stdout:
     - "root = \"C:\\\\ProgramData\\\\containerd\\\\root\""
+    timeout: 30000
+  Correct Containerd state:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'state = \\\"C:\\\\ProgramData\\\\containerd\\\\state\\\"'\""
+    exit-status: 0
+    stdout:
     - "state = \"C:\\\\ProgramData\\\\containerd\\\\state\""
     timeout: 30000
   {{ else }}
-  Correct Containerd config:
-    exec: "\"/Program Files/containerd/containerd.exe\" config dump"
+  Correct Containerd sandbox config:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'sandbox_image = \\\"{{.Vars.pause_image}}\\\"'\""
     exit-status: 0
     stdout:
     - "sandbox_image = \"{{.Vars.pause_image}}\""
+    timeout: 30000
+  Correct Containerd CNI conf_dir:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'conf_dir = \\\"C:/etc/cni/net.d\\\"'\""
+    exit-status: 0
+    stdout:
     - "conf_dir = \"C:/etc/cni/net.d\""
+    timeout: 30000
+  Correct Containerd CNI bin_dir:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'bin_dir = \\\"C:/opt/cni/bin\\\"'\""
+    exit-status: 0
+    stdout:
     - "bin_dir = \"C:/opt/cni/bin\""
+    timeout: 30000
+  Correct Containerd root:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'root = \\\"C:\\\\ProgramData\\\\containerd\\\\root\\\"'\""
+    exit-status: 0
+    stdout:
     - "root = \"C:\\\\ProgramData\\\\containerd\\\\root\""
+    timeout: 30000
+  Correct Containerd state:
+    exec: "powershell -command \"Get-Content 'C:\\Program Files\\containerd\\config.toml' | Select-String -SimpleMatch 'state = \\\"C:\\\\ProgramData\\\\containerd\\\\state\\\"'\""
+    exit-status: 0
+    stdout:
     - "state = \"C:\\\\ProgramData\\\\containerd\\\\state\""
     timeout: 30000
   {{ end }}


### PR DESCRIPTION
It's my first contribution, please double-check.

Upgrade of ContainerD is mandatory for Kubernetes 1.36

https://kubernetes.io/blog/2025/08/27/kubernetes-v1-34-release/#kubernetes-to-end-containerd-1-x-support-in-v1-36

The 2.2 release of ContainerD is not LTS. We will be able to upgrade to 2.3 later (maybe in May 2026) once the LTS is out.

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? No
- If yes, has the Provider/OS matrix been updated in the readme? No
- If adding a new provider, are you a representative of that provider? No

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #1891 

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
```
dev007-control-plane-2v2ql:~# containerd --version
containerd github.com/containerd/containerd/v2 v2.2.2

dev007-control-plane-2v2ql:~# kubectl get no
NAME                                             STATUS   ROLES           AGE   VERSION
dev007-control-plane-2v2ql                       Ready    control-plane   19m   v1.34.5
dev007-control-plane-fswz7                       Ready    control-plane   30m   v1.34.5
dev007-control-plane-xcpmn                       Ready    control-plane   23m   v1.34.5
dev007-workers-defaults-lnnkg-qfhbs    Ready    <none>          16m   v1.34.5
dev007-workers-defaults-lnnkg-tsbqm    Ready    <none>          16m   v1.34.5
dev007-workers-defaults-xq2lc-llvfp   Ready    <none>          16m   v1.34.5
dev007-workers-defaults-xq2lc-pz6tp   Ready    <none>          16m   v1.34.5
```

config.toml

```
version = 3
root = "/srv/data"

[plugins]
  [plugins."io.containerd.cri.v1.images"]
    [plugins."io.containerd.cri.v1.images".registry]
      config_path = "/etc/containerd/certs.d"

  [plugins."io.containerd.cri.v1.runtime"]
    [plugins."io.containerd.cri.v1.runtime".containerd]
      [plugins."io.containerd.cri.v1.runtime".containerd.runtimes]
        [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]
          runtime_type = "io.containerd.runc.v2"
          [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc.options]
            SystemdCgroup = true
```