### PR TITLE
Fix Windows failure caused by WinRM connection reset

### DIFF
--- a/images/capi/ansible/windows/ansible_winrm.ps1
+++ b/images/capi/ansible/windows/ansible_winrm.ps1
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file is from packer documentation: 
+# This file is from packer documentation:
 # https://www.packer.io/docs/provisioners/ansible.html#winrm-communicator
 # https://www.packer.io/docs/builders/amazon/ebs#connecting-to-windows-instances-using-winrm
 
@@ -43,6 +43,12 @@ cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
 cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`"5986`";Hostname=`"packer`";CertificateThumbprint=`"$($Cert.Thumbprint)`"}"
 cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
 cmd.exe /c netsh firewall add portopening TCP 5986 "Port 5986"
-cmd.exe /c net stop winrm
 cmd.exe /c sc config winrm start= auto
-cmd.exe /c net start winrm
+
+# Restart WinRM via a scheduled task so the current session can finish
+# cleanly before the service cycles. This prevents Packer's WinRM
+# connection (which is running this script) from being severed mid-flight.
+$taskAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-Command Restart-Service winrm -Force"
+$taskTrigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddSeconds(5))
+Register-ScheduledTask -TaskName "RestartWinRM" -Action $taskAction -Trigger $taskTrigger -User "SYSTEM" -RunLevel Highest -Force
+write-output "Scheduled WinRM restart in 5 seconds"


### PR DESCRIPTION
## Change description

In the Azure GH workflow, Windows SIG image builds fail during the Packer provisioning phase with "connection reset by peer".

Probable root cause: the ansible_winrm.ps1 script calls `net stop winrm` / `net start winrm` synchronously, which severs the WinRM session that Packer is using to execute the script. With Packer 1.9.5, the built-in WinRM communicator does not recover from this mid-script connection loss.

This change replaces the synchronous net stop/net start with a scheduled task that restarts the WinRM service 5 seconds after the script completes. This allows the script to return cleanly to Packer before the service cycles. The existing pause_before: "15s" on the subsequent Ansible provisioner provides additional time for WinRM to come back up with the new configuration.

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
