### PR TITLE
Bump ansible to v2.16.18

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Note: ansible-core v2.16 supports Python 3.10-3.12.
-_version_ansible_core="2.16.16"
+_version_ansible_core="2.16.18"
 
 case "${OSTYPE}" in
 linux*)


### PR DESCRIPTION
## Change description

Updates ansible-core to [v2.16.18](https://pypi.org/project/ansible-core/2.16.18/), supporting Python 3.10-3.12.

## Related issues

See #1925 for prior art.

## Additional context

See also #1894. I think we can get there, but maybe in baby steps...
