### PR TITLE
Bump ansible to v2.18.15

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/redhat.yml
+++ b/images/capi/ansible/roles/containerd/tasks/redhat.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 - name: Install libseccomp package
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: libseccomp
     state: present
     lock_timeout: 60

--- a/images/capi/ansible/roles/kubernetes/tasks/azurelinux.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/azurelinux.yml
@@ -21,7 +21,7 @@
     gpgkey: "{{ kubernetes_rpm_gpg_key }}"
 
 - name: Install Kubernetes
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     allow_downgrade: true
     state: present

--- a/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
@@ -21,7 +21,7 @@
     gpgkey: "{{ kubernetes_rpm_gpg_key }}"
 
 - name: Install Kubernetes
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     allow_downgrade: true
     state: present

--- a/images/capi/ansible/roles/providers/tasks/awscliv2.yml
+++ b/images/capi/ansible/roles/providers/tasks/awscliv2.yml
@@ -16,7 +16,7 @@
   when: ansible_os_family == "Flatcar"
 
 - name: Install AWS CLI prequisites
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name:
       - gnupg
       - unzip

--- a/images/capi/ansible/roles/providers/tasks/googlecompute.yml
+++ b/images/capi/ansible/roles/providers/tasks/googlecompute.yml
@@ -53,12 +53,12 @@
         gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
         EOM
     - name: Install google-cloud-cli package
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: google-cloud-cli
         state: present
 
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/providers/tasks/hcloud.yml
+++ b/images/capi/ansible/roles/providers/tasks/hcloud.yml
@@ -37,7 +37,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:
@@ -60,7 +60,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Install CSI prerequisites on RedHat
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/providers/tasks/nutanix-redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/nutanix-redhat.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:
@@ -22,7 +22,7 @@
       - cloud-utils-growpart
 
 - name: Install CAPX prerequisites
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/providers/tasks/proxmox.yml
+++ b/images/capi/ansible/roles/providers/tasks/proxmox.yml
@@ -26,7 +26,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -26,7 +26,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/providers/tasks/raw.yml
+++ b/images/capi/ansible/roles/providers/tasks/raw.yml
@@ -26,7 +26,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
@@ -14,7 +14,7 @@
 
 ---
 - name: Install cloud-init packages
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:
@@ -31,7 +31,7 @@
     cloud_init_version: "{{ ansible_facts.packages['cloud-init'][0].version }}"
 
 - name: Install python2 pip
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ packages }}"
     state: present
   vars:

--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -33,7 +33,7 @@
   when: packer_builder_type.startswith('amazon')
 
 - name: Install EPEL package
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: epel-release
     state: present
   when: packer_builder_type.startswith('amazon')
@@ -45,7 +45,7 @@
   when: epel_rpm_gpg_key != "" and not packer_builder_type.startswith('amazon') and not packer_builder_type.startswith('scaleway')
 
 - name: Add epel repo
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ redhat_epel_rpm }}"
     state: present
     lock_timeout: 60
@@ -54,19 +54,19 @@
 - ansible.builtin.import_tasks: rpm_repos.yml
 
 - name: Perform a yum update
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "*"
     state: latest
     lock_timeout: 60
 
 - name: Install baseline dependencies
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ rpms }}"
     state: present
     lock_timeout: 60
 
 - name: Install extra rpms
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ extra_rpms.split() }}"
     state: present
     lock_timeout: 60

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -60,7 +60,7 @@
       ansible.builtin.command: subscription-manager clean
 
 - name: Remove yum package caches
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     autoremove: true
     lock_timeout: 60
 

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Note: ansible-core v2.16 supports Python 3.10-3.12.
-_version_ansible_core="2.16.18"
+# Note: ansible-core v2.18 supports Python 3.11-3.13.
+_version_ansible_core="2.18.15"
 
 case "${OSTYPE}" in
 linux*)


### PR DESCRIPTION
## Change description

Updates ansible-core to [v2.18.15](https://pypi.org/project/ansible-core/2.18.15/), supporting Python 3.11-3.13.

## Related issues

See #1925 for prior art.

## Additional context

See also #1894. I think we can get there, but maybe in baby steps...
