### PR TITLE
set default ubuntu repos for setup role

### DIFF
--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -19,6 +19,8 @@ redhat_epel_rpm: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noa
 epel_rpm_gpg_key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 rpms: ""
 extra_rpms: ""
+ubuntu_repo: "http://us.archive.ubuntu.com/ubuntu/"
+ubuntu_security_repo: "http://security.ubuntu.com/ubuntu/"
 
 disable_public_repos: false
 external_binary_path: "{{ '/opt/bin' if ansible_os_family == 'Flatcar' else '/usr/local/bin' }}"


### PR DESCRIPTION
## Change description
Adds default values to the Ansible vars added in #1961

## Additional context
These are only available to Ansible because the templates pass them in via ansible_common_vars. Set defaults so this role doesn't depend on the specifics of the build pipeline.

We maintain custom build targets that reuse some of the existing Ansible roles. Our templates are HCL based though, and can't make use of the JSON-based common var files (which are how these values are currently passed to Ansible.) This PR just makes the setup role fully self-contained and agnostic of how it's executed.