### PR TITLE
Migrate bare ansible_* facts to ansible_facts[] dict form

### DIFF
--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -15,6 +15,7 @@
 [defaults]
 remote_tmp = /tmp/.ansible
 display_skipped_hosts = False
+inject_facts_as_vars = False
 
 [ssh_connection]
 pipelining = False

--- a/images/capi/ansible/node.yml
+++ b/images/capi/ansible/node.yml
@@ -20,7 +20,7 @@
     node_custom_roles_post: ""
     custom_role_names: ""
     system: linux
-    arch_uname: "{{ ansible_architecture }}"
+    arch_uname: "{{ ansible_facts['architecture'] }}"
     arch: "{{ {'x86_64': 'amd64', 'amd64': 'amd64', 'aarch64': 'arm64', 'arm64': 'arm64', 'ppc64le': 'ppc64le'}.get(arch_uname, 'unsupported') }}"
 
   tasks:

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -14,15 +14,15 @@
 ---
 - name: Import Debian containerd tasks
   ansible.builtin.import_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Import RedHat containerd tasks
   ansible.builtin.import_tasks: redhat.yml
-  when: ansible_os_family in ["Common Base Linux Mariner", "Microsoft Azure Linux", "RedHat"]
+  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux", "RedHat"]
 
 - name: Import Photon containerd tasks
   ansible.builtin.import_tasks: photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+  when: ansible_facts['os_family'] == "VMware Photon OS"
 
 # TODO(vincepri): Use deb/rpm packages once available.
 # See https://github.com/containerd/containerd/issues/1508 for context.
@@ -73,7 +73,7 @@
     dest: "{{ containerd_prefix | default('/usr/local') }}"
     extra_opts:
       - --no-overwrite-dir
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Copy containerd.service to /etc/systemd/system
   ansible.builtin.copy:
@@ -88,7 +88,7 @@
     src: /tmp/runc
     dest: /usr/local/sbin/runc
     mode: "0755"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 # Install containerd Wasm shims specified in a comma-separated string. Known runtimes are 'lunatic', 'slight', 'spin', and 'wws'.
 - name: Unpack containerd-wasm-shims
@@ -98,7 +98,7 @@
     dest: "{{ sysusr_prefix }}/bin"
     extra_opts:
       - --no-overwrite-dir
-  when: ansible_os_family != "Flatcar" and (containerd_wasm_shims_runtimes | length > 0)
+  when: ansible_facts['os_family'] != "Flatcar" and (containerd_wasm_shims_runtimes | length > 0)
   loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"
 
 - name: Unpack containerd for Flatcar to /opt/bin
@@ -106,7 +106,7 @@
     remote_src: true
     src: /tmp/{{ containerd_filename }}
     dest: "{{ containerd_prefix | default('/opt') }}"
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Copy runc to /opt/bin
   ansible.builtin.copy:
@@ -114,7 +114,7 @@
     src: /tmp/runc
     dest: /opt/bin/runc
     mode: "0755"
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 # Install containerd Wasm shims specified in a comma-separated string. Known runtimes are 'lunatic', 'slight', 'spin', and 'wws'.
 - name: Unpack containerd-wasm-shims for Flatcar to /opt/bin
@@ -124,7 +124,7 @@
     dest: "{{ sysusr_prefix }}/bin"
     extra_opts:
       - --no-overwrite-dir
-  when: ansible_os_family == "Flatcar" and (containerd_wasm_shims_runtimes | length > 0)
+  when: ansible_facts['os_family'] == "Flatcar" and (containerd_wasm_shims_runtimes | length > 0)
   loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"
 
 - name: Create unit file directory
@@ -138,7 +138,7 @@
     dest: /etc/systemd/system/containerd.service.d/10-opt-bin-custom.conf
     src: etc/systemd/system/containerd-flatcar.conf
     mode: "0600"
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Create containerd memory pressure drop-in file
   ansible.builtin.template:
@@ -157,7 +157,7 @@
     dest: /etc/systemd/system/containerd.service.d/limit-nofile.conf
     src: etc/systemd/system/containerd.service.d/limit-nofile.conf
     mode: "0644"
-  when: ansible_os_family in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux"]
 
 - name: Create containerd http proxy conf file if needed
   ansible.builtin.template:
@@ -210,7 +210,7 @@
     - ctr
     - crictl
     - critest
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Delete containerd tarball
   ansible.builtin.file:
@@ -237,11 +237,11 @@
 - name: Download runsc for gvisor
   ansible.builtin.get_url:
     dest: "{{ sysusr_prefix }}/bin/{{ item }}"
-    url: https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_architecture }}/{{ item }}
+    url: https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_facts['architecture'] }}/{{ item }}
     mode: "0755"
     owner: root
     group: root
-    checksum: sha512:https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_architecture }}/{{ item }}.sha512
+    checksum: sha512:https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_facts['architecture'] }}/{{ item }}.sha512
   loop:
     - runsc
     - containerd-shim-runsc-v1

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -241,7 +241,8 @@
     mode: "0755"
     owner: root
     group: root
-    checksum: sha512:https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_facts['architecture'] }}/{{ item }}.sha512
+    checksum: >-
+      sha512:https://storage.googleapis.com/gvisor/releases/release/{{ containerd_gvisor_version }}/{{ ansible_facts['architecture'] }}/{{ item }}.sha512
   loop:
     - runsc
     - containerd-shim-runsc-v1

--- a/images/capi/ansible/roles/ecr_credential_provider/tasks/main.yaml
+++ b/images/capi/ansible/roles/ecr_credential_provider/tasks/main.yaml
@@ -37,7 +37,7 @@
   block:
     - name: Ensure kubelet config exists
       ansible.builtin.stat:
-        path: "{{ '/etc/default/kubelet' if ansible_os_family == 'Debian' else '/etc/sysconfig/kubelet' }}"
+        path: "{{ '/etc/default/kubelet' if ansible_facts['os_family'] == 'Debian' else '/etc/sysconfig/kubelet' }}"
       register: kubelet_config
       failed_when: not kubelet_config.stat.exists
 
@@ -45,6 +45,6 @@
       when: kubelet_config.stat.exists
       ansible.builtin.shell: |
         set -e -o pipefail
-        sed -Ei 's|^(KUBELET_EXTRA_ARGS.*)|\1 --image-credential-provider-config=/var/usr/ecr-credential-provider/ecr-credential-provider-config --image-credential-provider-bin-dir={{ ecr_credential_provider_install_dir }}|' {{ '/etc/default/kubelet' if ansible_os_family == 'Debian' else '/etc/sysconfig/kubelet' }}
+        sed -Ei 's|^(KUBELET_EXTRA_ARGS.*)|\1 --image-credential-provider-config=/var/usr/ecr-credential-provider/ecr-credential-provider-config --image-credential-provider-bin-dir={{ ecr_credential_provider_install_dir }}|' {{ '/etc/default/kubelet' if ansible_facts['os_family'] == 'Debian' else '/etc/sysconfig/kubelet' }}
       args:
         executable: /bin/bash

--- a/images/capi/ansible/roles/firstboot/meta/main.yml
+++ b/images/capi/ansible/roles/firstboot/meta/main.yml
@@ -17,7 +17,7 @@ dependencies:
     vars:
       rpms: ""
       debs: ""
-    when: ansible_os_family == "VMware Photon OS"
+    when: ansible_facts['os_family'] == "VMware Photon OS"
 
   - role: setup
     vars:

--- a/images/capi/ansible/roles/firstboot/tasks/main.yaml
+++ b/images/capi/ansible/roles/firstboot/tasks/main.yaml
@@ -15,7 +15,7 @@
 
 - name: Include Photon firstboot tasks
   ansible.builtin.include_tasks: photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+  when: ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Include QEMU firstboot tasks
   ansible.builtin.include_tasks: qemu.yml

--- a/images/capi/ansible/roles/gpu/defaults/main.yml
+++ b/images/capi/ansible/roles/gpu/defaults/main.yml
@@ -16,5 +16,5 @@
 gpu_amd_usecase: dkms
 gpu_block_nouveau_loading: false
 gpu_systemd_networkd_update_initramfs: >-
-  {%- if ansible_os_family == 'VMware Photon OS' -%} dracut -f{%- elif ansible_os_family == 'Debian' -%} update-initramfs -u{%- endif -%}
+  {%- if ansible_facts['os_family'] == 'VMware Photon OS' -%} dracut -f{%- elif ansible_facts['os_family'] == 'Debian' -%} update-initramfs -u{%- endif -%}
 gpu_nvidia_ceph: false

--- a/images/capi/ansible/roles/gpu/tasks/amd.yml
+++ b/images/capi/ansible/roles/gpu/tasks/amd.yml
@@ -18,12 +18,12 @@
     name: root
     groups: render,video
     append: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install the .deb for AMDGPU-Install
   ansible.builtin.apt:
     deb: https://repo.radeon.com/amdgpu-install/{{ amd_version }}/ubuntu/jammy/amdgpu-install_{{ amd_deb_version }}_all.deb
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Perform a cache update
   ansible.builtin.apt:
@@ -33,19 +33,19 @@
   until: apt_lock_status is not failed
   retries: 5
   delay: 10
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install packages required for AMD driver installation
   become: true
   ansible.builtin.apt:
     pkg:
-      - linux-headers-{{ ansible_kernel }}
-      - linux-modules-extra-{{ ansible_kernel }}
+      - linux-headers-{{ ansible_facts['kernel'] }}
+      - linux-modules-extra-{{ ansible_facts['kernel'] }}
       - build-essential
       - dkms
       - rocminfo
       - clinfo
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Run AMDGPU_Install binary with use-cases
   ansible.builtin.command:

--- a/images/capi/ansible/roles/gpu/tasks/nvidia.yml
+++ b/images/capi/ansible/roles/gpu/tasks/nvidia.yml
@@ -16,7 +16,7 @@
 - name: Add NVIDIA package signing key
   ansible.builtin.apt_key:
     url: https://nvidia.github.io/libnvidia-container/gpgkey
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Perform a cache update
   ansible.builtin.apt:
@@ -26,7 +26,7 @@
   until: apt_lock_status is not failed
   retries: 5
   delay: 10
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install packages for building NVIDIA driver kernel module and interacting with s3 endpoint
   become: true
@@ -37,7 +37,7 @@
       - dkms
       - python3-boto3
       - python3-botocore
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Make /etc/nvidia/ClientConfigToken directory
   become: true
@@ -119,4 +119,4 @@
     pkg:
       - python3-boto3
       - python3-botocore
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/kubernetes/tasks/ecrpull.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/ecrpull.yml
@@ -27,4 +27,4 @@
   ansible.builtin.file:
     path: /etc/kubeadm.yml
     state: absent
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"

--- a/images/capi/ansible/roles/kubernetes/tasks/kubeadmpull.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/kubeadmpull.yml
@@ -12,4 +12,4 @@
   ansible.builtin.file:
     path: /etc/kubeadm.yml
     state: absent
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -14,19 +14,19 @@
 ---
 - name: Import Debian Kubernetes tasks
   ansible.builtin.import_tasks: debian.yml
-  when: kubernetes_source_type == "pkg" and ansible_os_family == "Debian"
+  when: kubernetes_source_type == "pkg" and ansible_facts['os_family'] == "Debian"
 
 - name: Import Azure Linux Kubernetes tasks
   ansible.builtin.import_tasks: azurelinux.yml
-  when: kubernetes_source_type == "pkg" and ansible_os_family in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: kubernetes_source_type == "pkg" and ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
 
 - name: Import RedHat Kubernetes tasks
   ansible.builtin.import_tasks: redhat.yml
-  when: kubernetes_source_type == "pkg" and ansible_os_family == "RedHat"
+  when: kubernetes_source_type == "pkg" and ansible_facts['os_family'] == "RedHat"
 
 - name: Import Photon Kubernetes tasks
   ansible.builtin.import_tasks: photon.yml
-  when: kubernetes_source_type == "pkg" and ansible_os_family == "VMware Photon OS"
+  when: kubernetes_source_type == "pkg" and ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Import URL Kubernetes tasks
   ansible.builtin.import_tasks: url.yml
@@ -40,7 +40,7 @@
 - name: Create kubelet default config file
   ansible.builtin.template:
     src: etc/sysconfig/kubelet
-    dest: "{{ '/etc/default/kubelet' if ansible_os_family == 'Debian' else '/etc/sysconfig/kubelet' }}"
+    dest: "{{ '/etc/default/kubelet' if ansible_facts['os_family'] == 'Debian' else '/etc/sysconfig/kubelet' }}"
     owner: root
     group: root
     mode: "0644"
@@ -88,19 +88,19 @@
   ansible.builtin.shell:
     cmd: "{{ sysusr_prefix }}/bin/kubectl completion bash > {{ sysusr_prefix }}/share/bash-completion/completions/kubectl"
     creates: "{{ sysusr_prefix }}/share/bash-completion/completions/kubectl"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Generate kubeadm bash completion
   ansible.builtin.shell:
     cmd: "{{ sysusr_prefix }}/bin/kubeadm completion bash > {{ sysusr_prefix }}/share/bash-completion/completions/kubeadm"
     creates: "{{ sysusr_prefix }}/share/bash-completion/completions/kubeadm"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Generate crictl bash completion
   ansible.builtin.shell:
     cmd: "{{ sysusr_prefix }}/bin/crictl completion bash > {{ sysusr_prefix }}/share/bash-completion/completions/crictl"
     creates: "{{ sysusr_prefix }}/share/bash-completion/completions/crictl"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Set KUBECONFIG variable and alias
   ansible.builtin.copy:
@@ -117,7 +117,7 @@
 
 - name: Import kubeadm pull tasks
   ansible.builtin.import_tasks: kubeadmpull.yml
-  when: (kubernetes_source_type == "pkg" and not ecr) or ansible_os_family == "Flatcar"
+  when: (kubernetes_source_type == "pkg" and not ecr) or ansible_facts['os_family'] == "Flatcar"
 
 - name: Import ECR pull tasks
   ansible.builtin.import_tasks: ecrpull.yml

--- a/images/capi/ansible/roles/load_additional_components/tasks/s3.yml
+++ b/images/capi/ansible/roles/load_additional_components/tasks/s3.yml
@@ -18,7 +18,7 @@
     pkg:
       - python3-boto3
       - python3-botocore
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 # TODO: We should probably think of an approach to allow a loop here to prevent multiple calls
 # and as such, multiple installs/removals of the boto packages.
@@ -43,4 +43,4 @@
     pkg:
       - python3-boto3
       - python3-botocore
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -119,7 +119,7 @@ common_raw_photon_rpms: []
 # photon and flatcar do not have backward compatibility for legacy distro behavior for sysctl.conf by default
 # as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.
 sysctl_conf_file: >-
-  {{ '/etc/sysctl.d/99-sysctl.conf' if ansible_os_family in ['Common Base Linux Mariner', 'Flatcar', 'Microsoft Azure Linux', 'VMware Photon OS']
+  {{ '/etc/sysctl.d/99-sysctl.conf' if ansible_facts['os_family'] in ['Common Base Linux Mariner', 'Flatcar', 'Microsoft Azure Linux', 'VMware Photon OS']
     else '/etc/sysctl.conf' }}
 
 pause_image: registry.k8s.io/pause:3.10
@@ -127,7 +127,7 @@ containerd_additional_settings:
 leak_local_mdns_to_dns: false
 build_target: virt
 cloud_cfg_file: /etc/cloud/cloud.cfg
-external_binary_path: "{{ '/opt/bin' if ansible_os_family == 'Flatcar' else '/usr/local/bin' }}"
+external_binary_path: "{{ '/opt/bin' if ansible_facts['os_family'] == 'Flatcar' else '/usr/local/bin' }}"
 
 # Enable containerd trace audit in auditd, default: false.
 enable_containerd_audit: false

--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -17,26 +17,26 @@ dependencies:
     vars:
       rpms: "{{ common_rpms + al2_rpms + lookup('vars', 'common_' + build_target + '_rpms') }}"
       debs: "{{ common_debs }}"
-    when: ansible_distribution == "Amazon" and ansible_distribution_version == "2"
+    when: ansible_facts['distribution'] == "Amazon" and ansible_facts['distribution_version'] == "2"
 
   - role: setup
     vars:
       rpms: "{{ common_rpms + al2023_rpms + lookup('vars', 'common_' + build_target + '_rpms') }}"
       debs: "{{ common_debs }}"
-    when: ansible_distribution == "Amazon" and ansible_distribution_version == "2023"
+    when: ansible_facts['distribution'] == "Amazon" and ansible_facts['distribution_version'] == "2023"
 
   - role: setup
     vars:
       rpms: "{{ common_rpms }}"
       debs: "{{ common_debs }}"
-    when: packer_builder_type == "oracle-oci" and ansible_architecture == "aarch64"
+    when: packer_builder_type == "oracle-oci" and ansible_facts['architecture'] == "aarch64"
 
   - role: setup
     vars:
       rpms: >-
-        {{ (common_photon_rpms + lookup('vars', 'photon_' + ansible_distribution_major_version + '_rpms' )
+        {{ (common_photon_rpms + lookup('vars', 'photon_' + ansible_facts['distribution_major_version'] + '_rpms' )
           + lookup('vars', 'common_' + build_target + '_photon_rpms')) }}
-    when: ansible_distribution == "VMware Photon OS"
+    when: ansible_facts['distribution'] == "VMware Photon OS"
 
   - role: setup
     vars:
@@ -44,11 +44,11 @@ dependencies:
         {{ ( common_rpms + rh8_rpms + lookup('vars', 'common_' + build_target + '_rpms') ) }}
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
     when: >
-      ansible_distribution not in ["VMware Photon OS", "Amazon"]
-        and not (packer_builder_type == "oracle-oci" and ansible_architecture == "aarch64")
+      ansible_facts['distribution'] not in ["VMware Photon OS", "Amazon"]
+        and not (packer_builder_type == "oracle-oci" and ansible_facts['architecture'] == "aarch64")
         and not packer_builder_type is search('qemu')
 
   - role: setup
     vars:
       rpms: "{{ common_rpms + azurelinux_rpms + lookup('vars', 'common_' + build_target + '_rpms') }}"
-    when: ansible_distribution in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+    when: ansible_facts['distribution'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -14,23 +14,23 @@
 ---
 - name: Import Photon node tasks
   ansible.builtin.import_tasks: photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+  when: ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Import Amazon Linux node tasks
   ansible.builtin.import_tasks: amazonLinux.yml
-  when: ansible_distribution == "Amazon"
+  when: ansible_facts['distribution'] == "Amazon"
 
 # This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
 - name: Override Flatcar's OS family
   ansible.builtin.set_fact:
     ansible_os_family: Flatcar
-  when: ansible_os_family == "Flatcar Container Linux by Kinvolk"
+  when: ansible_facts['os_family'] == "Flatcar Container Linux by Kinvolk"
   tags:
     - facts
 
 - name: Import Flatcar node tasks
   ansible.builtin.import_tasks: flatcar.yml
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Ensure overlay module is present
   community.general.modprobe:
@@ -74,18 +74,18 @@
 - name: Disable swap memory
   ansible.builtin.shell: |
     swapoff -a
-  when: ansible_memory_mb.swap.total != 0
+  when: ansible_facts['memory_mb'].swap.total != 0
 
 - name: Edit fstab file to disable swap
   ansible.builtin.shell: sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-  when: ansible_memory_mb.swap.total != 0
+  when: ansible_facts['memory_mb'].swap.total != 0
 
 - name: Disable conntrackd service
   ansible.builtin.systemd:
     name: conntrackd
     state: stopped
     enabled: false
-  when: ansible_os_family not in ["Common Base Linux Mariner", "Debian", "Flatcar", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Debian", "Flatcar", "Microsoft Azure Linux"]
 
 - name: Ensure auditd is running and comes on at reboot
   ansible.builtin.service:
@@ -95,7 +95,7 @@
 
 - name: Configure auditd rules for containerd
   ansible.builtin.copy:
-    src: "etc/audit/rules.d/containerd.rules{{ '-flatcar' if ansible_os_family == 'Flatcar' else '' }}"
+    src: "etc/audit/rules.d/containerd.rules{{ '-flatcar' if ansible_facts['os_family'] == 'Flatcar' else '' }}"
     dest: /etc/audit/rules.d/containerd.rules
     owner: root
     group: root
@@ -109,7 +109,7 @@
     state: present
     sysctl_set: true
     reload: true
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_facts['distribution'] == "Ubuntu"
 
 - name: Set transparent huge pages to madvise
   ansible.builtin.lineinfile:
@@ -117,7 +117,7 @@
     backrefs: true
     regexp: ^(?!.*transparent_hugepage=madvise)(GRUB_CMDLINE_LINUX=.*)("$)
     line: \1 transparent_hugepage=madvise"
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Copy udev etcd network tuning rules
   ansible.builtin.template:

--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -14,7 +14,7 @@
 ---
 - name: Include AWS CLI v2 tasks
   ansible.builtin.include_tasks: awscliv2.yml
-  when: ansible_distribution != "Amazon"
+  when: ansible_facts['distribution'] != "Amazon"
 
 # Remove after https://github.com/aws/amazon-ssm-agent/issues/235 is fixed.
 - name: Install aws agents RPM on Redhat distributions
@@ -25,33 +25,33 @@
   with_items:
     - "{{ amazon_ssm_agent_rpm }}"
   when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution != "Amazon"
+    - ansible_facts['os_family'] == "RedHat"
+    - ansible_facts['distribution'] != "Amazon"
 
 - name: Ensure ssm agent is running RPM
   ansible.builtin.service:
     name: amazon-ssm-agent
     state: started
     enabled: true
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Install aws agents Ubuntu
   ansible.builtin.command: snap install amazon-ssm-agent --classic
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_facts['distribution'] == "Ubuntu"
 
 - name: Ensure ssm agent is running Ubuntu
   ansible.builtin.service:
     name: snap.amazon-ssm-agent.amazon-ssm-agent.service
     state: started
     enabled: true
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_facts['distribution'] == "Ubuntu"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Create cloud-init custom data source list
   ansible.builtin.copy:
@@ -60,7 +60,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_version'] is version('22.04', '>=')
 
 - name: Create custom cloud-init data source
   ansible.builtin.copy:
@@ -69,4 +69,4 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_distribution == "Ubuntu" and ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_version'] is version('22.04', '>=')

--- a/images/capi/ansible/roles/providers/tasks/awscliv2.yml
+++ b/images/capi/ansible/roles/providers/tasks/awscliv2.yml
@@ -4,7 +4,7 @@
     name: pip
     executable: pip3
     state: latest
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Install aws clients via pip
   ansible.builtin.pip:
@@ -13,7 +13,7 @@
   vars:
     packages:
       - awscli
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Install AWS CLI prequisites
   ansible.builtin.dnf:
@@ -21,7 +21,7 @@
       - gnupg
       - unzip
     state: present
-  when: ansible_distribution == "RedHat"
+  when: ansible_facts['distribution'] == "RedHat"
 
 - name: Install AWS CLI prerequisites
   ansible.builtin.apt:
@@ -29,7 +29,7 @@
       - gnupg
       - unzip
     state: present
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Import AWS public key
   ansible.builtin.shell: |
@@ -65,39 +65,39 @@
     EOF
     gpg --import aws-public-key
     rm aws-public-key
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Download AWS CLI v2 archive signature file
   ansible.builtin.get_url:
-    url: https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip.sig
+    url: https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_facts['architecture'] }}.zip.sig
     dest: /tmp/awscliv2.zip.sig
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Download AWS CLI v2 archive
   ansible.builtin.get_url:
-    url: https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_architecture }}.zip
+    url: https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_facts['architecture'] }}.zip
     dest: /tmp/awscliv2.zip
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Verify AWS CLI v2 archive
   ansible.builtin.command: gpg --verify /tmp/awscliv2.zip.sig /tmp/awscliv2.zip
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Unzip AWS CLI v2 archive
   ansible.builtin.unarchive:
     src: /tmp/awscliv2.zip
     dest: /tmp
     remote_src: true
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Install AWS CLI v2
   ansible.builtin.command: /tmp/aws/install --update -i /usr/local/aws-cli -b /usr/local/sbin
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Remove temporary files
   ansible.builtin.file:
     path: /tmp/aws*
     state: absent
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -23,7 +23,7 @@
     line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
     mode: "0644"
   # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
-  when: ansible_os_family != "Flatcar" or (ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '<'))
+  when: ansible_facts['os_family'] != "Flatcar" or (ansible_facts['os_family'] == "Flatcar" and  ansible_facts['distribution_version'] is version('3975.2.0', '<'))
 
 - name: Ensure makestep parameter set as per Azure recommendation
   ansible.builtin.lineinfile:
@@ -31,7 +31,7 @@
     regexp: ^makestep
     line: makestep 1.0 -1
   # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
-  when: ansible_os_family != "Flatcar" or (ansible_os_family == "Flatcar" and  ansible_distribution_version is version('3975.2.0', '<'))
+  when: ansible_facts['os_family'] != "Flatcar" or (ansible_facts['os_family'] == "Flatcar" and  ansible_facts['distribution_version'] is version('3975.2.0', '<'))
 
 - name: Install iptables persistence
   ansible.builtin.apt:
@@ -41,7 +41,7 @@
   vars:
     packages:
       - iptables-persistent
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Block traffic to 168.63.129.16 port 80 for cve-2021-27075
   ansible.builtin.copy:
@@ -50,13 +50,13 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Load iptable rules from file
   community.general.iptables_state:
     state: restored
     path: /etc/iptables/rules.v4
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install netbase and nfs-common
   ansible.builtin.apt:
@@ -67,7 +67,7 @@
     packages:
       - netbase
       - nfs-common
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 ## refer to ../files/etc/cloud/cloud.cfg.d/15_azure-vnet.cfg
 ## for more context on below file addition
@@ -78,7 +78,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Create the credential provider path
   ansible.builtin.file:

--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -23,7 +23,10 @@
     line: refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
     mode: "0644"
   # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
-  when: ansible_facts['os_family'] != "Flatcar" or (ansible_facts['os_family'] == "Flatcar" and  ansible_facts['distribution_version'] is version('3975.2.0', '<'))
+  when: >
+    ansible_facts['os_family'] != "Flatcar" or
+    (ansible_facts['os_family'] == "Flatcar" and
+    ansible_facts['distribution_version'] is version('3975.2.0', '<'))
 
 - name: Ensure makestep parameter set as per Azure recommendation
   ansible.builtin.lineinfile:
@@ -31,7 +34,10 @@
     regexp: ^makestep
     line: makestep 1.0 -1
   # Flatcar now includes this by default as of 3975.2.0 which causes this task to fail
-  when: ansible_facts['os_family'] != "Flatcar" or (ansible_facts['os_family'] == "Flatcar" and  ansible_facts['distribution_version'] is version('3975.2.0', '<'))
+  when: >
+    ansible_facts['os_family'] != "Flatcar" or
+    (ansible_facts['os_family'] == "Flatcar" and
+    ansible_facts['distribution_version'] is version('3975.2.0', '<'))
 
 - name: Install iptables persistence
   ansible.builtin.apt:

--- a/images/capi/ansible/roles/providers/tasks/azurecli.yml
+++ b/images/capi/ansible/roles/providers/tasks/azurecli.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 - name: Install Azure CLI
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
   block:
     - name: Add Microsoft Package Repository Key
       ansible.builtin.apt_key:
@@ -44,13 +44,13 @@
         state: present
 
 - name: Install Azure CLI
-  when: ansible_os_family in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
   ansible.builtin.package:
     name: azure-cli
     state: present
 
 - name: Install Azure CLI
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
   block:
     - name: Import the Microsoft repository key
       ansible.builtin.rpm_key:

--- a/images/capi/ansible/roles/providers/tasks/cloudstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/cloudstack.yml
@@ -27,7 +27,7 @@
 
 - name: Run dracut cmd to regenerate initramfs with all drivers - needed when converting to different hypervisor templates
   ansible.builtin.command: dracut --force --no-hostonly
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Add draut cmd to regenerate initramfs with only necessary drivers on first boot
   ansible.builtin.lineinfile:
@@ -36,4 +36,4 @@
     line: |-
       bootcmd:
         - dracut --force
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"

--- a/images/capi/ansible/roles/providers/tasks/googlecompute.yml
+++ b/images/capi/ansible/roles/providers/tasks/googlecompute.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 - name: Install gcloud SDK
-  when: ansible_os_family != "RedHat"
+  when: ansible_facts['os_family'] != "RedHat"
   block:
     - name: Download gcloud SDK
       ansible.builtin.get_url:
@@ -39,7 +39,7 @@
       with_items: "{{ find.files }}"
 
 - name: Install gcloud SDK
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
   block:
     - name: Add gcloud repository info
       ansible.builtin.shell: |
@@ -65,11 +65,11 @@
     packages:
       - cloud-init
       - cloud-utils-growpart
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/hcloud.yml
+++ b/images/capi/ansible/roles/providers/tasks/hcloud.yml
@@ -23,7 +23,7 @@
       - cloud-guest-utils
       - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install cloud-tools and tools packages
   ansible.builtin.apt:
@@ -34,7 +34,7 @@
     packages:
       - linux-cloud-tools-generic
       - linux-tools-generic
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install cloud-init packages
   ansible.builtin.dnf:
@@ -44,7 +44,7 @@
     packages:
       - cloud-init
       - cloud-utils-growpart
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Install CSI prerequisites on Ubuntu
   ansible.builtin.apt:
@@ -57,7 +57,7 @@
       - open-iscsi
       - lvm2
       - xfsprogs
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install CSI prerequisites on RedHat
   ansible.builtin.dnf:
@@ -69,18 +69,18 @@
       - nfs-utils
       - lvm2
       - xfsprogs
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Enable iSCSI initiator daemon on Ubuntu or RedHat
   ansible.builtin.systemd:
     name: iscsid
     state: started
     enabled: true
-  when: ansible_os_family in ["Debian", "Redhat"]
+  when: ansible_facts['os_family'] in ["Debian", "Redhat"]
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/huaweicloud.yml
+++ b/images/capi/ansible/roles/providers/tasks/huaweicloud.yml
@@ -17,21 +17,21 @@
     name: pip
     executable: pip3
     state: latest
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Uninstall cloud-init pip package
   ansible.builtin.pip:
     name: "cloud-init"
     executable: pip3
     state: absent
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Create dns default conf directory
   ansible.builtin.file:
     path: /etc/systemd/resolved.conf.d
     state: directory
     mode: "0755"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Add default dns
   ansible.builtin.copy:
@@ -42,4 +42,4 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/maas.yml
+++ b/images/capi/ansible/roles/providers/tasks/maas.yml
@@ -3,4 +3,4 @@
 
 - name: Include MaaS Specific configs for Ubuntu Distro
   ansible.builtin.include_tasks: maas-ubuntu.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -84,7 +84,7 @@
     path: /etc/systemd/system/cloud-final.service.d
     state: directory
     mode: "0755"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Create cloud-final boot order drop in file
   ansible.builtin.copy:
@@ -93,14 +93,14 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Creates unit file directory for cloud-config
   ansible.builtin.file:
     path: /etc/systemd/system/cloud-config.service.d
     state: directory
     mode: "0755"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Create cloud-config boot order drop in file
   ansible.builtin.copy:
@@ -109,7 +109,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 # Some OS might disable cloud-final service on boot (rhel 7).
 # Enable all cloud-init services on boot.
@@ -122,7 +122,7 @@
     - cloud-config
     - cloud-init
     - cloud-init-local
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Create cloud-init config file
   ansible.builtin.copy:
@@ -131,7 +131,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 # `feature_overrides.py` only works on old cloud-init versions (removed in https://github.com/canonical/cloud-init/pull/4228)...
 - name: Set cloudinit feature flags
@@ -141,7 +141,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Set cloudinit feature flags for redhat 8
   ansible.builtin.copy:
@@ -150,7 +150,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "RedHat" and ansible_distribution == "RedHat" and ansible_distribution_major_version == "8"
+  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] == "8"
 
 - name: Set cloudinit feature flags for redhat 9
   ansible.builtin.copy:
@@ -159,7 +159,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "RedHat" and ansible_distribution == "RedHat" and ansible_distribution_major_version == "9"
+  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] == "9"
 
 # ...and `features.py` must be patched instead
 - name: Patch cloud-init feature flags for Debian-based OS
@@ -167,14 +167,14 @@
     path: /usr/lib/python3/dist-packages/cloudinit/features.py
     marker: "# {mark} ANSIBLE MANAGED BLOCK (by image-builder)"
     block: "{{ lookup('file', 'cloud-init-features.patch') }}"
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Patch cloud-init feature flags for RedHat 9
   ansible.builtin.blockinfile:
     path: /usr/lib/python3.9/site-packages/cloudinit/features.py
     marker: "# {mark} ANSIBLE MANAGED BLOCK (by image-builder)"
     block: "{{ lookup('file', 'cloud-init-features.patch') }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution == "RedHat" and ansible_distribution_major_version == "9"
+  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] == "9"
 
 - name: Ensure chrony is running
   ansible.builtin.systemd:
@@ -185,4 +185,4 @@
   when: >
     (packer_builder_type.startswith('amazon') or packer_builder_type.startswith('azure')
       or packer_builder_type is search('vmware') or packer_builder_type is search('vsphere'))
-      and ansible_os_family != "Flatcar"
+      and ansible_facts['os_family'] != "Flatcar"

--- a/images/capi/ansible/roles/providers/tasks/nutanix.yml
+++ b/images/capi/ansible/roles/providers/tasks/nutanix.yml
@@ -14,11 +14,11 @@
 ---
 - name: Include Nutanix RedHat tasks
   ansible.builtin.include_tasks: nutanix-redhat.yml
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Include Nutanix Ubuntu tasks
   ansible.builtin.include_tasks: nutanix-ubuntu.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure ip_vs module is loaded
   ansible.builtin.lineinfile:

--- a/images/capi/ansible/roles/providers/tasks/oci.yml
+++ b/images/capi/ansible/roles/providers/tasks/oci.yml
@@ -17,18 +17,18 @@
     path: /etc/iptables/rules.v4
     state: absent
     regexp: -A INPUT -j REJECT --reject-with icmp-host-prohibited
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_facts['distribution'] == "Ubuntu"
 
 - name: Remove the default input reject all iptable rule
   ansible.builtin.lineinfile:
     path: /etc/iptables/rules.v4
     state: absent
     regexp: -A FORWARD -j REJECT --reject-with icmp-host-prohibited
-  when: ansible_distribution == "Ubuntu"
+  when: ansible_facts['distribution'] == "Ubuntu"
 
 - name: Disable firewalld service
   ansible.builtin.systemd:
     name: firewalld
     state: stopped
     enabled: false
-  when: ansible_distribution == "OracleLinux"
+  when: ansible_facts['distribution'] == "OracleLinux"

--- a/images/capi/ansible/roles/providers/tasks/openstack.yml
+++ b/images/capi/ansible/roles/providers/tasks/openstack.yml
@@ -23,35 +23,35 @@
       - cloud-guest-utils
       - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure networkd-dispatcher is installed
   ansible.builtin.apt:
     name: networkd-dispatcher
     state: present
     force_apt_get: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Enable networkd-dispatcher service
   ansible.builtin.systemd:
     name: networkd-dispatcher
     state: started
     enabled: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Create directory for DHCP chrony server files
   ansible.builtin.file:
     path: /var/lib/dhcp
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
@@ -65,4 +65,4 @@
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/outscale.yml
+++ b/images/capi/ansible/roles/providers/tasks/outscale.yml
@@ -14,10 +14,10 @@
   ansible.builtin.apt:
     name: cloud-initramfs-dyn-netconf
     state: present
-  when: ansible_distribution == 'Debian'
+  when: ansible_facts['distribution'] == 'Debian'
 
 - name: Install Ubuntu specific packages
   ansible.builtin.apt:
     name: cloud-initramfs-copymods
     state: present
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Ubuntu'

--- a/images/capi/ansible/roles/providers/tasks/proxmox.yml
+++ b/images/capi/ansible/roles/providers/tasks/proxmox.yml
@@ -23,7 +23,7 @@
       - cloud-guest-utils
       - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install cloud-init packages
   ansible.builtin.dnf:
@@ -33,21 +33,21 @@
     packages:
       - cloud-init
       - cloud-utils-growpart
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Create directory for DHCP chrony server files
   ansible.builtin.file:
     path: /var/lib/dhcp
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
@@ -61,16 +61,16 @@
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure networkd-dispatcher is started
   ansible.builtin.systemd:
     name: networkd-dispatcher
     state: started
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Ensure networkd-dispatcher is enabled
   ansible.builtin.systemd:
     name: networkd-dispatcher
     enabled: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -23,7 +23,7 @@
       - cloud-guest-utils
       - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install cloud-init packages
   ansible.builtin.dnf:
@@ -33,21 +33,21 @@
     packages:
       - cloud-init
       - cloud-utils-growpart
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Create directory for DHCP chrony server files
   ansible.builtin.file:
     path: /var/lib/dhcp
     state: directory
     mode: '0755'
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Copy networkd-dispatcher scripts to add DHCP provided NTP servers
   ansible.builtin.template:
@@ -61,4 +61,4 @@
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/no-carrier.d/20-chrony.j2, dest: /etc/networkd-dispatcher/no-carrier.d/20-chrony }
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/raw.yml
+++ b/images/capi/ansible/roles/providers/tasks/raw.yml
@@ -23,7 +23,7 @@
       - cloud-guest-utils
       - cloud-initramfs-copymods
       - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install cloud-init packages
   ansible.builtin.dnf:
@@ -33,11 +33,11 @@
     packages:
       - cloud-init
       - cloud-utils-growpart
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Run dracut cmd to regenerate initramfs with all drivers - needed when converting to different hypervisor templates
   ansible.builtin.command: dracut --force --no-hostonly
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Symlink /usr/libexec/cloud-init to /usr/lib/cloud-init
   ansible.builtin.file:
@@ -45,11 +45,11 @@
     dest: /usr/lib/cloud-init
     mode: "0777"
     state: link
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Disable Hyper-V KVP protocol daemon on Ubuntu
   ansible.builtin.systemd:
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/scaleway.yml
+++ b/images/capi/ansible/roles/providers/tasks/scaleway.yml
@@ -17,4 +17,4 @@
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
@@ -37,7 +37,7 @@
   vars:
     packages:
       - python2-pip
-  when: ansible_distribution_major_version|int <= 8
+  when: ansible_facts['distribution_major_version']|int <= 8
 
 # pip on CentOS needs to be upgraded, but since it's still
 # Python 2.7, need < 21.0
@@ -45,7 +45,7 @@
   ansible.builtin.pip:
     name: pip<21.0
     state: forcereinstall
-  when: ansible_distribution_major_version == '7'
+  when: ansible_facts['distribution_major_version'] == '7'
 
 # Directly installing Guestinfo datasource is needed so long as
 # cloud-init is < 21.3

--- a/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-ubuntu.yml
@@ -55,7 +55,7 @@
     mode: a+x
   vars:
     server_dir: /var/lib/dhcp
-    chrony_helper_dir: "{{ '/usr/libexec/chrony' if ansible_distribution_version is version('22.04', '>=') else '/usr/lib/chrony' }}"
+    chrony_helper_dir: "{{ '/usr/libexec/chrony' if ansible_facts['distribution_version'] is version('22.04', '>=') else '/usr/lib/chrony' }}"
   loop:
     - { src: files/etc/networkd-dispatcher/routable.d/20-chrony.j2, dest: /etc/networkd-dispatcher/routable.d/20-chrony }
     - { src: files/etc/networkd-dispatcher/off.d/20-chrony.j2, dest: /etc/networkd-dispatcher/off.d/20-chrony }
@@ -68,4 +68,4 @@
     content: |
       datasource: VMware
     mode: "0644"
-  when: ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution_version'] is version('22.04', '>=')

--- a/images/capi/ansible/roles/providers/tasks/vmware.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware.yml
@@ -14,15 +14,15 @@
 ---
 - name: Include VMware Photon tasks
   ansible.builtin.include_tasks: vmware-photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+  when: ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Include VMware Ubuntu tasks
   ansible.builtin.include_tasks: vmware-ubuntu.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Include VMware RedHat tasks
   ansible.builtin.include_tasks: vmware-redhat.yml
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Create provider vmtools config drop-in file
   ansible.builtin.copy:
@@ -31,7 +31,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Create service to modify cloud-init config
   ansible.builtin.copy:
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Copy cloud-init modification script
   ansible.builtin.copy:
@@ -49,7 +49,7 @@
     owner: root
     group: root
     mode: "0755"
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Enable modify-cloud-init-cfg.service
   ansible.builtin.systemd:
@@ -57,4 +57,4 @@
     daemon_reload: true
     enabled: true
     state: stopped
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"

--- a/images/capi/ansible/roles/python/tasks/main.yml
+++ b/images/capi/ansible/roles/python/tasks/main.yml
@@ -18,6 +18,6 @@
 
 - name: Include Flatcar Python tasks
   ansible.builtin.include_tasks: flatcar.yml
-  # We can't use ansible_os_family fact here for consistency, as facts gathering
+  # We can't use ansible_facts['os_family'] fact here for consistency, as facts gathering
   # is disabled in the playbook which includes this role. See playbook for more details.
   when: distrib_id.stdout_lines[0] is search("Flatcar")

--- a/images/capi/ansible/roles/security/tasks/falco.yml
+++ b/images/capi/ansible/roles/security/tasks/falco.yml
@@ -15,7 +15,7 @@
 ---
 
 - name: Install Falco on Debian based systems
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
   block:
     - name: Add Falco package signing key
       ansible.builtin.apt_key:
@@ -33,7 +33,7 @@
         pkg:
           - dkms
           - make
-          - "linux-headers-{{ ansible_kernel }}"
+          - "linux-headers-{{ ansible_facts['kernel'] }}"
           - clang
           - llvm
         update_cache: true
@@ -43,7 +43,7 @@
       until: pkg_result is success
 
 - name: Install Falco on RedHat based systems
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
   block:
     - name: Add Falco YUM repo
       ansible.builtin.yum_repository:
@@ -60,7 +60,7 @@
         pkg:
           - dkms
           - make
-          - "kernel-devel-{{ ansible_kernel }}"
+          - "kernel-devel-{{ ansible_facts['kernel'] }}"
           - clang
           - llvm
           - dialog
@@ -73,11 +73,11 @@
   ansible.builtin.package:
     name: falco
     state: present
-  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"
 
 - name: Enable Falco Modern eBPF
   ansible.builtin.service:
     name: falco-modern-bpf
     state: started
     enabled: true
-  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"

--- a/images/capi/ansible/roles/security/tasks/trivy.yml
+++ b/images/capi/ansible/roles/security/tasks/trivy.yml
@@ -15,7 +15,7 @@
 ---
 
 - name: Install Trivy on Debian based systems
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
   block:
     - name: Add Trivy package signing key
       ansible.builtin.apt_key:
@@ -24,19 +24,19 @@
 
     - name: Add Trivy apt repo
       ansible.builtin.apt_repository:
-        repo: "deb https://aquasecurity.github.io/trivy-repo/deb {{ ansible_distribution_release }} main"
+        repo: "deb https://aquasecurity.github.io/trivy-repo/deb {{ ansible_facts['distribution_release'] }} main"
         state: present
         filename: trivy
 
 - name: Install Trivy on RedHat based systems
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
   block:
     - name: Add Trivy rpm repo
       ansible.builtin.yum_repository:
         name: Trivy repository
         description: Trivy YUM repo
         file: trivy
-        baseurl: https://aquasecurity.github.io/trivy-repo/rpm/releases/{{ ansible_distribution_release }}/{{ ansible_architecture }}/
+        baseurl: https://aquasecurity.github.io/trivy-repo/rpm/releases/{{ ansible_facts['distribution_release'] }}/{{ ansible_facts['architecture'] }}/
         gpgcheck: true
         enabled: true
         gpgkey: https://aquasecurity.github.io/trivy-repo/rpm/public.keyy
@@ -46,10 +46,10 @@
     name: trivy
     update_cache: true
     state: present
-  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"
 
 - name: Update Trivy DB to ensure latest records are available as of now
   ansible.builtin.command: trivy rootfs --download-db-only
   args:
     creates: ~/.cache/trivy/db/trivy.db
-  when: ansible_os_family == "Debian" or ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat"

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -23,6 +23,6 @@ ubuntu_repo: "http://us.archive.ubuntu.com/ubuntu/"
 ubuntu_security_repo: "http://security.ubuntu.com/ubuntu/"
 
 disable_public_repos: false
-external_binary_path: "{{ '/opt/bin' if ansible_os_family == 'Flatcar' else '/usr/local/bin' }}"
+external_binary_path: "{{ '/opt/bin' if ansible_facts['os_family'] == 'Flatcar' else '/usr/local/bin' }}"
 extra_repos: ""
 pip_conf_file: ""

--- a/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/bootstrap-flatcar.yml
@@ -23,6 +23,6 @@
 - name: Override Flatcar's OS family
   ansible.builtin.set_fact:
     ansible_os_family: Flatcar
-  when: ansible_os_family == "Flatcar Container Linux by Kinvolk"
+  when: ansible_facts['os_family'] == "Flatcar Container Linux by Kinvolk"
   tags:
     - facts

--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -21,7 +21,7 @@
   # from this repo leads to build failures(especially in Arm), hence ignoring the step.
   # Ubuntu 24.04 has changed to deb822 source management
   # As a result the there is change in format source configurations and location
-  when: (packer_builder_type != "oracle-oci") and ((ansible_distribution == "Ubuntu") and (ansible_distribution_major_version is version('24', '<')))
+  when: (packer_builder_type != "oracle-oci") and ((ansible_facts['distribution'] == "Ubuntu") and (ansible_facts['distribution_major_version'] is version('24', '<')))
 
 - name: Put templated ubuntu.sources in place
   ansible.builtin.template:
@@ -30,7 +30,7 @@
     mode: "0644"
   # Ubuntu 24.04 has changed to deb822 source management
   # As a result the there is change in format source configurations and location
-  when: (ansible_distribution == "Ubuntu") and (ansible_distribution_major_version is version('24', '>='))
+  when: (ansible_facts['distribution'] == "Ubuntu") and (ansible_facts['distribution_major_version'] is version('24', '>='))
 
 - name: Put templated apt.conf.d/90proxy in place when defined
   ansible.builtin.template:

--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -21,7 +21,10 @@
   # from this repo leads to build failures(especially in Arm), hence ignoring the step.
   # Ubuntu 24.04 has changed to deb822 source management
   # As a result the there is change in format source configurations and location
-  when: (packer_builder_type != "oracle-oci") and ((ansible_facts['distribution'] == "Ubuntu") and (ansible_facts['distribution_major_version'] is version('24', '<')))
+  when: >
+    (packer_builder_type != "oracle-oci") and
+    ((ansible_facts['distribution'] == "Ubuntu") and
+    (ansible_facts['distribution_major_version'] is version('24', '<')))
 
 - name: Put templated ubuntu.sources in place
   ansible.builtin.template:

--- a/images/capi/ansible/roles/setup/tasks/main.yml
+++ b/images/capi/ansible/roles/setup/tasks/main.yml
@@ -14,26 +14,26 @@
 ---
 - name: Import Debian setup tasks
   ansible.builtin.import_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Import Flatcar setup tasks
   ansible.builtin.import_tasks: flatcar.yml
-  # This task overrides ansible_os_family to "Flatcar" as a workaround for
+  # This task overrides ansible_facts['os_family'] to "Flatcar" as a workaround for
   # regression between Flatcar and Ansible, so rest of the code can use just
   # "Flatcar" for comparison, which is the correct value.
-  when: ansible_os_family in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
+  when: ansible_facts['os_family'] in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Import Azure Linux setup tasks
   ansible.builtin.import_tasks: azurelinux.yml
-  when: ansible_os_family in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
 
 - name: Import RedHat setup tasks
   ansible.builtin.import_tasks: redhat.yml
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Import Photon setup tasks
   ansible.builtin.import_tasks: photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+  when: ansible_facts['os_family'] == "VMware Photon OS"
 
 # Copy in pip config file when defined
 - name: Install pip config file

--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -19,7 +19,7 @@
     password: "{{ lookup('env', 'RHSM_PASS') }}"
     auto_attach: true
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_facts['distribution'] == "RedHat"
     - lookup('env', 'RHSM_USER') | length > 0
     - lookup('env', 'RHSM_PASS') | length > 0
 

--- a/images/capi/ansible/roles/setup/templates/etc/apt/sources.list.d/ubuntu.sources.j2
+++ b/images/capi/ansible/roles/setup/templates/etc/apt/sources.list.d/ubuntu.sources.j2
@@ -1,11 +1,11 @@
 Types: deb
 URIs: {{ ubuntu_repo }}
-Suites: {{ ansible_distribution_release }} {{ ansible_distribution_release }}-updates {{ ansible_distribution_release }}-backports
+Suites: {{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }}-updates {{ ansible_facts['distribution_release'] }}-backports
 Components: main restricted universe multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
 URIs: {{ ubuntu_security_repo }}
-Suites: {{ ansible_distribution_release }}-security
+Suites: {{ ansible_facts['distribution_release'] }}-security
 Components: main restricted universe multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

--- a/images/capi/ansible/roles/setup/templates/etc/apt/sources.list.j2
+++ b/images/capi/ansible/roles/setup/templates/etc/apt/sources.list.j2
@@ -1,4 +1,4 @@
-deb {{ ubuntu_repo }} {{ ansible_distribution_release }} main restricted universe
-deb {{ ubuntu_repo }} {{ ansible_distribution_release }}-updates main restricted universe
-deb {{ ubuntu_repo }} {{ ansible_distribution_release }}-backports main restricted universe
-deb {{ ubuntu_security_repo }} {{ ansible_distribution_release }}-security main restricted universe
+deb {{ ubuntu_repo }} {{ ansible_facts['distribution_release'] }} main restricted universe
+deb {{ ubuntu_repo }} {{ ansible_facts['distribution_release'] }}-updates main restricted universe
+deb {{ ubuntu_repo }} {{ ansible_facts['distribution_release'] }}-backports main restricted universe
+deb {{ ubuntu_security_repo }} {{ ansible_facts['distribution_release'] }}-security main restricted universe

--- a/images/capi/ansible/roles/sysprep/tasks/azurelinux.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/azurelinux.yml
@@ -37,7 +37,7 @@
     name: swap.target
     enabled: false
     masked: true
-  when: ansible_memory_mb.swap.total != 0
+  when: ansible_facts['memory_mb'].swap.total != 0
 
 - name: Remove the kickstart log
   ansible.builtin.file:

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -71,7 +71,7 @@
   ansible.builtin.service:
     name: rsyslog
     state: stopped
-  when: "'rsyslog' in services"
+  when: "'rsyslog' in ansible_facts.services"
 
 - name: Remove apt package caches
   ansible.builtin.apt:

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -136,28 +136,28 @@
   ansible.builtin.file:
     path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
     state: absent
-  when: ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution_version'] is version('22.04', '>=')
 
 - name: Removing 99-installer.cfg which sets the cloud-init datasource to None
   ansible.builtin.file:
     path: /etc/cloud/cloud.cfg.d/99-installer.cfg
     state: absent
-  when: ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution_version'] is version('22.04', '>=')
 
 - name: Removing subiquity curtin preserve sources config
   ansible.builtin.file:
     path: /etc/cloud/cloud.cfg.d/curtin-preserve-sources.cfg
     state: absent
-  when: ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution_version'] is version('22.04', '>=')
 
 - name: Removing cloud-init ds identify config
   ansible.builtin.file:
     path: /etc/cloud/ds-identify.cfg
     state: absent
-  when: ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution_version'] is version('22.04', '>=')
 
 - name: Removing 90-installer-network.cfg installer network configuration
   ansible.builtin.file:
     path: /etc/cloud/cloud.cfg.d/90-installer-network.cfg
     state: absent
-  when: ansible_distribution_version is version('22.04', '>=')
+  when: ansible_facts['distribution_version'] is version('22.04', '>=')

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -72,7 +72,9 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: localhost.local
-  when: ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux", "VMware Photon OS"] and packer_build_name != "nutanix"
+  when: >
+    ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux", "VMware Photon OS"]
+    and packer_build_name != "nutanix"
 
 - name: Reset hosts file
   ansible.builtin.copy:

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -14,23 +14,23 @@
 ---
 - name: Import Debian sysprep tasks
   ansible.builtin.import_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Import Flatcar sysprep tasks
   ansible.builtin.import_tasks: flatcar.yml
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Import RedHat sysprep tasks
   ansible.builtin.import_tasks: redhat.yml
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Import Azure Linux sysprep tasks
   ansible.builtin.import_tasks: azurelinux.yml
-  when: ansible_os_family in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
 
 - name: Import Photon sysprep tasks
   ansible.builtin.import_tasks: photon.yml
-  when: ansible_os_family == "VMware Photon OS"
+  when: ansible_facts['os_family'] == "VMware Photon OS"
 
 - name: Remove containerd http proxy conf file if needed
   ansible.builtin.file:
@@ -56,7 +56,7 @@
   loop:
     - { path: /etc/machine-id, state: absent, mode: "{{ machine_id_mode }}" }
     - { path: /etc/machine-id, state: touch, mode: "{{ machine_id_mode }}" }
-  when: ansible_os_family not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linuz"]
+  when: ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linuz"]
 
 - name: Truncate hostname file
   ansible.builtin.file:
@@ -72,7 +72,7 @@
 - name: Set hostname
   ansible.builtin.hostname:
     name: localhost.local
-  when: ansible_os_family not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux", "VMware Photon OS"] and packer_build_name != "nutanix"
+  when: ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux", "VMware Photon OS"] and packer_build_name != "nutanix"
 
 - name: Reset hosts file
   ansible.builtin.copy:
@@ -109,13 +109,13 @@
   ansible.builtin.shell:
     cmd: |
       cloud-init clean --machine-id
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Reset cloud-init
   ansible.builtin.shell:
     cmd: |
       cloud-init clean
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Remove cloud-init.disabled
   ansible.builtin.file:
@@ -169,7 +169,7 @@
     src: files/etc/netplan/51-kubevirt-netplan.yaml
     dest: /etc/netplan/51-kubevirt-netplan.yaml
     mode: "0644"
-  when: ansible_os_family == "Debian" and kubevirt == "true"
+  when: ansible_facts['os_family'] == "Debian" and kubevirt == "true"
 
 - name: Find SSH host keys
   ansible.builtin.find:
@@ -189,8 +189,8 @@
     path: "{{ item.path }}"
   loop:
     - { path: /root/.ssh/authorized_keys }
-    - { path: "/home/{{ ansible_env.SUDO_USER | default(ansible_user_id) }}/.ssh/authorized_keys" }
-  when: ansible_os_family != "Flatcar"
+    - { path: "/home/{{ ansible_facts['env'].SUDO_USER | default(ansible_facts['user_id']) }}/.ssh/authorized_keys" }
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Remove SSH authorized users for Flatcar
   ansible.builtin.file:
@@ -198,7 +198,7 @@
     path: "{{ item.path }}"
   loop:
     - { path: /root/.ssh/authorized_keys }
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Truncate all remaining log files in /var/log
   ansible.builtin.shell: |
@@ -207,13 +207,13 @@
   args:
     executable: /bin/bash
 
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Delete all logrotated logs
   ansible.builtin.shell:
     cmd: |
       find /var/log -type f -regex '.*[0-9z]$' -exec rm {} +
-  when: ansible_os_family != "Flatcar"
+  when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Remove swapfile
   ansible.builtin.file:
@@ -223,7 +223,7 @@
     - /swap.img
     - /swapfile
     - /mnt/resource/swapfile
-  when: ansible_memory_mb.swap.total != 0
+  when: ansible_facts['memory_mb'].swap.total != 0
 
 - name: Truncate shell history
   ansible.builtin.file:
@@ -231,13 +231,13 @@
     path: "{{ item.path }}"
   loop:
     - { path: /root/.bash_history }
-    - { path: "/home/{{ ansible_env.SUDO_USER | default(ansible_user_id) }}/.bash_history" }
+    - { path: "/home/{{ ansible_facts['env'].SUDO_USER | default(ansible_facts['user_id']) }}/.bash_history" }
 
 - name: Rotate journalctl to archive logs
   ansible.builtin.shell:
     cmd: |
       journalctl --rotate
-  when: not ( ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 7 )
+  when: not ( ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version']|int <= 7 )
 
 - name: Remove archived journalctl logs
   ansible.builtin.shell:
@@ -251,22 +251,22 @@
     owner: root
     group: root
     mode: "0644"
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Remove any default Ignition files used by Packer
   ansible.builtin.file:
     state: absent
     path: /usr/share/oem/config.ign
-  when: ansible_os_family == "Flatcar"
+  when: ansible_facts['os_family'] == "Flatcar"
 
 - name: Start fstrim
   ansible.builtin.systemd:
     name: fstrim.service
     state: started
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Start ssh
   ansible.builtin.systemd:
     name: ssh
     enabled: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -29,14 +29,14 @@
     path: /etc/yum.conf
     regexp: ^exclude=
     line: exclude={{ package_list }}
-  when: ansible_distribution != "Amazon" or ansible_distribution_version != "2023"
+  when: ansible_facts['distribution'] != "Amazon" or ansible_facts['distribution_version'] != "2023"
 
 - name: Exclude packages from upgrade
   ansible.builtin.lineinfile:
     path: /etc/dnf/dnf.conf
     regexp: ^excludepkgs=
     line: excludepkgs={{ package_list }}
-  when: ansible_distribution == "Amazon" and ansible_distribution_version == "2023"
+  when: ansible_facts['distribution'] == "Amazon" and ansible_facts['distribution_version'] == "2023"
 
 - name: Import RPM repository tasks
   ansible.builtin.import_tasks: rpm_repos.yml
@@ -44,7 +44,7 @@
 
 - name: Remove RHEL subscription
   when:
-    - ansible_distribution == "RedHat"
+    - ansible_facts['distribution'] == "RedHat"
     - lookup('env', 'RHSM_USER') | length > 0
     - lookup('env', 'RHSM_PASS') | length > 0
   block:
@@ -72,15 +72,15 @@
   ansible.builtin.shell: |
     set -o pipefail
     sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
-  when: packer_builder_type != "googlecompute" and ansible_distribution_major_version|int != 9
+  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int != 9
 
 - name: Migrate interface configuration files to NetworkManager keyfiles
   ansible.builtin.command: nmcli connection migrate
-  when: packer_builder_type != "googlecompute" and ansible_distribution_major_version|int == 9
+  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int == 9
 
 - name: Reset network interface IDs
   ansible.builtin.shell: sed -i '/^\(uuid\)=/d' /etc/NetworkManager/system-connections/*.nmconnection
-  when: packer_builder_type != "googlecompute" and ansible_distribution_major_version|int == 9
+  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int == 9
 
 - name: Remove the kickstart log
   ansible.builtin.file:


### PR DESCRIPTION
## Change description

This PR sets `inject_facts_as_vars=False` in ansible.cfg and converts all bare ansible_* fact references (e.g. ansible_os_family) to the dict form (ansible_facts['os_family']) across playbooks, roles, and templates.

This eliminates the INJECT_FACTS_AS_VARS deprecation warnings emitted by ansible-core >=2.18. The current default (True) will flip to False in ansible-core 2.24, so this change future-proofs the codebase.

The Flatcar OS-family override tasks retain bare ansible_os_family as the set_fact key, which Ansible syncs back into ansible_facts.

## Related issues

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
