### PR TITLE
Add support for arm64-based AMIs

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -369,7 +369,7 @@ NODE_OVA_VSPHERE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-,$(PLATFORMS_AND_V
 NODE_OVA_VSPHERE_BASE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-base-,$(PLATFORMS_AND_VERSIONS))
 NODE_OVA_VSPHERE_CLONE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-clone-,$(PLATFORMS_AND_VERSIONS))
 
-AMI_BUILD_NAMES			   ?= ami-ubuntu-2204 ami-ubuntu-2404 ami-amazon-2 ami-amazon-2023 ami-flatcar ami-flatcar-arm64 ami-windows-2019
+AMI_BUILD_NAMES			   ?= ami-ubuntu-2204 ami-ubuntu-2404 ami-ubuntu-2204-arm64 ami-ubuntu-2404-arm64 ami-amazon-2 ami-amazon-2023 ami-amazon-2023-arm64 ami-flatcar ami-flatcar-arm64 ami-windows-2019
 HUAWEICLOUD_BUILD_NAMES ?= huaweicloud-ubuntu-2204
 GCE_BUILD_NAMES			   ?= gce-ubuntu-2204 gce-ubuntu-2404
 
@@ -698,8 +698,11 @@ $(RAW_CLEAN_TARGETS):
 ##@ Builds
 build-ami-amazon-2: ## Builds Amazon-2 Linux AMI
 build-ami-amazon-2023: ## Builds Amazon-2023 Linux AMI
+build-ami-amazon-2023-arm64: ## Builds Amazon-2023 Linux arm64 AMI
 build-ami-ubuntu-2204: ## Builds Ubuntu 22.04 AMI
+build-ami-ubuntu-2204-arm64: ## Builds Ubuntu 22.04 arm64 AMI
 build-ami-ubuntu-2404: ## Builds Ubuntu 24.04 AMI
+build-ami-ubuntu-2404-arm64: ## Builds Ubuntu 24.04 arm64 AMI
 build-ami-flatcar: ## Builds Flatcar
 build-ami-flatcar-arm64: ## Builds Flatcar arm64
 build-ami-windows-2019: ## Build Windows Server 2019 AMI Packer config
@@ -876,11 +879,13 @@ build-scaleway-all: $(SCALEWAY_BUILD_TARGETS) ## Builds all Scaleway images
 ##@ Validate packer config
 validate-ami-amazon-2: ## Validates Amazon-2 Linux AMI Packer config
 validate-ami-amazon-2023: ## Validates Amazon-2023 Linux AMI Packer config
+validate-ami-amazon-2023-arm64: ## Validates Amazon-2023 Linux arm64 AMI Packer config
 validate-ami-flatcar: ## Validates Flatcar AMI Packer config
 validate-ami-flatcar-arm64: ## Validates Flatcar arm64 AMI Packer config
 validate-ami-ubuntu-2204: ## Validates Ubuntu 22.04 AMI Packer config
-
+validate-ami-ubuntu-2204-arm64: ## Validates Ubuntu 22.04 arm64 AMI Packer config
 validate-ami-ubuntu-2404: ## Validates Ubuntu 24.04 AMI Packer config
+validate-ami-ubuntu-2404-arm64: ## Validates Ubuntu 24.04 arm64 AMI Packer config
 validate-ami-windows-2019: ## Validates Windows Server 2019 AMI Packer config
 validate-ami-all: $(AMI_VALIDATE_TARGETS) ## Validates all AMIs Packer config
 

--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -29,7 +29,9 @@ dependencies:
     vars:
       rpms: "{{ common_rpms }}"
       debs: "{{ common_debs }}"
-    when: packer_builder_type == "oracle-oci" and ansible_facts['architecture'] == "aarch64"
+    when: >
+      ansible_facts['architecture'] == "aarch64"
+        and ansible_facts['distribution'] not in ["VMware Photon OS", "Amazon"]
 
   - role: setup
     vars:
@@ -45,7 +47,7 @@ dependencies:
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
     when: >
       ansible_facts['distribution'] not in ["VMware Photon OS", "Amazon"]
-        and not (packer_builder_type == "oracle-oci" and ansible_facts['architecture'] == "aarch64")
+        and ansible_facts['architecture'] != "aarch64"
         and not packer_builder_type is search('qemu')
 
   - role: setup

--- a/images/capi/ansible/roles/providers/tasks/aws.yml
+++ b/images/capi/ansible/roles/providers/tasks/aws.yml
@@ -51,6 +51,11 @@
     name: hv-kvp-daemon
     state: stopped
     enabled: false
+  register: disable_hypervisor
+  ignore_errors: true
+  failed_when:
+    - disable_hypervisor.failed
+    - '"Could not find" not in (disable_hypervisor.msg | default(""))'
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Create cloud-init custom data source list

--- a/images/capi/packer/ami/amazon-2023-arm64.json
+++ b/images/capi/packer/ami/amazon-2023-arm64.json
@@ -1,0 +1,19 @@
+{
+  "amazon_ssm_agent_rpm": "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm",
+  "ami_filter_arch": "arm64",
+  "ami_filter_name": "al2023-ami-minimal-2023.*-kernel-6.1*",
+  "ami_filter_owners": "amazon",
+  "arch": "arm64",
+  "build_name": "amazon-2023-arm64",
+  "builder_instance_type": "t4g.small",
+  "distribution": "Amazon Linux",
+  "distribution_release": "Amazon Linux 2023",
+  "distribution_version": "2023",
+  "distro_version": "2023",
+  "epel_rpm_gpg_key": "",
+  "goss_arch": "arm64",
+  "redhat_epel_rpm": "",
+  "root_device_name": "/dev/xvda",
+  "source_ami": "",
+  "ssh_username": "ec2-user"
+}

--- a/images/capi/packer/ami/packer.json
+++ b/images/capi/packer/ami/packer.json
@@ -125,7 +125,7 @@
       "use_sudo": true,
       "vars_file": "{{user `goss_vars_file`}}",
       "vars_inline": {
-        "ARCH": "amd64",
+        "ARCH": "{{user `arch`}}",
         "OS": "{{user `distribution` | lower}}",
         "OS_VERSION": "{{user `distribution_version` | lower}}",
         "PROVIDER": "amazon",

--- a/images/capi/packer/ami/ubuntu-2204-arm64.json
+++ b/images/capi/packer/ami/ubuntu-2204-arm64.json
@@ -1,0 +1,18 @@
+{
+  "ami_filter_arch": "arm64",
+  "ami_filter_name": "ubuntu/images/*ubuntu-jammy-22.04-arm64-server-*",
+  "ami_filter_owners": "099720109477",
+  "ansible_extra_vars": "",
+  "arch": "arm64",
+  "build_name": "ubuntu-22.04-arm64",
+  "builder_instance_type": "t4g.small",
+  "distribution": "Ubuntu",
+  "distribution_release": "jammy",
+  "distribution_version": "22.04",
+  "goss_arch": "arm64",
+  "root_device_name": "/dev/sda1",
+  "source_ami": "",
+  "ssh_username": "ubuntu",
+  "ubuntu_repo": "http://ports.ubuntu.com/ubuntu-ports",
+  "ubuntu_security_repo": "http://ports.ubuntu.com/ubuntu-ports"
+}

--- a/images/capi/packer/ami/ubuntu-2404-arm64.json
+++ b/images/capi/packer/ami/ubuntu-2404-arm64.json
@@ -1,0 +1,18 @@
+{
+  "ami_filter_arch": "arm64",
+  "ami_filter_name": "ubuntu/images/*ubuntu-noble-24.04-arm64-server-*",
+  "ami_filter_owners": "099720109477",
+  "ansible_extra_vars": "",
+  "arch": "arm64",
+  "build_name": "ubuntu-24.04-arm64",
+  "builder_instance_type": "t4g.small",
+  "distribution": "Ubuntu",
+  "distribution_release": "noble",
+  "distribution_version": "24.04",
+  "goss_arch": "arm64",
+  "root_device_name": "/dev/sda1",
+  "source_ami": "",
+  "ssh_username": "ubuntu",
+  "ubuntu_repo": "http://ports.ubuntu.com/ubuntu-ports",
+  "ubuntu_security_repo": "http://ports.ubuntu.com/ubuntu-ports"
+}

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -57,7 +57,7 @@ package:
   {{end}}
 {{end}}
 # x86-only provider packages (hypervisor tools not available on arm64)
-{{if ne .Vars.ARCH "arm64"}}
+{{if ne .Vars.arch "arm64"}}
 {{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "package-x86"}}
   {{$name}}:
     installed: true

--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -56,6 +56,16 @@ package:
     {{$key}}: {{$val}}
   {{end}}
 {{end}}
+# x86-only provider packages (hypervisor tools not available on arm64)
+{{if ne .Vars.ARCH "arm64"}}
+{{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "package-x86"}}
+  {{$name}}:
+    installed: true
+  {{range $key, $val := $vers}}
+    {{$key}}: {{$val}}
+  {{end}}
+{{end}}
+{{end}}
 
 # Iterate thru different OS Versions like RHEL7/8, Photon 3/4(future) etc.
 {{$distro_version := .Vars.OS_VERSION}}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -461,7 +461,8 @@ ubuntu:
       snap.amazon-ssm-agent.amazon-ssm-agent.service:
         enabled: true
         running: true
-    package:
+    package: {}
+    package-x86:
       linux-cloud-tools-virtual:
       linux-tools-virtual:
     command:


### PR DESCRIPTION
## Change description
Enables ARM64 builds for AWS AMIs by skipping hypervisor packages not available on ARM.

- Is this change including a new Provider or a new OS? (y/n) N
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) N
- If adding a new provider, are you a representative of that provider? (y/n) N

## Additional context
Mostly we just needed to skip the hypervisor related packages. I did broaden the exclusions in the full setup tasks. Previously only oracle-oci aarch64 got the stripped-down package set. This way future ARM builds don't need to be added to a growing list of carve-outs as they're introduced.

I have built and launched an Ubuntu 2404 cluster using this AMI.
