### PR TITLE
ova: fix Photon 5 distro-sync failure due to alternatives/chkconfig conflict

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-photon.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 ---
+- name: Replace chkconfig with alternatives to satisfy iptables dependency
+  ansible.builtin.command: tdnf install -y alternatives --allowerasing
+  register: install_alternatives
+  changed_when: '"Nothing to do" not in install_alternatives.stderr'
+
 - name: Install cloud-init and tools for VMware Photon OS
   ansible.builtin.command: tdnf install {{ packages }} -y
   vars:

--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -36,6 +36,11 @@
   changed_when: '"Nothing to do" not in distro.stderr'
   when: not disable_public_repos|default(false)|bool
 
+- name: Replace chkconfig with alternatives to satisfy iptables dependency
+  ansible.builtin.command: tdnf install -y alternatives --allowerasing
+  register: install_alternatives
+  changed_when: '"Nothing to do" not in install_alternatives.stderr'
+
 - name: Perform a tdnf distro-sync
   ansible.builtin.command: tdnf distro-sync -y --refresh
   register: distro


### PR DESCRIPTION
## Change description

\`iptables-1.8.13-2.ph5\` and \`ebtables-2.0.11-4.ph5\` in the Photon 5 package repository now explicitly require the \`alternatives\` package (introduced by Broadcom on April 9, 2026 — see [iptables.spec](https://github.com/vmware/photon/blob/5.0/SPECS/iptables/iptables.spec#L41)).

The Photon 5 minimal ISO includes \`chkconfig\`, which **conflicts** with \`alternatives\` (alternatives is its replacement). Simply adding \`alternatives\` to the kickstart hangs the Photon installer due to the conflict.

**Fix:** Install \`alternatives --allowerasing\` (atomically replacing \`chkconfig\`) via Ansible before any \`tdnf\` install or \`distro-sync\` commands run. Applied in two places:

1. **\`roles/setup/tasks/photon.yml\`** — before \`distro-sync\` in \`firstboot.yml\`
2. **\`roles/providers/tasks/vmware-photon.yml\`** — before cloud-init install in \`node.yml\`, so the fix is present even if \`node.yml\` is run independently

- Is this change including a new Provider or a new OS? (y/n) **n**

## Related issues

- Ref: https://github.com/vmware/photon/issues/1646

## Additional context

**Root cause chain:**
1. Photon 5 minimal ISO installs \`chkconfig\` as part of the base system
2. \`iptables-1.8.13-2.ph5\` (updated April 9 2026) adds \`Requires: alternatives\`
3. \`alternatives\` conflicts with \`chkconfig\` (it is its replacement); \`tdnf\` cannot install \`alternatives\` without removing \`chkconfig\` first
4. \`tdnf distro-sync --refresh\` fails with \`Solv general runtime error (1301)\` because it cannot upgrade \`iptables\` without resolving the conflict
5. Fix: pre-install \`alternatives --allowerasing\` (replaces \`chkconfig\`) before \`distro-sync\` and \`tdnf install\` calls

**Why not the kickstart?** Adding \`alternatives\` to \`ks.json.tmpl\` causes the Photon minimal ISO installer to hang (the conflict with \`chkconfig\` is hit during kickstart package resolution, before the OS boots). The Ansible approach avoids this.

**Validated** with a live vSphere build against a Nimbus testbed — the \`distro-sync\` step and cloud-init install both complete successfully and the full \`photon-5-kube-v1.34.3\` OVA is produced.

The upstream fix ([vmware/photon#1646](https://github.com/vmware/photon/issues/1646)) would be to add \`Obsoletes: chkconfig\` + \`Provides: chkconfig\` to \`alternatives.spec\` so \`tdnf\` handles the transition automatically — making this workaround unnecessary in a future Photon 5 release.