### PR TITLE
fix: create /etc/sysctl.d/ for Flatcar before sysctl tasks run

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/flatcar.yml
+++ b/images/capi/ansible/roles/setup/tasks/flatcar.yml
@@ -21,6 +21,16 @@
     state: directory
     mode: "0755"
 
+# Flatcar Stable 4593.2.0+ ships without /etc/sysctl.d/ pre-created. The
+# node role's sysctl tasks write to /etc/sysctl.d/99-sysctl.conf via the
+# ansible.posix.sysctl module, which uses mkstemp in the parent directory
+# and fails with FileNotFoundError when the directory is missing.
+- name: Create /etc/sysctl.d directory
+  ansible.builtin.file:
+    path: /etc/sysctl.d
+    state: directory
+    mode: "0755"
+
 - name: Add env generator that includes system PATH on service path
   ansible.builtin.copy:
     src: etc/systemd/system-environment-generators/10-flatcar-path


### PR DESCRIPTION
## Change description

Flatcar uses a stateless `/etc/` model. Its baselayout package only pre-creates a small set of `/etc/` directories ([`tmpfiles.d/baselayout-etc.conf`](https://github.com/flatcar/baselayout/blob/HEAD/tmpfiles.d/baselayout-etc.conf): `/etc/profile.d`, `/etc/vim`, `/etc/sudoers.d`, …) — `/etc/sysctl.d/` is not among them and is never pre-created.

The `node` role's "Set and persist kernel params" task writes to `/etc/sysctl.d/99-sysctl.conf` (per `node` defaults for Flatcar) via `ansible.posix.sysctl`, which calls `mkstemp` in the parent directory and fails with `FileNotFoundError` when the directory is missing.

Fix: add a `file` task in the `setup` role's `flatcar.yml` that ensures `/etc/sysctl.d/` exists before any sysctl task runs. This mirrors the existing pattern in `node/tasks/flatcar.yml` for `/etc/modprobe.d/`, which is created the same way with the inline note *"because of the read-only filesystem on Flatcar in /etc"*. Aligns with Flatcar's documented convention for persistent sysctl overrides: https://www.flatcar.org/docs/latest/setup/customization/other-settings/

- Is this change including a new Provider or a new OS? (y/n) n

## Additional context

Failing task excerpt:

```
TASK [node : Set and persist kernel params]
FileNotFoundError: [Errno 2] No such file or directory:
'/etc/sysctl.d/.ansible_m_sysctl_<hash>.conf'
```