### PR TITLE
fix: bump Flatcar AMI volume_size to 15 GB for 4593.2.0+ partition layout

### DIFF
--- a/images/capi/packer/ami/flatcar-arm64.json
+++ b/images/capi/packer/ami/flatcar-arm64.json
@@ -17,5 +17,6 @@
   "sysusr_prefix": "/opt",
   "sysusrlocal_prefix": "/opt",
   "user_data": "",
-  "user_data_file": "packer/files/flatcar/ignition/bootstrap-cloud.json"
+  "user_data_file": "packer/files/flatcar/ignition/bootstrap-cloud.json",
+  "volume_size": "15"
 }

--- a/images/capi/packer/ami/flatcar.json
+++ b/images/capi/packer/ami/flatcar.json
@@ -15,5 +15,6 @@
   "sysusr_prefix": "/opt",
   "sysusrlocal_prefix": "/opt",
   "user_data": "",
-  "user_data_file": "packer/files/flatcar/ignition/bootstrap-cloud.json"
+  "user_data_file": "packer/files/flatcar/ignition/bootstrap-cloud.json",
+  "volume_size": "15"
 }


### PR DESCRIPTION
## Change description

Flatcar Stable 4593.2.0 increased baseline partition sizes (`/boot` to 1 GB, both `/usr` partitions to 2 GB, `/oem` to 1 GB), which pushes the source AMI snapshot above the global default `volume_size` of 8 GB defined in `packer/ami/packer.json`. EC2 rejects launch with:

    InvalidBlockDeviceMapping: Volume of size 8GB is smaller than
    snapshot, expect size >= 13GB

Override `volume_size` to 15 in `packer/ami/flatcar.json` and `packer/ami/flatcar-arm64.json` so the launch instance has headroom for the new `/` partition during Ansible provisioning and for the further partition growth Flatcar's release notes hint at (snapshot minimum is 13 GB).

- Is this change including a new Provider or a new OS? (y/n) n
