### PR TITLE
Bump ansible to v2.18.16

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Note: ansible-core v2.18 supports Python 3.11-3.13.
-_version_ansible_core="2.18.15"
+_version_ansible_core="2.18.16"
 
 case "${OSTYPE}" in
 linux*)


### PR DESCRIPTION
## Change description

Bump `ansible-core` from 2.18.15 to 2.18.16 (latest patch in the 2.18.x line).

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

- Fixes #

## Additional context

`make lint` passes cleanly with the new version.
