### PR TITLE
chore(ci): updating the cloudbuild gcb-docker-gcloud image to the latest release

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ timeout: 3000s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:63840f133e0dfeea0af9ef391210da7fab9d2676172e2967fccab0cd6110c4e7' # v20250513-9264efb079
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2' # v20260205-38cfa9523f
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/docs/book/src/capi/releasing.md
+++ b/docs/book/src/capi/releasing.md
@@ -5,6 +5,7 @@ The current release of Image Builder is [v0.1.50][] (April 1, 2026). The corresp
 ## Release Process
 
 Releasing image-builder is a simple process: project maintainers should be able to follow the steps below in order to create a new release.
+Before proceeding, make sure the current SHA being used in [`cloudbuild.yaml`](../../../../cloudbuild.yaml) is [still valid](https://console.cloud.google.com/artifacts/docker/k8s-staging-test-infra/us/gcr.io/gcb-docker-gcloud). If it is not, then the job that runs on tag will fail. 
 
 ### Create a tag
 


### PR DESCRIPTION
## Change description
A recent release failed due to a missing sha in the registry which is used for by prow. This has meant the release has failed.

This PR changes the SHA to the latest version available.

It also updates the release docs with a note to make sure `cloudbuild.yaml` is using the latest version or at least a version that still exists.
