### PR TITLE
Remove dead python2 references

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+++ b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
@@ -30,23 +30,6 @@
   ansible.builtin.set_fact:
     cloud_init_version: "{{ ansible_facts.packages['cloud-init'][0].version }}"
 
-- name: Install python2 pip
-  ansible.builtin.dnf:
-    name: "{{ packages }}"
-    state: present
-  vars:
-    packages:
-      - python2-pip
-  when: ansible_facts['distribution_major_version']|int <= 8
-
-# pip on CentOS needs to be upgraded, but since it's still
-# Python 2.7, need < 21.0
-- name: Upgrade pip
-  ansible.builtin.pip:
-    name: pip<21.0
-    state: forcereinstall
-  when: ansible_facts['distribution_major_version'] == '7'
-
 # Directly installing Guestinfo datasource is needed so long as
 # cloud-init is < 21.3
 - name: Directly install Guestinfo

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -156,7 +156,6 @@ centos:
       open-vm-tools:
   ova:
     package:
-      python2-pip:
       open-vm-tools:
   qemu:
     package:
@@ -171,7 +170,6 @@ centos:
     package:
       cloud-init:
       cloud-utils-growpart:
-      python2-pip:
 almalinux:
   common-package: *common_rpms
   ova:
@@ -278,7 +276,6 @@ rockylinux:
     os_version:
     - distro_version: "8"
       package:
-        python2-pip:
         <<: *rh8_rpms
     - distro_version: "9"
       package:
@@ -379,7 +376,6 @@ rhel:
     os_version:
     - distro_version: "8"
       package:
-        python2-pip:
         <<: *rh8_rpms
     - distro_version: "9"
       package:


### PR DESCRIPTION
## Change description

Cleanup of dead `python2` references that target RHEL/CentOS 7 and 8 — neither of which are build targets in image-builder anymore (the README only lists `rhel-9`, `rockylinux-9`, `almalinux-9`, `centos-9`, and `Makefile` has no `*-7`/`*-8` entries).

Removes:

- `roles/providers/tasks/vmware-redhat.yml`: the `Install python2 pip` task (gated on `distribution_major_version <= 8`) and the `Upgrade pip` task (gated on `== 7`). Both conditions are now unreachable.
- `packer/goss/goss-vars.yaml`: four `python2-pip:` entries (two ungated under `centos:`, two under `distro_version: "8"` blocks).

`make lint` passes cleanly.

- Is this change including a new Provider or a new OS? (y/n) **n**

## Related issues

- Closes #578 (no longer applicable — Photon 3 has been removed entirely; current Photon 4/5 paths already use python3 only — but this PR cleans up the unrelated python2 cruft that lingered elsewhere)

## Additional context

No behavior change for any currently-built distro. Easy revert if desired.
