### PR TITLE
Remove dead RHEL 7/8 ansible code paths and orphaned nutanix cloud-init files

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/main.yml
+++ b/images/capi/ansible/roles/providers/tasks/main.yml
@@ -143,15 +143,6 @@
     mode: "0644"
   when: ansible_facts['os_family'] == "Debian"
 
-- name: Set cloudinit feature flags for redhat 8
-  ansible.builtin.copy:
-    src: usr/lib/python3/site-packages/cloudinit/feature_overrides.py
-    dest: /usr/lib/python3.6/site-packages/cloudinit/feature_overrides.py
-    owner: root
-    group: root
-    mode: "0644"
-  when: ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] == "8"
-
 - name: Set cloudinit feature flags for redhat 9
   ansible.builtin.copy:
     src: usr/lib/python3/site-packages/cloudinit/feature_overrides.py

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -239,7 +239,6 @@
   ansible.builtin.shell:
     cmd: |
       journalctl --rotate
-  when: not ( ansible_facts['os_family'] == "RedHat" and ansible_facts['distribution_major_version']|int <= 7 )
 
 - name: Remove archived journalctl logs
   ansible.builtin.shell:

--- a/images/capi/packer/nutanix/linux/cloud-init/rhel/8/user-data.tmpl
+++ b/images/capi/packer/nutanix/linux/cloud-init/rhel/8/user-data.tmpl
@@ -1,9 +1,0 @@
-#cloud-config
-users:
-  - name: builder
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-chpasswd:
-  list: |
-    builder:$SSH_PASSWORD
-  expire: False
-ssh_pwauth: True

--- a/images/capi/packer/nutanix/linux/cloud-init/rockylinux/8/user-data.tmpl
+++ b/images/capi/packer/nutanix/linux/cloud-init/rockylinux/8/user-data.tmpl
@@ -1,9 +1,0 @@
-#cloud-config
-users:
-  - name: builder
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-chpasswd:
-  list: |
-    builder:$SSH_PASSWORD
-  expire: False
-ssh_pwauth: True


### PR DESCRIPTION
## Change description

Cleanup of dead code and orphaned files for RHEL/CentOS 7 and 8 paths that are no longer build targets. The Makefile and README matrix have only `*-9` variants for RHEL/CentOS/Rocky/AlmaLinux.

Removes:

- `roles/providers/tasks/main.yml`: the `Set cloudinit feature flags for redhat 8` task (gated on `distribution_major_version == "8"`).
- `roles/sysprep/tasks/main.yml`: the `<= 7` guard around the `Rotate journalctl` task (always-true now).
- `packer/nutanix/linux/cloud-init/{rhel,rockylinux}/8/user-data.tmpl`: orphaned — there's no `rhel-8.json` or `rockylinux-8.json` in `packer/nutanix/` that would consume them.

`make lint` passes cleanly.

- Is this change including a new Provider or a new OS? (y/n) **n**

## Related issues

- Follow-up cleanup discovered while looking at #578 (closed). A second small PR will follow for the `rh8_rpms` blocks in `packer/goss/goss-vars.yaml`.

## Additional context

No behavior change for any currently-built distro.
