### PR TITLE
Remove dead RHEL/CentOS 8 entries from goss-vars

### DIFF
--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -176,9 +176,6 @@ almalinux:
     package:
       open-vm-tools:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -257,10 +254,6 @@ rockylinux:
   amazon:
     package:
       amazon-ssm-agent:
-    os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     command:
       /usr/local/sbin/aws --version:
         exit-status: 0
@@ -274,9 +267,6 @@ rockylinux:
     package:
       open-vm-tools:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -286,9 +276,6 @@ rockylinux:
       cloud-init:
       cloud-utils:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -300,9 +287,6 @@ rockylinux:
       lvm2:
       xfsprogs:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -314,10 +298,6 @@ rockylinux:
     package:
       cloud-init:
       cloud-utils-growpart:
-    os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
   openstack:
     package:
       cloud-init:
@@ -339,10 +319,6 @@ rhel:
   amazon:
     package:
       amazon-ssm-agent:
-    os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     command:
       /usr/local/sbin/aws --version:
         exit-status: 0
@@ -355,10 +331,6 @@ rhel:
   azure:
     package:
       open-vm-tools:
-    os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
   gcp:
     command:
       find -L /bin -maxdepth 1 -type f -executable -printf "%f\n" | grep -Fx 'gcloud':
@@ -366,17 +338,10 @@ rhel:
         stdout: ["gcloud"]
         stderr: []
         timeout: 0
-    os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
   ova:
     package:
       open-vm-tools:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -386,9 +351,6 @@ rhel:
       cloud-init:
       cloud-utils-growpart:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -397,9 +359,6 @@ rhel:
       cloud-init:
       cloud-utils-growpart:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms
@@ -411,9 +370,6 @@ rhel:
       lvm2:
       xfsprogs:
     os_version:
-    - distro_version: "8"
-      package:
-        <<: *rh8_rpms
     - distro_version: "9"
       package:
         <<: *rh9_rpms


### PR DESCRIPTION
## Change description

Removes dead `distro_version: "8"` blocks from `images/capi/packer/goss/goss-vars.yaml`. These goss test entries are unreachable: image-builder no longer has any `*-8` build targets — `Makefile` and the README matrix only reference `rhel-9`, `rockylinux-9`, `almalinux-9`, and `centos-9`.

Also drops a few empty `os_version:` keys left behind after removing the only child entry, and deletes a couple of `python2-pip:` entries that lived inside the removed blocks (also covered by #2000 in the lines outside these blocks).

The `rh8_rpms` YAML alias itself is **kept** because the `oracle linux:oci` block still references it; all five packages it lists (`curl`, `yum-utils`, `nftables`, `python3-netifaces`, `python3-requests`) are valid on Oracle Linux 9, so goss behavior for `oci-oracle-linux-9` is unchanged.

- Is this change including a new Provider or a new OS? (y/n) **n**

## Related issues

- Follow-up cleanup discovered while looking at #578 (closed). Companion to #2001.

## Additional context

YAML structure validated locally with `yaml.safe_load`. No behavior change for any currently-built distro.
