### PR TITLE
Add CentOS Stream 10 support for PowerVS image builds

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -397,7 +397,7 @@ QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES				?=	raw-ubuntu-2204 raw-ubuntu-2204-efi raw-ubuntu-2404 raw-ubuntu-2404-efi raw-flatcar raw-rhel-9 raw-rhel-9-efi
 
-POWERVS_BUILD_NAMES         ?= powervs-centos-9
+POWERVS_BUILD_NAMES         ?= powervs-centos-9 powervs-centos-10
 
 NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2204 nutanix-ubuntu-2404 nutanix-rhel-9 nutanix-rockylinux-9 nutanix-flatcar nutanix-windows-2022
 
@@ -977,6 +977,7 @@ validate-osc-ubuntu-2404: ## Validates Ubuntu 24.04 Outscale Snapshot Packer con
 validate-osc-all: $(OSC_VALIDATE_TARGETS) ## Validates all Outscale Snapshot Packer config
 
 validate-powervs-centos-9: ## Validates the PowerVS CentOS 9 image packer config
+validate-powervs-centos-10: ## Validates the PowerVS CentOS 10 image packer config
 validate-powervs-all: $(POWERVS_VALIDATE_TARGETS) ## Validates all PowerVS Packer config
 
 validate-nutanix-ubuntu-2204: ## Validates Ubuntu 22.04 Nutanix Packer config

--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -59,6 +59,7 @@
     name: "*"
     state: latest
     lock_timeout: 60
+    exclude: "{{ 'lsvpd*' if ansible_facts['distribution_major_version']|int == 10 else omit }}"
 
 - name: Install baseline dependencies
   ansible.builtin.dnf:

--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
@@ -72,7 +72,7 @@
   ansible.builtin.shell: |
     set -o pipefail
     sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
-  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int != 9
+  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int not in [9, 10]
 
 - name: Migrate interface configuration files to NetworkManager keyfiles
   ansible.builtin.command: nmcli connection migrate
@@ -80,7 +80,7 @@
 
 - name: Reset network interface IDs
   ansible.builtin.shell: sed -i '/^\(uuid\)=/d' /etc/NetworkManager/system-connections/*.nmconnection
-  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int == 9
+  when: packer_builder_type != "googlecompute" and ansible_facts['distribution_major_version']|int in [9, 10]
 
 - name: Remove the kickstart log
   ansible.builtin.file:

--- a/images/capi/packer/powervs/centos-10.json
+++ b/images/capi/packer/powervs/centos-10.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "centos-streams10",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm",
+  "source_cos_bucket": "power-oss-bucket",
+  "source_cos_object": "centos-streams-10.ova.gz",
+  "source_cos_region": "us-south",
+  "ssh_username": "root"
+}


### PR DESCRIPTION
## Change description

Extends image-builder to support PowerVS image builds using CentOS Stream 10, enabling CAPIBM to build Kubernetes node images on CentOS 10 ppc64le.

- Add `packer/powervs/centos-10.json` with CentOS Stream 10 base image config
- Add `powervs-centos-10` build and validate targets to Makefile
- Exclude `lsvpd` from dnf update — IBM RHEL9 repo provides a version with a missing `libsgutils2` dependency on CentOS 10
- Skip ifcfg network reset for CentOS 10 — the `network-scripts` directory was removed in CentOS 10 in favour of NetworkManager

- Is this change including a new Provider or a new OS? (y/n) **y** (new OS: CentOS Stream 10)
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) **n** (PowerVS section does not currently list supported OS versions)
- If adding a new provider, are you a representative of that provider? (y/n) **n/a**

## Related issues

None

## Additional context

Validated by successfully building `capibm-powervs-centos-streams10` with Kubernetes v1.34.7.
Node reached `Ready` state on PowerVS osa21 (ppc64le) with the following configuration:

- OS: CentOS Stream 10 (Coughlan)
- Kernel: 6.12.0-225.el10.ppc64le
- Architecture: ppc64le
- Container runtime: containerd 2.2.2
- Kubernetes: v1.34.7

