### PR TITLE
Windows: improve StartKubelet.ps1 kubelet bootstrap

### DIFF
--- a/images/capi/ansible/windows/roles/kubernetes/templates/StartKubelet.ps1
+++ b/images/capi/ansible/windows/roles/kubernetes/templates/StartKubelet.ps1
@@ -13,18 +13,30 @@
 # limitations under the License.
 
 # From https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
-$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
-$kubeAdmArgs = $FileContent.TrimStart('KUBELET_KUBEADM_ARGS=').Trim('"')
+$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env" -Raw
+# Substring strip (not char-set) of the KUBELET_KUBEADM_ARGS="..." wrapper.
+$kubeAdmArgs = ($FileContent -replace '(?s)^\s*KUBELET_KUBEADM_ARGS=("?)(.*?)\1\s*$', '$2').Trim()
 
-$args = "--cert-dir=$env:SYSTEMDRIVE/var/lib/kubelet/pki",
-        "--config=$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml",
-        "--bootstrap-kubeconfig=$env:SYSTEMDRIVE/etc/kubernetes/bootstrap-kubelet.conf",
-        "--kubeconfig=$env:SYSTEMDRIVE/etc/kubernetes/kubelet.conf",
-        "--hostname-override=$(hostname)",
-        "--enable-debugging-handlers",
-        "--cgroups-per-qos=false",
-        "--enforce-node-allocatable=`"`"",
-        "--resolv-conf=`"`""
+$argList = @(
+    "--cert-dir=$env:SYSTEMDRIVE/var/lib/kubelet/pki",
+    "--config=$env:SYSTEMDRIVE/var/lib/kubelet/config.yaml",
+    "--bootstrap-kubeconfig=$env:SYSTEMDRIVE/etc/kubernetes/bootstrap-kubelet.conf",
+    "--kubeconfig=$env:SYSTEMDRIVE/etc/kubernetes/kubelet.conf",
+    "--hostname-override=$(hostname)",
+    "--enable-debugging-handlers",
+    "--cgroups-per-qos=false",
+    '--enforce-node-allocatable=""',
+    '--resolv-conf=""'
+)
+if ($kubeAdmArgs) {
+    $argList += $kubeAdmArgs -split '\s+'
+}
 
-$kubeletCommandLine = "{{ kubernetes_install_path }}\kubelet.exe " + ($args -join " ") + " $kubeAdmArgs"
-Invoke-Expression $kubeletCommandLine
+# Log the resolved command line so failures are diagnosable from the kubelet log dir.
+$kubeletExe = "{{ kubernetes_install_path }}\kubelet.exe"
+$logDir = "$env:SYSTEMDRIVE\var\log\kubelet"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+"$(Get-Date -Format o) $kubeletExe $($argList -join ' ')" | Out-File -Append -FilePath "$logDir\start-kubelet.log"
+
+# Splat the args so PowerShell does not re-interpret values containing `=`, `:`, `$`, etc.
+& $kubeletExe @argList


### PR DESCRIPTION
## Change description

Three small robustness fixes to the Windows `StartKubelet.ps1` template:

1. Replace `String.TrimStart('KUBELET_KUBEADM_ARGS=')` (char-set strip, fragile) with a regex substring strip.
2. Replace `Invoke-Expression` with `& $kubelet @argList` so PowerShell doesn't re-parse flag values containing `=`, `:`, `$`, etc.
3. Log the final kubelet command line to `…\var\log\kubelet\start-kubelet.log` before exec, so future bootstrap issues are diagnosable from a single file.

No behavioral change intended for the current kubeadm output format; this is purely defensive against future kubeadm/kubelet flag changes (e.g. recent activity around `--cloud-provider` and `--register-with-taints`).

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

- Fixes #

## Additional context

Surfaced while debugging Windows nodes that registered without the `node.cloudprovider.kubernetes.io/uninitialized` taint in the `cloud-provider-azure-ccm-windows-capz` job.
