### PR TITLE
Bump CAPG nightly Kubernetes versions to 1.34.8 and 1.35.5

### DIFF
--- a/images/capi/packer/gce/ci/nightly/overwrite-1-34.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-34.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.34.3-1.1",
-  "kubernetes_rpm_version": "1.34.3",
-  "kubernetes_semver": "v1.34.3",
+  "kubernetes_deb_version": "1.34.8-1.1",
+  "kubernetes_rpm_version": "1.34.8",
+  "kubernetes_semver": "v1.34.8",
   "kubernetes_series": "v1.34",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }

--- a/images/capi/packer/gce/ci/nightly/overwrite-1-35.json
+++ b/images/capi/packer/gce/ci/nightly/overwrite-1-35.json
@@ -1,8 +1,8 @@
 {
   "build_timestamp": "nightly",
-  "kubernetes_deb_version": "1.35.0-1.1",
-  "kubernetes_rpm_version": "1.35.0",
-  "kubernetes_semver": "v1.35.0",
+  "kubernetes_deb_version": "1.35.5-1.1",
+  "kubernetes_rpm_version": "1.35.5",
+  "kubernetes_semver": "v1.35.5",
   "kubernetes_series": "v1.35",
   "service_account_email": "gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com"
 }


### PR DESCRIPTION

Bump Kubernetes versions in the CAPG GCE nightly overwrite files:

- `overwrite-1-34.json`: 1.34.3 → 1.34.8
- `overwrite-1-35.json`: 1.35.0 → 1.35.5