### PR TITLE
Ubuntu 2404 cloud-image

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -390,7 +390,7 @@ OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2204 osc-ubuntu-2404 osc-ubuntu-2604
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2404 qemu-ubuntu-2404-efi qemu-ubuntu-2604 qemu-ubuntu-2604-efi qemu-ubuntu-2204-efi qemu-centos-9 qemu-rhel-9 qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2404 qemu-ubuntu-2404-cloudimg qemu-ubuntu-2404-efi qemu-ubuntu-2604 qemu-ubuntu-2604-efi qemu-ubuntu-2204-efi qemu-centos-9 qemu-rhel-9 qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
 
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
@@ -820,6 +820,7 @@ build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
 build-qemu-ubuntu-2204-cloudimg: ## Builds Ubuntu 22.04 QEMU image using cloud image
 build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
 build-qemu-ubuntu-2404: ## Builds Ubuntu 24.04 QEMU image
+build-qemu-ubuntu-2404-cloudimg: ## Builds Ubuntu 24.04 QEMU image using cloud image
 build-qemu-ubuntu-2404-efi: ## Builds Ubuntu 24.04 QEMU image that EFI boots
 build-qemu-ubuntu-2604: ## Builds Ubuntu 26.04 QEMU image
 build-qemu-ubuntu-2604-efi: ## Builds Ubuntu 26.04 QEMU image that EFI boots
@@ -983,6 +984,7 @@ validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
 validate-qemu-ubuntu-2204-cloudimg: ## Validates Ubuntu 22.04 QEMU image packer config using cloud image
 validate-qemu-ubuntu-2204-efi: ## Validates Ubuntu 22.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2404: ## Validates Ubuntu 24.04 QEMU image packer config
+validate-qemu-ubuntu-2404-cloudimg: ## Validates Ubuntu 24.04 QEMU image packer config using cloud image
 validate-qemu-ubuntu-2404-efi: ## Validates Ubuntu 24.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2604: ## Validates Ubuntu 26.04 QEMU image packer config
 validate-qemu-ubuntu-2604-efi: ## Validates Ubuntu 26.04 QEMU EFI image packer config

--- a/images/capi/packer/qemu/linux/ubuntu/cloud-init/24.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/cloud-init/24.04/user-data.tmpl
@@ -1,0 +1,9 @@
+#cloud-config
+ssh_pwauth: true
+users:
+  - name: builder
+    passwd: $ENCRYPTED_SSH_PASSWORD
+    groups: [adm, cdrom, dip, plugdev, lxd, sudo]
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash

--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -70,6 +70,18 @@
   ],
   "provisioners": [
     {
+      "expect_disconnect": true,
+      "environment_vars": [
+        "WAIT_FOR_CLOUDINIT={{user `wait_for_cloudinit`}}"
+      ],
+      "inline": [
+        "if [ \"$WAIT_FOR_CLOUDINIT\" != \"true\" ]; then exit 0; fi",
+        "cloud-init status --wait"
+      ],
+      "inline_shebang": "/bin/bash -e",
+      "type": "shell"
+    },
+    {
       "environment_vars": [
         "PYPY_HTTP_SOURCE={{user `pypy_http_source`}}"
       ],
@@ -102,7 +114,8 @@
         "sudo reboot now"
       ],
       "inline_shebang": "/bin/bash -e",
-      "type": "shell"
+      "type": "shell",
+      "pause_after": "{{user `extra_reboot_timeout`}}s"
     },
     {
       "pause_before": "30s",
@@ -228,6 +241,8 @@
     "ssh_password": "$SSH_PASSWORD",
     "ssh_username": "builder",
     "vm_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
-    "vnc_bind_address": "127.0.0.1"
+    "vnc_bind_address": "127.0.0.1",
+    "wait_for_cloudinit": "false",
+    "extra_reboot_timeout": "1"
   }
 }

--- a/images/capi/packer/qemu/qemu-ubuntu-2404-cloudimg.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2404-cloudimg.json
@@ -1,0 +1,15 @@
+{
+  "build_name": "ubuntu-2404",
+  "cd_files": "./packer/qemu/linux/ubuntu/cloud-init/24.04/*",
+  "disk_image": "true",
+  "distribution_version": "2404",
+  "distro_name": "ubuntu",
+  "extra_reboot_timeout": "90",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "https://cloud-images.ubuntu.com/noble/current/SHA256SUMS",
+  "iso_checksum_type": "file",
+  "iso_url": "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img",
+  "os_display_name": "Ubuntu 24.04",
+  "shutdown_command": "shutdown -P now",
+  "wait_for_cloudinit": "true"
+}


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->
Following the tradition from Ubuntu 22 cloud-image, somehow the Ubuntu 24 was introduced 2 years ago, non-cloudimage. 
This PR brings Ubuntu 24 cloud image, following closely the pattern from Ubuntu 22.

## Notes
There are a few delay tweaks to improve the reliabilty to successfully start, handling race conditions.


**- Is this change including a new Provider or a new OS? (y/n)**  
       - "No" - Ubuntu 24.04 is already there, this is another imagetype.
**- If yes, has the Provider/OS matrix been updated in the readme? (y/n)** 
       - "no" - Ubuntu 24.04 already is present. Ubuntu 22.04  using cloud-image was not specified as cloud-image. 
**- If adding a new provider, are you a representative of that provider? (y/n)** 
      -Not relevant.

