### PR TITLE
⬆️ Bump containerd to LTS v2.3.1 and runc to v1.4.2

### DIFF
--- a/images/capi/ansible/roles/containerd/defaults/main.yml
+++ b/images/capi/ansible/roles/containerd/defaults/main.yml
@@ -20,5 +20,5 @@ containerd_baseurl: https://github.com/containerd/containerd/releases/download/v
 containerd_filename: "containerd-{{ containerd_version }}-{{ system }}-{{ arch }}.tar.gz"
 containerd_url: "{{ containerd_baseurl }}/{{ containerd_filename }}"
 containerd_runc_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ arch }}"
-runc_version: "1.3.4"
+runc_version: "1.4.2"
 containerd_runc_checksum_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.sha256sum"

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -5,6 +5,6 @@
   "containerd_gvisor_runtime": "false",
   "containerd_gvisor_version": "latest",
   "containerd_image_pull_progress_timeout": null,
-  "containerd_version": "2.2.2",
-  "runc_version": "1.3.4"
+  "containerd_version": "2.3.1",
+  "runc_version": "1.4.2"
 }

--- a/images/capi/packer/config/ppc64le/containerd.json
+++ b/images/capi/packer/config/ppc64le/containerd.json
@@ -1,5 +1,5 @@
 {
   "containerd_image_pull_progress_timeout": null,
-  "containerd_sha256": "8f7a8190f2a635cd0e5580a131408a275ba277f7a04edffba4a4005960093987",
-  "containerd_version": "2.2.2"
+  "containerd_sha256": "cb5bcdb38c79fb78dc7b4e7c02d0c0e41b486446f646a49ed7e6c35c077d8d33",
+  "containerd_version": "2.3.1"
 }


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
We can now upgrade to Containerd 2.3 LTS release.


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) no
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) no
- If adding a new provider, are you a representative of that provider? (y/n) no

