### PR TITLE
Validate target names in top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,6 @@ update-release-docs: ## Updates the docs with reference to the latest release ve
 	images/capi/scripts/release-update-docs.sh
 
 .DEFAULT:
-	$(MAKE) -C images/capi $@
+	@$(if $(or $(findstring ',$@),$(findstring \,$@)),$(error Invalid target name: $@))
+	@case '$@' in *[!a-zA-Z0-9_./-]*) echo 'Invalid target name' >&2; exit 1 ;; esac
+	@$(MAKE) -C images/capi '$@'


### PR DESCRIPTION
## Change description

The top-level Makefile's .DEFAULT rule forwarded unknown targets to images/capi via:

    .DEFAULT:
            $(MAKE) -C images/capi $@

This commit hardens .DEFAULT with two layers of validation:

  1. A make-level $(findstring) check rejects target names containing single quotes or backslashes, both of which could be used to break out of shell single-quoting.
  2. A shell-level case statement enforces an allowlist of safe characters ([a-zA-Z0-9_./-]) on the validated target name, which is now passed to the recursive make call inside single quotes.
