### PR TITLE
Fix apt-mark hold race with apt-daily/unattended-upgrades

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -17,6 +17,28 @@
     last_log_mode: "0664"
     machine_id_mode: "0644"
 
+- name: Get installed packages
+  ansible.builtin.package_facts:
+
+- name: Disable apt-daily services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop:
+    - apt-daily.timer
+    - apt-daily-upgrade.timer
+
+- name: Disable unattended upgrades if installed
+  ansible.builtin.systemd:
+    name: unattended-upgrades
+    state: stopped
+    enabled: false
+  when: "'unattended-upgrades' in ansible_facts.packages"
+
+# The apt-daily/unattended-upgrades services may still be running from before
+# they were disabled above. Retry the apt-mark calls until the dpkg frontend
+# lock is released to avoid a flaky race with concurrent apt activity.
 - name: Pin all installed packages with apt-mark
   ansible.builtin.shell: |
     set -o pipefail
@@ -24,6 +46,10 @@
 
   args:
     executable: /bin/bash
+  register: sysprep_apt_mark_hold
+  until: sysprep_apt_mark_hold.rc == 0
+  retries: 30
+  delay: 10
 
 - name: Unpin grub packages with apt-mark for MaaS
   ansible.builtin.shell: |
@@ -32,6 +58,10 @@
 
   args:
     executable: /bin/bash
+  register: sysprep_apt_mark_unhold_grub
+  until: sysprep_apt_mark_unhold_grub.rc == 0
+  retries: 30
+  delay: 10
   when: provider is defined and provider is search('maas')
 
 - name: Remove extra repos
@@ -89,25 +119,6 @@
   loop:
     - { path: /var/lib/apt/lists, state: absent, mode: "0755" }
     - { path: /var/lib/apt/lists, state: directory, mode: "0755" }
-
-- name: Disable apt-daily services
-  ansible.builtin.systemd:
-    name: "{{ item }}"
-    state: stopped
-    enabled: false
-  loop:
-    - apt-daily.timer
-    - apt-daily-upgrade.timer
-
-- name: Get installed packages
-  ansible.builtin.package_facts:
-
-- name: Disable unattended upgrades if installed
-  ansible.builtin.systemd:
-    name: unattended-upgrades
-    state: stopped
-    enabled: false
-  when: "'unattended-upgrades' in ansible_facts.packages"
 
 - name: Reset network interface IDs
   ansible.builtin.file:


### PR DESCRIPTION
**What this PR does / why we need it**

The sysprep Debian playbook disables `apt-daily` timers and `unattended-upgrades`, but does so *after* running `apt-mark hold` on all installed packages. On freshly booted Azure VMs those services are often still in flight and hold the dpkg frontend lock, causing intermittent failures like the one seen in [pull-azure-sigs #2059304841871626240](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_image-builder/2017/pull-azure-sigs/2059304841871626240):

```
dpkg: error: dpkg frontend lock was locked by another process with pid 10455
E: Sub-process dpkg --set-selections returned an error code (2)
E: Executing dpkg failed. Are you root?
```

This change:

1. Moves the `Disable apt-daily services`, `Get installed packages`, and `Disable unattended upgrades` tasks ahead of the `apt-mark hold` task, so the timers/services are stopped before we contend for the dpkg lock.
2. Adds a bounded retry loop (`until` / `retries: 30` / `delay: 10`) on the `apt-mark` shell tasks as a guard, in case cloud-init or another apt run is still finishing when sysprep starts.

Both Ubuntu 22.04 SIG builds (regular and gen2) in the linked CI run failed at this exact task; the other 12 images in the same run succeeded. The fix targets the well-known apt/dpkg lock race seen on Ubuntu cloud images.

**Which issue(s) this PR fixes**

Addresses flaky `pull-azure-sigs` failures at the `Pin all installed packages with apt-mark` task.

**Special notes for your reviewer**

- Pure ordering + retry change; no behavior change on the happy path.
- `ansible-lint` passes for this file (the remaining findings are pre-existing in surrounding tasks).
- The new register variables use the required `sysprep_` role prefix.