### PR TITLE
Allow Bring Your Own Packer via PACKER_BIN/PACKER_VERSION env vars

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -27,5 +27,6 @@
   - [Testing the Images](./capi/goss/goss.md)
   - [Using Container Images](./capi/container-image.md)
   - [Customizing containerd](./capi/containerd/customizing-containerd.md)
+  - [Packer version and BYO Packer](./capi/packer.md)
   - [Releasing](./capi/releasing.md)
 - [Glossary](./glossary.md)

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -6,7 +6,7 @@ The Image Builder can be used to build images intended for use with Kubernetes [
 
 [Packer](https://www.packer.io) and [Ansible](https://github.com/ansible/ansible) are used for building these images. This tooling has been forked and extended from the [Wardroom](https://github.com/heptiolabs/wardroom) project.
 
-- [Packer](https://www.packer.io/intro/getting-started/install.html) version >= 1.6.0
+- [Packer](https://www.packer.io/intro/getting-started/install.html) version `1.9.5` (the default pinned by `hack/ensure-packer.sh`; see [Packer version and Bring Your Own Packer](./packer.md) to use a different version)
 - [Goss plugin for Packer](https://github.com/YaleUniversity/packer-provisioner-goss) version >= 1.2.0
 - [Ansible](http://docs.ansible.com/ansible/latest/intro_installation.html) version >= 2.10.0
 

--- a/docs/book/src/capi/packer.md
+++ b/docs/book/src/capi/packer.md
@@ -1,0 +1,91 @@
+# Packer version and Bring Your Own Packer
+
+image-builder uses [HashiCorp Packer](https://www.packer.io) to drive every
+image build. The repository **pins Packer to version `1.9.5`**, which is the
+last release under the MPL-2.0 license. Beginning with v1.10.0, HashiCorp
+relicensed Packer under the Business Source License (BUSL).
+
+`images/capi/hack/ensure-packer.sh` installs the pinned version into
+`images/capi/.local/bin` whenever `make deps-*` runs.
+
+## Why the pin?
+
+Kubernetes-sigs projects depend only on open-source-licensed tooling. The
+pin to the last MPL-2.0 Packer release lets image-builder continue to be
+used and distributed without inheriting the BUSL terms.
+
+## Bring Your Own Packer
+
+You can override the pinned Packer in three ways. These knobs are
+recognized by both `hack/ensure-packer.sh` and the `Makefile`, and apply to
+every `make build-*` / `make validate-*` target.
+
+| Variable               | Default | Effect                                                                                                                                                                                                                  |
+| ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PACKER_BIN`           | _unset_ | Absolute path to an existing Packer binary. `ensure-packer.sh` validates it and exits; the `Makefile` uses it for every `packer init`/`build`/`validate`. Highest precedence.                                            |
+| `PACKER_VERSION`       | `1.9.5` | Version that `ensure-packer.sh` downloads into `.local/bin` when it manages Packer itself.                                                                                                                               |
+| `IB_ALLOW_ANY_PACKER`  | `0`     | Set to `1` to accept whatever `packer` is already on `PATH` instead of having `ensure-packer.sh` replace it with the pinned version. Emits a license warning if the detected Packer is >= 1.10.0 (BUSL).                |
+
+You can also override the binary directly on the `make` command line:
+
+```bash
+make PACKER=/opt/packer/packer build-ami-ubuntu-2404
+```
+
+### Examples
+
+Use a Packer you already have installed:
+
+```bash
+export PACKER_BIN=/usr/local/bin/packer
+make deps-azure
+make build-azure-sig-ubuntu-2404
+```
+
+Use a newer Packer version, downloaded into `.local/bin`:
+
+```bash
+export PACKER_VERSION=1.11.2
+make deps-ami
+make build-ami-ubuntu-2404
+```
+
+Accept the Packer that's already on your `PATH` without downgrading it:
+
+```bash
+export IB_ALLOW_ANY_PACKER=1
+make deps-common
+```
+
+### Container image
+
+The same knobs are exposed as `Dockerfile` build args:
+
+```bash
+docker build \
+  --build-arg PACKER_VERSION=1.11.2 \
+  --build-arg IB_ALLOW_ANY_PACKER=1 \
+  -t my/image-builder:byo-packer \
+  images/capi
+```
+
+`PACKER_BIN` is intentionally only a runtime knob — pass it via
+`docker run --env PACKER_BIN=/path/in/container/to/packer ...` if you mount
+a binary into the container.
+
+## Compatibility notes — please read
+
+* **License**: Using Packer >= 1.10.0 means you accept the BUSL terms.
+  image-builder makes no representation about your obligations under that
+  license.
+* **Plugins**: Each provider's `packer/<provider>/config.pkr.hcl` declares a
+  pinned `required_plugins` block. `packer init` resolves those regardless
+  of which Packer version you use. Newer Packer releases are generally
+  backward compatible with the plugin versions we pin, but specific
+  combinations are **not tested by the project's CI**.
+* **Support**: Bug reports against builds run with anything other than the
+  default Packer (`1.9.5`) are best-effort. If you hit a problem, please
+  first try reproducing with the default before opening an issue.
+* **`packer init` cache**: If you switch Packer versions mid-checkout you
+  may need to clear `~/.packer.d/plugins` or run `packer init -upgrade`
+  inside `images/capi` to refresh the local plugin cache.

--- a/images/capi/Dockerfile
+++ b/images/capi/Dockerfile
@@ -45,6 +45,13 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 ARG ARCH
 ARG PASSED_IB_VERSION
 
+# Bring-your-own Packer build args. Defaults match hack/ensure-packer.sh,
+# which pins Packer to the last MPL-2.0 release. Set PACKER_VERSION to
+# install a different version, or PACKER_BIN at runtime to use an
+# already-installed binary. See docs/book/src/capi/packer.md.
+ARG PACKER_VERSION=1.9.5
+ARG IB_ALLOW_ANY_PACKER=0
+
 USER imagebuilder
 WORKDIR /home/imagebuilder/
 
@@ -59,6 +66,8 @@ COPY --chown=imagebuilder:imagebuilder azure_targets.sh azure_targets.sh
 ENV PATH="/home/imagebuilder/.local/bin:${PATH}"
 ENV PACKER_ARGS=''
 ENV PACKER_VAR_FILES=''
+ENV PACKER_VERSION="${PACKER_VERSION}"
+ENV IB_ALLOW_ANY_PACKER="${IB_ALLOW_ANY_PACKER}"
 ENV IB_VERSION="${PASSED_IB_VERSION}"
 
 RUN make deps

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -25,7 +25,22 @@ export DOCKER_CLI_EXPERIMENTAL := enabled
 export PATH := $(PATH):$(CURDIR)/.local/bin
 # Defining the canonical location of the Packer binary which will be used for
 # `packer init`, `packer build` and `packer validate` commands.
-PACKER=$(shell if [ $$(command -v packer | grep -v sbin) ]; then echo $$(command -v packer); else echo $(CURDIR)/.local/bin/packer; fi)
+#
+# Resolution order:
+#   1. $PACKER_BIN (explicit user override for "bring your own Packer")
+#   2. $(CURDIR)/.local/bin/packer if present (installed by hack/ensure-packer.sh)
+#   3. `packer` on PATH (excluding the unrelated cracklib /usr/sbin/packer)
+#   4. $(CURDIR)/.local/bin/packer fallback (will be created by `make deps-*`)
+PACKER ?= $(shell \
+	if [ -n "$$PACKER_BIN" ]; then \
+		echo "$$PACKER_BIN"; \
+	elif [ -x "$(CURDIR)/.local/bin/packer" ]; then \
+		echo "$(CURDIR)/.local/bin/packer"; \
+	elif [ -n "$$(command -v packer | grep -v sbin)" ]; then \
+		command -v packer | grep -v sbin; \
+	else \
+		echo "$(CURDIR)/.local/bin/packer"; \
+	fi)
 
 export IB_VERSION ?= $(shell git describe --dirty)
 

--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -20,14 +20,36 @@ set -o pipefail
 
 [[ -n ${DEBUG:-} ]] && set -o xtrace
 
-# **DO NOT** change the Packer version unless it is available under MPL v2.0.
-_version="1.9.5"
+# **DO NOT** change the default Packer version unless it is available under
+# MPL v2.0. HashiCorp relicensed Packer under the BUSL starting with v1.10.0,
+# so 1.9.5 is the last MPL-2.0 release.
+#
+# Users who want to "bring their own Packer" can either:
+#   * set PACKER_BIN=/path/to/packer to point at an existing binary, in which
+#     case this script will leave it alone, or
+#   * set PACKER_VERSION=x.y.z to download a different version into .local/bin
+#     (combine with IB_ALLOW_ANY_PACKER=1 to accept a non-default Packer
+#     already on PATH instead of "downgrading" it to the pinned version).
+_default_version="1.9.5"
+_version="${PACKER_VERSION:-${_default_version}}"
+_allow_any="${IB_ALLOW_ANY_PACKER:-0}"
 
 # Change directories to the parent directory of the one in which this
 # script is located.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 source hack/utils.sh
+
+# If the user has explicitly pointed us at a Packer binary, trust it.
+if [ -n "${PACKER_BIN:-}" ]; then
+  if [ ! -x "${PACKER_BIN}" ]; then
+    echo "PACKER_BIN=${PACKER_BIN} is not an executable file" >&2
+    exit 1
+  fi
+  echo "Using user-provided Packer at ${PACKER_BIN}"
+  "${PACKER_BIN}" version || true
+  exit 0
+fi
 
 # Some Linux distributions such as Fedora, RHEL, CentOS have a tool
 # called packer installed by default at /usr/sbin, which will pass the
@@ -41,21 +63,30 @@ source hack/utils.sh
 
 if (command -v packer) >/dev/null 2>&1; then
   echo "Packer is already installed, checking version..."
-  # if it's not the hashicorp packer, return "unexpected packer found"
-  if !(timeout 10 packer version) >/dev/null 2>&1; then
-    echo "unexpected packer found";
-    echo "downloading hashicorp packer version v1.9.5"
-  fi
-  existing_packer_version=$(packer version | head -1 | cut -d 'v' -f 2; exit 0)
-  echo "existing packer version: $existing_packer_version"
-  if [ "$existing_packer_version" != "$_version" ]; then
-    echo "unsupported packer version ($existing_packer_version) found"
-    echo "current packer version: $existing_packer_version is not supported"
-    echo "Downgrading packer to ${_version}"
+  # if it's not the hashicorp packer, fall through to install the pinned version
+  if ! (timeout 10 packer version) >/dev/null 2>&1; then
+    echo "unexpected packer found (no usable 'packer version' output)"
+    echo "downloading hashicorp packer version v${_version}"
   else
-    echo "Packer version is as expected"
-    echo "Packer version $existing_packer_version is already installed"
-    exit 0
+    existing_packer_version=$(packer version | head -1 | cut -d 'v' -f 2; exit 0)
+    echo "existing packer version: $existing_packer_version"
+    if [ "$existing_packer_version" = "$_version" ]; then
+      echo "Packer version $existing_packer_version is already installed"
+      exit 0
+    fi
+    if [ "$_allow_any" = "1" ]; then
+      echo "IB_ALLOW_ANY_PACKER=1 set; accepting existing packer ${existing_packer_version} (expected ${_version})"
+      # Warn loudly if the user has opted into a post-MPL release.
+      if [ "$(printf '%s\n1.10.0\n' "$existing_packer_version" | sort -V | head -n1)" != "$existing_packer_version" ] \
+         || [ "$existing_packer_version" = "1.10.0" ]; then
+        echo "WARNING: Packer >= 1.10.0 is licensed under the BUSL, not MPL-2.0."
+        echo "         You are responsible for ensuring your use complies with that license."
+      fi
+      exit 0
+    fi
+    echo "unsupported packer version ($existing_packer_version) found"
+    echo "current packer version: $existing_packer_version is not ${_version}"
+    echo "Installing packer ${_version} into .local/bin (set IB_ALLOW_ANY_PACKER=1 to keep the existing one)"
   fi
 fi
 

--- a/images/capi/hack/ensure-packer.sh
+++ b/images/capi/hack/ensure-packer.sh
@@ -91,7 +91,24 @@ if (command -v packer) >/dev/null 2>&1; then
 fi
 
 echo "Installing packer v${_version} in .local/bin"
-mkdir -p .local/bin && cd .local/bin
+mkdir -p .local/bin
+
+# CI runs many `make build-*` targets in parallel, and they all invoke this
+# script at once. Serialize the install with an advisory lock so concurrent
+# runs don't clobber each other's downloads in .local/bin. flock isn't
+# available everywhere (notably macOS), so fall back to running without it;
+# the atomic install below still prevents a half-written binary from being
+# observed by a sibling.
+if command -v flock >/dev/null 2>&1; then
+  exec 9>".local/bin/.packer-install.lock"
+  flock 9
+  # A sibling may have finished the install while we waited for the lock.
+  if [ -x .local/bin/packer ] \
+     && [ "$(.local/bin/packer version 2>/dev/null | head -1 | cut -d 'v' -f 2)" = "${_version}" ]; then
+    echo "Packer v${_version} was installed by a concurrent run; nothing to do"
+    exit 0
+  fi
+fi
 
 SED="sed"
 if command -v gsed >/dev/null; then
@@ -102,14 +119,25 @@ if ! (${SED} --version 2>&1 | grep -q GNU); then
   exit 1
 fi
 
+# Download and unpack in a private temp directory on the same filesystem as
+# .local/bin, then atomically rename the finished binary into place. This
+# guarantees a concurrent run never reads or executes a partially written
+# packer binary (or a clobbered .zip / SHA256SUMS file).
+_workdir="$(mktemp -d "${PWD}/.local/bin/.packer-install.XXXXXX")"
+trap 'rm -rf "${_workdir}"' EXIT
+
 _chkfile="packer_${_version}_SHA256SUMS"
 _chk_url="https://releases.hashicorp.com/packer/${_version}/${_chkfile}"
 _zipfile="packer_${_version}_${HOSTOS}_${HOSTARCH}.zip"
 _zip_url="https://releases.hashicorp.com/packer/${_version}/${_zipfile}"
-curl -SsLO "${_chk_url}"
-curl -SsLO "${_zip_url}"
-${SED} -i -n "/${HOSTOS}_${HOSTARCH}/p" "${_chkfile}"
-checksum_sha256 "${_chkfile}"
-unzip -o "${_zipfile}"
-rm -f "${_chkfile}" "${_zipfile}"
-echo "'packer' has been installed to $(pwd), make sure this directory is in your \$PATH"
+(
+  cd "${_workdir}"
+  curl -SsLO "${_chk_url}"
+  curl -SsLO "${_zip_url}"
+  ${SED} -i -n "/${HOSTOS}_${HOSTARCH}/p" "${_chkfile}"
+  checksum_sha256 "${_chkfile}"
+  unzip -o "${_zipfile}"
+)
+chmod +x "${_workdir}/packer"
+mv -f "${_workdir}/packer" .local/bin/packer
+echo "'packer' has been installed to ${PWD}/.local/bin, make sure this directory is in your \$PATH"


### PR DESCRIPTION
## What this PR does / why we need it

image-builder pins Packer to v1.9.5 — the last MPL-2.0 release before HashiCorp relicensed Packer under the BUSL in v1.10.0. `hack/ensure-packer.sh` enforces that pin by actively *replacing* any other Packer the user has on `PATH` with 1.9.5 in `.local/bin`, and the Makefile gives no way to point at a different binary without editing sources.

This PR introduces a **Bring Your Own Packer** capability while keeping the existing pinned behavior as the default.

## The new knobs

| Env var | Default | Effect |
|---|---|---|
| `PACKER_BIN` | unset | Explicit path to a Packer binary. `ensure-packer.sh` validates it and exits 0; the Makefile uses it for every `packer init/build/validate`. |
| `PACKER_VERSION` | `1.9.5` | Version that `ensure-packer.sh` downloads/verifies when managing Packer itself. |
| `IB_ALLOW_ANY_PACKER` | `0` | Opt-in: accept an existing Packer on PATH whose version differs from `PACKER_VERSION` instead of silently downgrading it. Emits a license warning if the detected version is ≥ 1.10.0 (BUSL). |

`PACKER` is also now overridable on the `make` command line (`make PACKER=/path/to/packer build-...`) thanks to `?=`.

`PACKER_VERSION` and `IB_ALLOW_ANY_PACKER` are also exposed as `Dockerfile` build args so container-image consumers can rebuild without forking.

## Commits

1. **Allow bring-your-own Packer via PACKER_BIN/PACKER_VERSION env vars** — Makefile + `hack/ensure-packer.sh` (plus drive-by `shellcheck` SC1035 fix and a fall-through bug fix in the 'unexpected packer found' branch).
2. **Plumb PACKER_VERSION/IB_ALLOW_ANY_PACKER through Dockerfile** — new `ARG`s and `ENV`s; defaults preserve current behavior.
3. **Document Packer pin and Bring Your Own Packer** — new `docs/book/src/capi/packer.md` page, added to `SUMMARY.md`, and `capi.md` prerequisites updated to point at it (replacing the stale '>= 1.6.0' constraint).

## Default behavior is unchanged

With no env vars set, `ensure-packer.sh` still installs and uses Packer 1.9.5 in `.local/bin`, and the Makefile resolves `PACKER` exactly as before. Verified locally:

```
--- no env vars ---
PACKER=[…/images/capi/.local/bin/packer]
--- PACKER_BIN=/usr/local/bin/foo ---
PACKER=[/usr/local/bin/foo]
--- PACKER=cli-override ---
PACKER=[cli-override]
```

`shellcheck -x hack/ensure-packer.sh` is clean.

## Follow-ups (not in this PR)

* Optionally a non-blocking CI matrix entry against a newer Packer to flag drift early.

## Which issue(s) this PR fixes

None tracked — motivated by the kubernetes-sigs/image-builder concern around Packer's BUSL relicense and the desire to let downstream users adopt newer Packer at their own risk.