### PR TITLE
Switch Windows kubernetes_base_url to dl.k8s.io

### DIFF
--- a/images/capi/packer/ami/packer-windows.json
+++ b/images/capi/packer/ami/packer-windows.json
@@ -185,7 +185,7 @@
     "ib_version": "{{env `IB_VERSION`}}",
     "image_name": "capa-ami-{{user `build_name`}}-{{user `kubernetes_semver`}}-{{user `build_timestamp`}}",
     "kms_key_id": "",
-    "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
+    "kubernetes_base_url": "https://dl.k8s.io/release/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
     "manifest_output": "manifest.json",
     "nssm_url": null,
     "prepull": null,

--- a/images/capi/packer/azure/packer-windows.json
+++ b/images/capi/packer/azure/packer-windows.json
@@ -190,7 +190,7 @@
     "image_publisher": "",
     "image_sku": "",
     "image_version": "latest",
-    "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
+    "kubernetes_base_url": "https://dl.k8s.io/release/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
     "manifest_output": "manifest.json",
     "nssm_url": null,
     "os_disk_size_gb": "",

--- a/images/capi/packer/nutanix/packer-windows.json
+++ b/images/capi/packer/nutanix/packer-windows.json
@@ -143,7 +143,7 @@
     "image_delete": "false",
     "image_export": "false",
     "image_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
-    "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
+    "kubernetes_base_url": "https://dl.k8s.io/release/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
     "kubernetes_container_registry": null,
     "kubernetes_http_package_url": "",
     "kubernetes_http_source": null,

--- a/images/capi/packer/oci/packer-windows.json
+++ b/images/capi/packer/oci/packer-windows.json
@@ -129,7 +129,7 @@
     "containerd_version": null,
     "ib_version": "{{env `IB_VERSION`}}",
     "image_version": "latest",
-    "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
+    "kubernetes_base_url": "https://dl.k8s.io/release/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
     "manifest_output": "manifest.json",
     "nssm_url": null,
     "ocpus": "2",

--- a/images/capi/packer/ova/packer-windows.json
+++ b/images/capi/packer/ova/packer-windows.json
@@ -253,7 +253,7 @@
     "http_port_max": "",
     "http_port_min": "",
     "ib_version": "{{env `IB_VERSION`}}",
-    "kubernetes_base_url": "https://kubernetesreleases.blob.core.windows.net/kubernetes/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
+    "kubernetes_base_url": "https://dl.k8s.io/release/{{user `kubernetes_semver`}}/bin/windows/{{user `kubernetes_goarch`}}",
     "kubernetes_http_package_url": "",
     "kubernetes_typed_version": "kube-{{user `kubernetes_semver`}}",
     "manifest_output": "manifest.json",


### PR DESCRIPTION
The `kubernetesreleases.blob.core.windows.net/kubernetes/...` path has had intermittent gaps for recent Kubernetes patch releases — for example `v1.35.1` and the entire `v1.36.x` line are currently missing — which blocks Kubernetes version bumps (see #1993).

`dl.k8s.io` is the canonical upstream Kubernetes release CDN, populated automatically by `krel` for every tagged release. I verified complete coverage of both `kubelet.exe` and `kube-log-runner.exe` (and the other Windows binaries) across v1.32.10, v1.33.12, v1.34.8, v1.35.1, v1.35.5, and v1.36.1. The URL shape is identical, so the change is a one-line swap in each provider's `packer-windows.json`.

`dl.k8s.io` is also already the example value documented in `images/capi/ansible/windows/example.vars.yml`.

Users who specifically need the Microsoft-signed Windows binaries previously fetched from `kubernetesreleases` can still override `kubernetes_base_url` via packer vars — it remains a user-configurable variable.

## Related issues

Unblocks #1993 and prevents this class of failure from recurring on future patch releases.

/closes #2041

## Special notes for your reviewer

Files changed (one identical line per file):
- `images/capi/packer/ami/packer-windows.json`
- `images/capi/packer/azure/packer-windows.json`
- `images/capi/packer/nutanix/packer-windows.json`
- `images/capi/packer/oci/packer-windows.json`
- `images/capi/packer/ova/packer-windows.json`