### PR TITLE
migrate missing ansible_* facts to ansible_facts[]  

### DIFF
--- a/images/capi/ansible/roles/firstboot/meta/main.yml
+++ b/images/capi/ansible/roles/firstboot/meta/main.yml
@@ -26,7 +26,7 @@ dependencies:
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs_arm64') }}"
     when: >
       packer_builder_type is search('qemu')
-        and ansible_architecture == "aarch64"
+        and ansible_facts['architecture'] == "aarch64"
 
   - role: setup
     vars:
@@ -35,4 +35,4 @@ dependencies:
       debs: "{{ common_debs +  lookup('vars', 'common_' + build_target + '_debs') }}"
     when: >
       packer_builder_type is search('qemu')
-        and ansible_architecture != "aarch64"
+        and ansible_facts['architecture'] != "aarch64"

--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -40,7 +40,7 @@
     name: hv-kvp-daemon
     state: stopped
     enabled: false
-  when: ansible_facts['os_family'] == "Debian" and ansible_architecture != "aarch64"
+  when: ansible_facts['os_family'] == "Debian" and ansible_facts['architecture'] != "aarch64"
 
 - name: Create directory for DHCP chrony server files
   ansible.builtin.file:


### PR DESCRIPTION
Hello team,

Need to update facts "ansible_architecture" to "ansible_facts['architecture']" to build image, if not there is an error about vars.

I have see this problem only on this file : 

- images/capi/ansible/roles/firstboot/meta/main.yml:29: and ansible_architecture == "aarch64" 
- images/capi/ansible/roles/firstboot/meta/main.yml:38: and ansible_architecture != "aarch64" 
- images/capi/ansible/roles/providers/tasks/qemu.yml:43: when: ansible_facts['os_family'] == "Debian" and ansible_architecture != "aarch64"

and by default in file ansible.cfg, this parameter : "inject_facts_as_vars" is set to False.

Best Regards
 
