### PR TITLE
Resolve latest Flatcar version from release server version.txt

### DIFF
--- a/images/capi/hack/image-grok-latest-flatcar-version.sh
+++ b/images/capi/hack/image-grok-latest-flatcar-version.sh
@@ -5,8 +5,6 @@
 channel="$1"
 
 curl -L -s \
-     "https://www.flatcar.org/releases-json/releases-$channel.json" \
-    | jq -r 'to_entries[] | "\(.key)"' \
-    | grep -v "current" \
-    | sort --version-sort \
-    | tail -n1
+     "https://$channel.release.flatcar-linux.net/amd64-usr/current/version.txt" \
+    | grep '^FLATCAR_VERSION=' \
+    | cut -d= -f2


### PR DESCRIPTION
## Change description

Resolve the Flatcar version directly from version.txt of the Flatcar release server. Until a few hours ago there was a discrepancy between the version released at release.flatcar-linux.net and flatcar.org - so the latest current stable was not pointing to [stable-4593.2.2](https://github.com/flatcar/scripts/releases/tag/stable-4593.2.2) yet.

To fix this, an image-builder user needed to explicitely set `FLATCAR_CHANNEL` to stable and `FLATCAR_VERSION` to 4593.2.2 - otherwise with the default `FLATCAR_VERSION` set to current, an image with 4593.2.1 was build.


- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Additional context

We point to the amd64 URL as the version output for arm64 is the same as well.