### PR TITLE
Mask apt-daily and unattended-upgrades early to fix dpkg lock race

### DIFF
--- a/images/capi/ansible/roles/node/tasks/debian.yml
+++ b/images/capi/ansible/roles/node/tasks/debian.yml
@@ -1,0 +1,46 @@
+# Copyright 2026 The Kubernetes Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# The apt-daily and unattended-upgrades systemd timers fire shortly after first
+# boot and intermittently hold the dpkg/apt frontend lock while later roles
+# (containerd, kubernetes, sysprep) install packages, causing flaky build
+# failures. Stop and mask them this early, before any package installs, so they
+# cannot race the build. sysprep also disables them, but that runs too late to
+# protect the install steps.
+- name: Stop and mask apt-daily and unattended-upgrades units
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    masked: true
+  failed_when: false
+  loop:
+    - apt-daily.timer
+    - apt-daily-upgrade.timer
+    - apt-daily.service
+    - apt-daily-upgrade.service
+    - unattended-upgrades.service
+
+- name: Wait for any in-flight apt/dpkg process to release the lock
+  ansible.builtin.shell: |
+    set -o pipefail
+    command -v fuser >/dev/null 2>&1 || exit 0
+    for _ in $(seq 1 60); do
+      fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || exit 0
+      sleep 5
+    done
+    echo "timed out waiting for dpkg frontend lock to be released" >&2
+    exit 1
+  args:
+    executable: /bin/bash
+  changed_when: false

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -20,6 +20,10 @@
   ansible.builtin.import_tasks: amazonLinux.yml
   when: ansible_facts['distribution'] == "Amazon"
 
+- name: Import Debian node tasks
+  ansible.builtin.import_tasks: debian.yml
+  when: ansible_facts['os_family'] == "Debian"
+
 # This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
 - name: Override Flatcar's OS family
   ansible.builtin.set_fact:


### PR DESCRIPTION
## What this PR does / why we need it

The `apt-daily`/`apt-daily-upgrade` timers and the `unattended-upgrades` service fire shortly after first boot and intermittently hold the dpkg/apt lock while the `containerd`, `kubernetes`, and `sysprep` roles install packages. This causes flaky Ubuntu (Azure) build failures like:

```
E: Could not get lock /var/cache/apt/archives/lock
```

`sysprep` already disables these units, but that runs at the *end* of the build — too late to protect the install steps that race them. #2024 fixed the sysprep `apt-mark hold` instance, but the same race still bites earlier roles.

This PR stops and **masks** the units at the start of the `node` role, before any package installs, and waits for any in-flight apt process to release the dpkg frontend lock. It complements #2024 by closing the earlier, install-time instances of the same race.

## Which issue(s) this PR fixes

Related to #2024.

## Release note

```release-note
Fix intermittent Ubuntu build failures caused by apt-daily/unattended-upgrades racing the dpkg lock during package installs.
```