### PR TITLE
Remove stale Microsoft prod repo on Azure Ubuntu builds

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -12,6 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Canonical's Ubuntu Azure marketplace images ship a preconfigured
+# packages.microsoft.com "prod" apt source. On the Ubuntu 26.04 (Resolute)
+# image this entry still points at the EOL Ubuntu 18.04 (bionic) prod repo,
+# whose signing key is not present on the image. That makes every subsequent
+# `apt-get update` fail with NO_PUBKEY / "repository is not signed", breaking
+# the containerd and kubernetes package installs. image-builder configures the
+# Microsoft repos it actually needs itself (see azurecli.yml), so remove the
+# stale baked-in source before any apt update runs.
+- name: Find stale preinstalled packages.microsoft.com 18.04 prod apt sources
+  ansible.builtin.find:
+    paths: /etc/apt/sources.list.d
+    patterns:
+      - "*.list"
+      - "*.sources"
+    contains: '.*https?://packages\.microsoft\.com/ubuntu/18\.04/prod/?'
+  register: stale_msft_prod_sources
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: Remove stale preinstalled packages.microsoft.com 18.04 prod apt sources
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ stale_msft_prod_sources.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: ansible_facts['os_family'] == "Debian"
+
 - name: Import Azure CLI tasks
   ansible.builtin.import_tasks: azurecli.yml
   when: debug_tools | bool


### PR DESCRIPTION
## What this PR does / why we need it

Canonical's Ubuntu 26.04 Azure image ships a packages.microsoft.com prod source that points at the old 18.04/bionic repo. Its signing key isn't on the image, so the first apt update fails with `NO_PUBKEY EB3E94ADBE1229CF` and the azure-sigs `ubuntu-2604` and `ubuntu-2604-gen2` builds break.

We don't use that baked-in repo, so this drops it early in the Azure provider tasks, before any apt update runs. It's scoped to the broken 18.04/prod source only, so 22.04 and 24.04 aren't touched.

## Release note

```release-note
Fix Azure Ubuntu 26.04 image builds failing on a stale preinstalled packages.microsoft.com repo.
```
