### PR TITLE
PowerVS: add CentOS Stream 10 DHCP image configuration

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -396,7 +396,7 @@ QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
 RAW_BUILD_NAMES				?=	raw-ubuntu-2204 raw-ubuntu-2204-efi raw-ubuntu-2404 raw-ubuntu-2404-efi raw-ubuntu-2604 raw-ubuntu-2604-efi raw-flatcar raw-rhel-9 raw-rhel-9-efi
 
-POWERVS_BUILD_NAMES         ?= powervs-centos-9 powervs-centos-10
+POWERVS_BUILD_NAMES         ?= powervs-centos-9 powervs-centos-10 powervs-centos-10-dhcp
 
 NUTANIX_BUILD_NAMES ?= nutanix-ubuntu-2204 nutanix-ubuntu-2404 nutanix-ubuntu-2604 nutanix-rhel-9 nutanix-rockylinux-9 nutanix-flatcar nutanix-windows-2022
 
@@ -1014,6 +1014,7 @@ validate-osc-all: $(OSC_VALIDATE_TARGETS) ## Validates all Outscale Snapshot Pac
 
 validate-powervs-centos-9: ## Validates the PowerVS CentOS 9 image packer config
 validate-powervs-centos-10: ## Validates the PowerVS CentOS 10 image packer config
+validate-powervs-centos-10-dhcp: ## Validates the PowerVS CentOS 10 DHCP image packer config
 validate-powervs-all: $(POWERVS_VALIDATE_TARGETS) ## Validates all PowerVS Packer config
 
 validate-nutanix-ubuntu-2204: ## Validates Ubuntu 22.04 Nutanix Packer config

--- a/images/capi/packer/powervs/centos-10-dhcp.json
+++ b/images/capi/packer/powervs/centos-10-dhcp.json
@@ -1,0 +1,9 @@
+{
+  "build_name": "centos-streams10",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm",
+  "source_cos_bucket": "power-oss-bucket",
+  "source_cos_object": "centos-streams-10-dhcp.ova.gz",
+  "source_cos_region": "us-south",
+  "ssh_username": "root"
+}


### PR DESCRIPTION
What this PR does / why we need it:
Adds a PowerVS Packer configuration for CentOS Stream 10 with DHCP-enabled networking.

The new configuration mirrors packer/powervs/centos-10.json and uses a 
DHCP-enabled base OVA (centos-streams-10-dhcp.ova.gz) as the source image.
This is required for PowerVS cluster deployments that use infrastructure 
auto-creation (cluster-template-powervs-create-infra.yaml), where the VM 
receives its IP via DHCP rather than a static assignment.

Is this change including a new Provider or a new OS? (y/n) n

Related issues: 
part of kubernetes-sigs/cluster-api-provider-ibmcloud#2764

Additional context:
The DHCP base OVA was built using pvsadm with a custom prep template that:
- Disables cloud-init network configuration
- Pre-configures NetworkManager to request DHCP on env2 (the PowerVS DHCP interface)

The resulting image was validated by successfully building a DHCP-enabled PowerVS image and completing provisioning using the centos-streams-10-dhcp.ova.gz source artifact.