### PR TITLE
Exclude Ubuntu 26.04 OVA build from CI

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -29,10 +29,12 @@ export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 # The following are currently having issues running in the
 # test environment so are specifically excluded for now
 # - Photon-4
+# - Ubuntu 26.04 (autoinstall never completes, hanging the job; see #2035)
 TARGETS=( $(make build-node-ova-vsphere-all --recon -d | grep "Must remake" | \
   grep -v build-node-ova-vsphere-all | \
   grep -E -v 'rhel|windows|efi' | \
   grep -v build-node-ova-vsphere-photon-4 | \
+  grep -v build-node-ova-vsphere-ubuntu-2604 | \
   grep -E -o 'build-node-ova-vsphere-[a-zA-Z0-9\-]+' ) )
 
 export BOSKOS_RESOURCE_OWNER=image-builder


### PR DESCRIPTION
## What this PR does / why we need it

The `ubuntu-2604` vSphere OVA build hangs in `pull-ova-all` and times out the whole job. `ci-ova.sh` runs all OVA builds in parallel and waits on all of them, so one stuck build holds the job until the 2h prow timeout and fails every build.

The 26.04 build boots and gets an IP, but its autoinstall never completes, so the VM never reboots into the installed system. Packer keeps failing SSH auth against the idle live installer until the timeout. This isn't a flake, it reproduces on every run and is failing `pull-ova-all` on all PRs.

This excludes `ubuntu-2604` the same way `photon-4` is already excluded, until the autoinstall is fixed.

Tracked in #2035.

## Release note

```release-note
NONE
```
