### PR TITLE
Move Azure WS2022 builds to new windowsserver2022 offer

### DIFF
--- a/images/capi/packer/azure/windows-2022-containerd-cvm.json
+++ b/images/capi/packer/azure/windows-2022-containerd-cvm.json
@@ -4,7 +4,7 @@
   "build_name": "windows-2022-containerd-cvm",
   "distribution": "windows",
   "distribution_version": "2022",
-  "image_offer": "WindowsServer",
+  "image_offer": "windowsserver2022",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2022-datacenter-g2",
   "image_version": "latest",

--- a/images/capi/packer/azure/windows-2022-containerd.json
+++ b/images/capi/packer/azure/windows-2022-containerd.json
@@ -4,7 +4,7 @@
   "build_name": "windows-2022-containerd",
   "distribution": "windows",
   "distribution_version": "2022",
-  "image_offer": "WindowsServer",
+  "image_offer": "windowsserver2022",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2022-Datacenter-Core-smalldisk",
   "image_version": "latest",


### PR DESCRIPTION
Microsoft is deprecating the old `WindowsServer` Marketplace offer's WS2022 images (the ones preinstalled with EOL .NET 6) on 9 June 2026. Builds need to move to the new `windowsserver2022` offer.

Both SKUs we use are already published under the new offer, so this is just an `image_offer` swap. Publisher and SKUs stay the same.

Verified with `az vm image list --publisher MicrosoftWindowsServer --offer windowsserver2022`:
- `2022-datacenter-core-smalldisk` and `2022-datacenter-g2` both publish current versions (latest 20348.5139.260507).

Affects `windows-2022-containerd` and `windows-2022-containerd-cvm`.

## Details

Migrate to new Microsoft Marketplace Windows Server 2022 images by 9 June 2026

You’re receiving this notification because you’re associated with one or more Azure subscriptions that use Marketplace Windows Server 2022 images. For reference, you can find this notification in the Azure portal under Service Health/[Health advisories](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Faka.ms%2FAzureServiceHealthAdvisories&data=05%7C02%7Cmatt.boersma%40microsoft.com%7Cef6e4bb9a69543a28bb908debd34cd86%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639156231652564741%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=dJO9TTODHw%2BAaLOigqbv%2F2iCkDfUa84%2Fn18jSNB9GE0%3D&reserved=0) using tracking ID: 8PJS-_48.

In October 2024, we communicated [incoming changes for Marketplace Windows Server 2022 images](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Ftechcommunity.microsoft.com%2Fblog%2Fazurecompute%2Fincoming-changes-for-window-server-2022-marketplace-image-users%2F4262423&data=05%7C02%7Cmatt.boersma%40microsoft.com%7Cef6e4bb9a69543a28bb908debd34cd86%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639156231652582220%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=QbIIi46gjZyK%2FA%2B9%2BXY9aYgsltKwSAg4z7KFI%2BFclig%3D&reserved=0). Aligned with that communication, on 9 June 2026 we’ll deprecate Marketplace Windows Server 2022 images preinstalled with .NET 6, which has reached end of support. [Migrate](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Ftechcommunity.microsoft.com%2Fblog%2Fazurecompute%2Fincoming-changes-for-window-server-2022-marketplace-image-users%2F4262423&data=05%7C02%7Cmatt.boersma%40microsoft.com%7Cef6e4bb9a69543a28bb908debd34cd86%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639156231652591660%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=DIaia5EzwLAKuJYZ2CFtRzvx1qXcgO3Uufu7sg6MgOY%3D&reserved=0) to the new Windows Server 2022 images under the new offer (offerID=windowsserver2022) with the following SKU(s) to avoid disruptions:

2022-DATACENTER
2022-DATACENTER-AZURE-EDITION
2022-DATACENTER-AZURE-EDITION-CORE
2022-DATACENTER-AZURE-EDITION-CORE-SMALLDISK
2022-DATACENTER-AZURE-EDITION-HOTPATCH
2022-DATACENTER-AZURE-EDITION-HOTPATCH-SMALLDISK
2022-DATACENTER-AZURE-EDITION-SMALLDISK
2022-DATACENTER-CORE
2022-DATACENTER-CORE-G2
2022-DATACENTER-CORE-SMALLDISK
2022-DATACENTER-CORE-SMALLDISK-G2
2022-DATACENTER-G2
2022-DATACENTER-SMALLDISK
2022-DATACENTER-SMALLDISK-G2
Recommended action

To avoid disruptions and maintain compliance, migrate to new Marketplace Windows Server 2022 images under the new offer by 9 June 2026. Review the .NET 6 image migration guidance for more information about the migration process, how to determine whether your subscriptions contain impacted images, and where to find the new images.

Help and support

If you have questions or issues regarding end of support for .NET 6 or the migration to newer versions, go to the [Services hub](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fsupport.serviceshub.microsoft.com%2Fsupportforbusiness%2Fonboarding%3Forigin%3D%2Fsupportforbusiness%2Fcreate&data=05%7C02%7Cmatt.boersma%40microsoft.com%7Cef6e4bb9a69543a28bb908debd34cd86%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639156231652609860%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=DpPdW%2Fp%2F%2FC0ZM0Wa63F%2BFOjxwZFbM2xzfllVmQIeTQk%3D&reserved=0) or create a [support request](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Flearn.microsoft.com%2Fazure%2Fazure-portal%2Fsupportability%2Fhow-to-create-azure-support-request&data=05%7C02%7Cmatt.boersma%40microsoft.com%7Cef6e4bb9a69543a28bb908debd34cd86%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639156231652618711%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=LSZ7NnDemQehih1YBDJwql9xiaoaQ4bW3%2FYDqMy7JoY%3D&reserved=0). Select the product family Developer Tools, the product .NET, and the version .NET 8.0 or .NET 10.
