### PR TITLE
Vultr: use `tags` instead of deprecated `tag` field

### DIFF
--- a/images/capi/packer/vultr/packer.json
+++ b/images/capi/packer/vultr/packer.json
@@ -7,7 +7,7 @@
       "region_id": "{{ user `region` }}",
       "snapshot_description": "Cluster API Kubernetes {{ user `kubernetes_semver` }} {{ user `snapshot_name_suffix` }}",
       "ssh_username": "root",
-      "tag": "cluster-api-{{ user `build_name` }}:{{ user `kubernetes_semver` | replace_all `.` `-` }}",
+      "tags": "cluster-api-{{ user `build_name` }}:{{ user `kubernetes_semver` | replace_all `.` `-` }}",
       "type": "vultr"
     }
   ],


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->

Replaces a deprecated field. `tag` will cause vultr capi builds to fail. 


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) ____
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
```
Error: Failed to prepare build: "vultr"

1 error occurred:
        * unknown configuration key: '"tag"'

make: *** [Makefile:665: build-vultr-ubuntu-2604] Error 1
```
