### PR TITLE
Pin ansible to tested version in Azure SIG workflow

### DIFF
--- a/.github/workflows/build-azure-sig.yaml
+++ b/.github/workflows/build-azure-sig.yaml
@@ -178,7 +178,6 @@ jobs:
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pip install ansible ansible-lint
           make deps-azure
 
       - name: Build SIG Image

--- a/.github/workflows/build-azure-sig.yaml
+++ b/.github/workflows/build-azure-sig.yaml
@@ -179,7 +179,7 @@ jobs:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           source hack/utils.sh
-          pip install "ansible-core==${_version_ansible_core}"
+          pip install "ansible-core==${_version_ansible_core:?}"
           make deps-azure
 
       - name: Build SIG Image

--- a/.github/workflows/build-azure-sig.yaml
+++ b/.github/workflows/build-azure-sig.yaml
@@ -178,6 +178,8 @@ jobs:
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          source hack/utils.sh
+          pip install "ansible-core==${_version_ansible_core}"
           make deps-azure
 
       - name: Build SIG Image


### PR DESCRIPTION
The Build Azure SIG Image workflow ran Windows builds on ansible-core 2.21.0. The 2.19+ WinRM exec wrapper breaks Windows builds at Gathering Facts (`-EncodedCommand is not properly encoded`).

The hosted runner ships ansible-core preinstalled, and `ensure-ansible.sh` only errors on older versions, so the repo's pin was skipped. Force-install the pinned `ansible-core` (2.18.16, sourced from `hack/utils.sh`) before `make deps-azure` so it overrides the preinstalled version.