### PR TITLE
Bump ansible to v2.18.17

### DIFF
--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Note: ansible-core v2.18 supports Python 3.11-3.13.
-_version_ansible_core="2.18.16"
+_version_ansible_core="2.18.17"
 
 case "${OSTYPE}" in
 linux*)


### PR DESCRIPTION
## Change description

Updates ansible-core to [v2.18.17](https://pypi.org/project/ansible-core/2.18.17/), supporting Python 3.11-3.13.

## Related issues

See #1974 for prior art.