### PR TITLE
Increase ansible connection timeout

### DIFF
--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -16,6 +16,7 @@
 remote_tmp = /tmp/.ansible
 display_skipped_hosts = False
 inject_facts_as_vars = False
+timeout = 60
 
 [ssh_connection]
 pipelining = False


### PR DESCRIPTION
## Change description

The **Build Azure SIG Image** GitHub workflow has been failing on Linux targets (ubuntu, azurelinux) with:

```
fatal: [default]: FAILED! => {"msg": "Timeout (12s) waiting for privilege escalation prompt: "}
```

This is a become/sudo handshake timing out under connection contention, **not** an ansible version problem. The `pull-azure-sigs` Prow presubmit builds the same Linux targets on the pinned `ansible-core` 2.18.16 with zero such failures, so the pin is correct and innocent.

Raising the connection `timeout` from the default 10s to **60s** gives the privilege escalation prompt more headroom before failing.

(Enabling `pipelining = True` would also help and speed up builds, but it has wider blast radius across all providers, so it will be proposed and tested separately.)

## Related issues

N/A