### PR TITLE
Raise Windows Feature goss check timeout to 180s

### DIFF
--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -92,7 +92,7 @@ command:
     exit-status: 0
     stdout: {{range $vers.expected}}
     - {{.}}
-    timeout: 60000
+    timeout: 180000
     {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
## Change description

The `Windows Feature - <name>` goss checks run `powershell -command "(Get-WindowsFeature <name> | select *)"` with a 60s timeout (`images/capi/packer/goss/goss-package.yaml`). On **Windows Server 2025**, `Get-WindowsFeature` intermittently takes longer than 60s, so the `Containers` and `Hyper-V-PowerShell` checks fail with:

```
Command execution timed out (1m0s)
```

This fails Goss validation and breaks the Azure SIG `windows-2025-containerd` build. It has been showing up as a recurring, content-unrelated failure in `pull-azure-sigs` (e.g. on #1993, the k8s 1.36 bump), where windows-2025 is the only consistently failing target. Windows Server 2022 runs the same 65 checks in ~34s total and passes, so this is a 2025-specific performance issue, not a missing feature (the checks even pass on retry).

Raising the command timeout to **180s** gives `Get-WindowsFeature` enough headroom on Windows Server 2025.

## Related issues

N/A