### PR TITLE
Default Windows kubelet to native service manager (sc)

### DIFF
--- a/images/capi/ansible/windows/example.vars.yml
+++ b/images/capi/ansible/windows/example.vars.yml
@@ -19,7 +19,7 @@ gmsa_keyvault_url: https://kubernetesartifacts.azureedge.net/ccgakvplugin/v1.1.4
 
 runtime: containerd
 kubernetes_install_path: c:\k
-windows_service_manager: nssm
+windows_service_manager: windows_service
 pause_image: registry.k8s.io/pause:3.10.2
 load_additional_components: true
 additional_registry_images: true

--- a/images/capi/packer/config/windows/common.json
+++ b/images/capi/packer/config/windows/common.json
@@ -10,7 +10,7 @@
   "prepull": "true",
   "runtime": "containerd",
   "ssh_source_url": "",
-  "windows_service_manager": "nssm",
+  "windows_service_manager": "windows_service",
   "windows_updates_categories": "",
   "windows_updates_kbs": ""
 }


### PR DESCRIPTION
## Change description

Switch the default `windows_service_manager` from `nssm` to `windows_service` in the Windows-only common var file (`packer/config/windows/common.json`). Windows images now install the kubelet via the native Windows service (`sc`) by default instead of using `nssm.exe`.

The setting lives in `COMMON_WINDOWS_VAR_FILES` only, so **non-Windows builds are unaffected** (the variable isn't declared in the Linux Packer templates).

Also updates `ansible/windows/example.vars.yml` to match the new default.

Builds can still opt back in to nssm with `-var windows_service_manager=nssm`.

### Caveat

The native Windows service path (`sc.yml`) does not consume `KUBELET_KUBEADM_ARGS` (see the note in `ansible/windows/roles/kubernetes/tasks/sc.yml`), whereas the nssm path does via `StartKubelet.ps1`. Reviewers should confirm this is acceptable for downstream consumers (e.g. Cluster API) before merging.

## Related issues

N/A