### PR TITLE
capi: allow deferring sysprep SSH cleanup

### DIFF
--- a/images/capi/ansible/roles/sysprep/defaults/main.yml
+++ b/images/capi/ansible/roles/sysprep/defaults/main.yml
@@ -17,4 +17,5 @@ pip_conf_file: ""
 remove_extra_repos: false
 flatcar_disable_autologin: false
 sysprep_require_grub_file: true
+defer_ssh_cleanup_to_packer: false
 extra_kernel_boot_params: ""

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -178,29 +178,38 @@
     path: /etc/ssh
     pattern: ssh_host_*
   register: ssh_host_keys
+  when: not (defer_ssh_cleanup_to_packer | bool)
 
 - name: Remove SSH host keys
   ansible.builtin.file:
     state: absent
     path: "{{ item.path }}"
-  loop: "{{ ssh_host_keys.files }}"
+  loop: "{{ ssh_host_keys.files | default([]) }}"
+  when: not (defer_ssh_cleanup_to_packer | bool)
 
 - name: Remove SSH authorized users
   ansible.builtin.file:
     state: absent
     path: "{{ item.path }}"
   loop:
-    - { path: /root/.ssh/authorized_keys }
-    - { path: "/home/{{ ansible_facts['env'].SUDO_USER | default(ansible_facts['user_id']) }}/.ssh/authorized_keys" }
-  when: ansible_facts['os_family'] != "Flatcar"
+    - path: /root/.ssh/authorized_keys
+    - path: >-
+        /home/{{
+        ansible_facts['env'].SUDO_USER | default(ansible_facts['user_id'])
+        }}/.ssh/authorized_keys
+  when:
+    - ansible_facts['os_family'] != "Flatcar"
+    - not (defer_ssh_cleanup_to_packer | bool)
 
 - name: Remove SSH authorized users for Flatcar
   ansible.builtin.file:
     state: absent
     path: "{{ item.path }}"
   loop:
-    - { path: /root/.ssh/authorized_keys }
-  when: ansible_facts['os_family'] == "Flatcar"
+    - path: /root/.ssh/authorized_keys
+  when:
+    - ansible_facts['os_family'] == "Flatcar"
+    - not (defer_ssh_cleanup_to_packer | bool)
 
 - name: Truncate all remaining log files in /var/log
   ansible.builtin.shell: |


### PR DESCRIPTION
## Change description

Allow the CAPI sysprep role to defer SSH host key and authorized key cleanup when the image build needs additional Packer provisioners to connect after sysprep has run.

This keeps the default cleanup behavior unchanged. Builders that set `defer_ssh_cleanup_to_packer=true` can move the final SSH cleanup to a later Packer step instead of losing direct SSH access in the middle of the build.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Additional context

Validation:
- `git diff --check`
