### PR TITLE
capi: dynamically include OS setup tasks

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/main.yml
+++ b/images/capi/ansible/roles/setup/tasks/main.yml
@@ -13,26 +13,26 @@
 # limitations under the License.
 ---
 - name: Import Debian setup tasks
-  ansible.builtin.import_tasks: debian.yml
+  ansible.builtin.include_tasks: debian.yml
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Import Flatcar setup tasks
-  ansible.builtin.import_tasks: flatcar.yml
+  ansible.builtin.include_tasks: flatcar.yml
   # This task overrides ansible_facts['os_family'] to "Flatcar" as a workaround for
   # regression between Flatcar and Ansible, so rest of the code can use just
   # "Flatcar" for comparison, which is the correct value.
   when: ansible_facts['os_family'] in ["Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Import Azure Linux setup tasks
-  ansible.builtin.import_tasks: azurelinux.yml
+  ansible.builtin.include_tasks: azurelinux.yml
   when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
 
 - name: Import RedHat setup tasks
-  ansible.builtin.import_tasks: redhat.yml
+  ansible.builtin.include_tasks: redhat.yml
   when: ansible_facts['os_family'] == "RedHat"
 
 - name: Import Photon setup tasks
-  ansible.builtin.import_tasks: photon.yml
+  ansible.builtin.include_tasks: photon.yml
   when: ansible_facts['os_family'] == "VMware Photon OS"
 
 # Copy in pip config file when defined


### PR DESCRIPTION
## Change description

Use `ansible.builtin.include_tasks` for mutually exclusive OS setup task files.

The setup role currently statically imports every OS-family task file and adds a `when` condition to each import. Dynamic includes avoid expanding irrelevant OS task files for the current guest, which keeps skipped OS-specific tasks from being parsed or logged during builds for another family.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Additional context

Validation:
- `git diff --check`
