### PR TITLE
capi: avoid following cri-tools symlinks

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -206,6 +206,7 @@
     mode: "0755"
     state: link
     force: true
+    follow: false
   loop:
     - ctr
     - crictl


### PR DESCRIPTION
## Change description

Set `follow: false` when the containerd role creates `/usr/bin/{ctr,crictl,critest}` symlinks.

The task creates forced symlinks that can temporarily point at targets that are not visible through `/usr/local/bin` yet. With Ansible's default symlink-follow behavior, applying file attributes can warn about a non-existent symlink target. The module-native fix is to keep `state: link` and explicitly avoid following the link.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Additional context

Validation:
- `git diff --check`
