### PR TITLE
capi: default empty public repo flags before bool

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -63,12 +63,12 @@
       - "*.list"
       - "*.sources"
   register: repo_files
-  when: disable_public_repos|bool
+  when: disable_public_repos | default(false, true) | bool
 
 - name: Disable repos
   ansible.builtin.command: mv {{ item.path }} {{ item.path }}.disabled
   loop: "{{ repo_files.files }}"
-  when: disable_public_repos|bool
+  when: disable_public_repos | default(false, true) | bool
 
 - name: Install extra repos
   ansible.builtin.copy:

--- a/images/capi/ansible/roles/setup/tasks/photon.yml
+++ b/images/capi/ansible/roles/setup/tasks/photon.yml
@@ -34,7 +34,7 @@
   ansible.builtin.command: tdnf update -y photon-repos --enablerepo=photon --refresh
   register: distro
   changed_when: '"Nothing to do" not in distro.stderr'
-  when: not disable_public_repos|default(false)|bool
+  when: not (disable_public_repos | default(false, true) | bool)
 
 - name: Replace chkconfig with alternatives to satisfy iptables dependency
   ansible.builtin.command: tdnf install -y alternatives --allowerasing

--- a/images/capi/ansible/roles/setup/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/setup/tasks/rpm_repos.yml
@@ -18,12 +18,12 @@
     paths: /etc/yum.repos.d
     patterns: "*.repo"
   register: repo_files
-  when: disable_public_repos|bool
+  when: disable_public_repos | default(false, true) | bool
 
 - name: Disable repos
   ansible.builtin.command: mv {{ item.path }} {{ item.path }}.disabled
   loop: "{{ repo_files.files }}"
-  when: disable_public_repos|bool
+  when: disable_public_repos | default(false, true) | bool
 
 - name: Install extra repos
   ansible.builtin.copy:

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -81,12 +81,12 @@
       - /etc/apt/sources.list.d
     patterns: "*.list.disabled"
   register: repo_files
-  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+  when: (disable_public_repos | default(false, true) | bool) and (reenable_public_repos | default(true, true) | bool)
 
 - name: Enable repos
   ansible.builtin.command: mv {{ item.path }} {{ item.path | regex_replace('.disabled') }}
   loop: "{{ repo_files.files }}"
-  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+  when: (disable_public_repos | default(false, true) | bool) and (reenable_public_repos | default(true, true) | bool)
 
 - name: Remove templated apt.conf.d/90proxy used for http(s)_proxy support
   ansible.builtin.file:

--- a/images/capi/ansible/roles/sysprep/tasks/photon.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/photon.yml
@@ -48,7 +48,7 @@
   ansible.builtin.command: tdnf update -y photon-repos --enablerepo=photon --refresh
   register: distro
   changed_when: '"Nothing to do" not in distro.stderr'
-  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+  when: (disable_public_repos | default(false, true) | bool) and (reenable_public_repos | default(true, true) | bool)
 
 - name: Remove tdnf package caches
   ansible.builtin.command: /usr/bin/tdnf -y clean all

--- a/images/capi/ansible/roles/sysprep/tasks/rpm_repos.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/rpm_repos.yml
@@ -27,9 +27,9 @@
     paths: /etc/yum.repos.d
     patterns: "*.repo.disabled"
   register: repo_files
-  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+  when: (disable_public_repos | default(false, true) | bool) and (reenable_public_repos | default(true, true) | bool)
 
 - name: Enable repos
   ansible.builtin.command: mv {{ item.path }} {{ item.path | regex_replace('.disabled') }}
   loop: "{{ repo_files.files }}"
-  when: disable_public_repos|default(false)|bool and reenable_public_repos|default(true)|bool
+  when: (disable_public_repos | default(false, true) | bool) and (reenable_public_repos | default(true, true) | bool)


### PR DESCRIPTION
## Change description

Normalize empty `disable_public_repos` and `reenable_public_repos` values before applying the Ansible `bool` filter.

Some Packer/HCL build paths can pass optional string variables as an empty string. Newer Ansible versions warn when `bool` coerces `""` directly. Using `default(..., true)` preserves the existing false/default behavior for empty values while avoiding the deprecation warning.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Additional context

Validation:
- `git diff --check`
