### PR TITLE
capi: default additional component flags to booleans

### DIFF
--- a/images/capi/ansible/roles/load_additional_components/defaults/main.yml
+++ b/images/capi/ansible/roles/load_additional_components/defaults/main.yml
@@ -13,15 +13,15 @@
 # limitations under the License.
 ---
 
-additional_registry_images: ""
+additional_registry_images: false
 additional_registry_images_list: ""
-additional_url_images: ""
+additional_url_images: false
 additional_url_images_list: ""
-additional_executables: ""
+additional_executables: false
 additional_executables_list: ""
 additional_executables_destination_path: ""
 
-additional_s3: ""
+additional_s3: false
 additional_s3_endpoint: ""
 additional_s3_access: ""
 additional_s3_secret: ""


### PR DESCRIPTION
## Change description

Default the `load_additional_components` boolean switches to `false` instead of an empty string.

The role already treats these values as booleans in task conditions. Setting boolean defaults avoids relying on Ansible coercion of `""` to false, which newer Ansible versions warn about.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Additional context

Validation:
- `git diff --check`
