### PR TITLE
capi: use dpkg selections in Debian sysprep

### DIFF
--- a/images/capi/ansible/roles/sysprep/defaults/main.yml
+++ b/images/capi/ansible/roles/sysprep/defaults/main.yml
@@ -16,6 +16,7 @@ extra_repos: ""
 pip_conf_file: ""
 remove_extra_repos: false
 flatcar_disable_autologin: false
+sysprep_hold_installed_packages: true
 sysprep_require_grub_file: true
 defer_ssh_cleanup_to_packer: false
 extra_kernel_boot_params: ""

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -45,32 +45,31 @@
   when: "'unattended-upgrades' in ansible_facts.packages"
 
 # The apt-daily/unattended-upgrades services may still be running from before
-# they were disabled above. Retry the apt-mark calls until the dpkg frontend
+# they were disabled above. Retry package selection changes until the dpkg frontend
 # lock is released to avoid a flaky race with concurrent apt activity.
-- name: Pin all installed packages with apt-mark
-  ansible.builtin.shell: |
-    set -o pipefail
-    dpkg-query -f '${binary:Package}\n' -W | xargs apt-mark hold
-
-  args:
-    executable: /bin/bash
-  register: sysprep_apt_mark_hold
-  until: sysprep_apt_mark_hold.rc == 0
+- name: Pin all installed packages
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: hold
+  loop: "{{ ansible_facts.packages.keys() }}"
+  register: sysprep_dpkg_selections_hold
+  until: sysprep_dpkg_selections_hold is not failed
   retries: 30
   delay: 10
+  when: sysprep_hold_installed_packages | default(true) | bool
 
-- name: Unpin grub packages with apt-mark for MaaS
-  ansible.builtin.shell: |
-    set -o pipefail
-    dpkg-query -f '${binary:Package}\n' -W | grep grub | xargs apt-mark unhold
-
-  args:
-    executable: /bin/bash
-  register: sysprep_apt_mark_unhold_grub
-  until: sysprep_apt_mark_unhold_grub.rc == 0
+- name: Unpin grub packages for MaaS
+  ansible.builtin.dpkg_selections:
+    name: "{{ item }}"
+    selection: install
+  loop: "{{ ansible_facts.packages.keys() | select('search', 'grub') | list }}"
+  register: sysprep_dpkg_selections_unhold_grub
+  until: sysprep_dpkg_selections_unhold_grub is not failed
   retries: 30
   delay: 10
-  when: provider is defined and provider is search('maas')
+  when:
+    - sysprep_hold_installed_packages | default(true) | bool
+    - provider is defined and provider is search('maas')
 
 - name: Remove extra repos
   ansible.builtin.file:


### PR DESCRIPTION
## Change description

Replace Debian sysprep `apt-mark` shell pipelines with `ansible.builtin.dpkg_selections`.

The role already gathers package facts before pinning packages. Using `dpkg_selections` keeps the existing package hold/unhold behavior in Ansible modules instead of shelling out to `dpkg-query | xargs apt-mark`. The retry loop remains so transient dpkg lock contention from apt-daily or unattended-upgrades is still handled.

This also adds `sysprep_hold_installed_packages`, defaulting to `true`, so downstream image variants that replace the OS atomically can opt out of the hold-all sysprep step without changing existing image-builder behavior.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Additional context

Validation:
- `python3` YAML parse of `images/capi/ansible/roles/sysprep/defaults/main.yml` and `images/capi/ansible/roles/sysprep/tasks/debian.yml`
- `git diff --check`
- grep guard confirmed no `apt-mark`, `dpkg-query`, or `ansible.builtin.shell` remains in `images/capi/ansible/roles/sysprep/tasks/debian.yml`

Known lint baseline:
- `ansible-lint images/capi/ansible/roles/sysprep/tasks/debian.yml images/capi/ansible/roles/sysprep/defaults/main.yml` still reports pre-existing sysprep role issues outside this PR, including role-prefix naming findings and the existing `Enable repos` command task.
