### PR TITLE
Allow Debian Kubernetes package downgrades

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/debian.yml
@@ -43,6 +43,7 @@
 - name: Install Kubernetes
   ansible.builtin.apt:
     name: "{{ packages }}"
+    allow_downgrade: true
   vars:
     packages:
       - kubelet={{ kubernetes_deb_version }}


### PR DESCRIPTION
What this PR does / why we need it:

The Debian Kubernetes install task pins kubelet, kubeadm, kubectl and kubernetes-cni versions, but unlike the RedHat and AzureLinux tasks it does not set `allow_downgrade: true`.

That breaks Packer retry/idempotency flows when a previous provisioning attempt left a newer package version installed and the next retry re-runs the pinned install task. apt refuses the downgrade under non-interactive `-y` without `--allow-downgrades`.

This aligns the Debian task with the existing RedHat and AzureLinux Kubernetes install tasks.

Which issue(s) this PR fixes:

None

Special notes for your reviewer:

This is intentionally limited to the `ansible.builtin.apt` module option. No shell wrapper is needed.

Validation:

- `ansible-lint images/capi/ansible/roles/kubernetes/tasks/debian.yml`
- `git diff --check`