### PR TITLE
Fix flaky GitHub-runner to Azure VM SSH that hung Linux SIG builds

### DIFF
--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -19,5 +19,5 @@ inject_facts_as_vars = False
 timeout = 120
 
 [ssh_connection]
-pipelining = True
+pipelining = False
 retries = 5

--- a/images/capi/ansible.cfg
+++ b/images/capi/ansible.cfg
@@ -16,7 +16,8 @@
 remote_tmp = /tmp/.ansible
 display_skipped_hosts = False
 inject_facts_as_vars = False
-timeout = 60
+timeout = 120
 
 [ssh_connection]
-pipelining = False
+pipelining = True
+retries = 5

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -51,6 +51,8 @@
         "resource_group": "{{user `resource_group_name`}}",
         "storage_account_type": "{{user `storage_account_type`}}"
       },
+      "ssh_keep_alive_interval": "30s",
+      "ssh_read_write_timeout": "10m",
       "ssh_username": "packer",
       "subscription_id": "{{user `subscription_id`}}",
       "type": "azure-arm",
@@ -86,7 +88,7 @@
   "provisioners": [
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'"
+        "ANSIBLE_SSH_ARGS={{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}} -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=5 -o TCPKeepAlive=yes"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -100,11 +102,12 @@
       ],
       "playbook_file": "./ansible/python.yml",
       "type": "ansible",
+      "use_proxy": false,
       "user": "packer"
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'"
+        "ANSIBLE_SSH_ARGS={{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}} -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=5 -o TCPKeepAlive=yes"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -118,6 +121,7 @@
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
+      "use_proxy": false,
       "user": "packer"
     },
     {

--- a/images/capi/packer/azure/packer.json
+++ b/images/capi/packer/azure/packer.json
@@ -88,7 +88,8 @@
   "provisioners": [
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS={{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}} -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=5 -o TCPKeepAlive=yes"
+        "ANSIBLE_SSH_ARGS={{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}} -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=5 -o TCPKeepAlive=yes",
+        "ANSIBLE_PIPELINING=True"
       ],
       "extra_arguments": [
         "--extra-vars",
@@ -107,7 +108,8 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS={{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}} -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=5 -o TCPKeepAlive=yes"
+        "ANSIBLE_SSH_ARGS={{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}} -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=20 -o ServerAliveCountMax=3 -o ConnectTimeout=30 -o ConnectionAttempts=5 -o TCPKeepAlive=yes",
+        "ANSIBLE_PIPELINING=True"
       ],
       "extra_arguments": [
         "--extra-vars",


### PR DESCRIPTION
Linux "Build Azure SIG Image" runs hung for ~2h and were cancelled, while Windows passed. The flaky leg is the GitHub-hosted runner to Azure VM SSH connection.

Two compounding issues:
- The Linux `ansible` provisioners used Packer's SSH proxy (`use_proxy` defaulted true), whose communicator `ssh_read_write_timeout` defaults to `0` (wait forever), so a dropped connection hung the whole build. Windows uses `use_proxy=false` and was unaffected.
- The provisioner's `ANSIBLE_SSH_ARGS` env var overrides `ansible.cfg`'s `ssh_args`, so keepalive/ControlPersist tuning there was a no-op.

Changes in `packer/azure/packer.json`: set `use_proxy: false` on both Linux ansible provisioners and add SSH keepalives plus ControlMaster/ControlPersist directly in `ANSIBLE_SSH_ARGS`; add `ssh_keep_alive_interval`/`ssh_read_write_timeout` on the builder. `ansible.cfg` enables pipelining, raises `timeout` to 120, and adds `retries`.

Verified with two green end-to-end runs including the Test stage (build plus smoke tests on a VM from the staging gallery image).
