### PR TITLE
capi: wait for apt cleanup lock

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -20,7 +20,7 @@
 - name: Get installed packages
   ansible.builtin.package_facts:
 
-- name: Disable apt-daily services
+- name: Disable apt-daily timers
   ansible.builtin.systemd:
     name: "{{ item }}"
     state: stopped
@@ -28,6 +28,14 @@
   loop:
     - apt-daily.timer
     - apt-daily-upgrade.timer
+
+- name: Stop apt-daily services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+  loop:
+    - apt-daily.service
+    - apt-daily-upgrade.service
 
 - name: Disable unattended upgrades if installed
   ansible.builtin.systemd:
@@ -108,6 +116,7 @@
     autoclean: true
     autoremove: true
     force_apt_get: true
+    lock_timeout: 300
 
 - name: Remove apt package lists
   ansible.builtin.file:


### PR DESCRIPTION
## What this fixes

The Debian sysprep cleanup can race with apt-daily/unattended-upgrades activity that is already running. A recent Azure SIG run for #2055 failed in `Remove apt package caches` with:

`E: Could not get lock /var/cache/apt/archives/lock. It is held by process ... (apt)`

The role already disables the apt-daily timers before cleanup, but stopping the timers does not stop service units that are already active.

## Changes

- keep disabling the apt-daily timers
- stop already-running `apt-daily.service` and `apt-daily-upgrade.service` before apt cleanup
- set `lock_timeout: 300` on the existing `ansible.builtin.apt` cleanup task

This intentionally keeps the fix module-native; it does not add shell wrappers arounnd apt.

## Validation

- `git diff --check upstream/main`
- YAML parsed with Python/PyYAML
- `ansible-lint images/capi/ansible/roles/sysprep/tasks/debian.yml` was also run locally; it reports existing upstream-main baseline violations in this file (apt-mark shell tasks and role variable naming), not new violations from this patch.