### PR TITLE
capi: trust Microsoft key for legacy apt repos

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azurecli.yml
+++ b/images/capi/ansible/roles/providers/tasks/azurecli.yml
@@ -34,6 +34,21 @@
       args:
         creates: /etc/apt/keyrings/microsoft.gpg
 
+    - name: Check for legacy Microsoft apt source
+      ansible.builtin.find:
+        paths: /etc/apt/sources.list.d
+        patterns: "*.list"
+        contains: ".*packages\\.microsoft\\.com.*"
+      register: providers_ms_legacy_source
+
+    - name: Trust Microsoft key for legacy Microsoft apt repositories
+      ansible.builtin.copy:
+        src: /etc/apt/keyrings/microsoft.gpg
+        dest: /etc/apt/trusted.gpg.d/microsoft.gpg
+        remote_src: true
+        mode: "0644"
+      when: providers_ms_legacy_source.matched > 0
+
     - name: Find Ubuntu Version
       ansible.builtin.command:
         cmd: lsb_release -cs


### PR DESCRIPTION
## What this does

Azure Ubuntu base images can include a legacy Microsoft prod apt source such as `https://packages.microsoft.com/ubuntu/18.04/prod bionic` without a `signed-by` option. The Azure provider role already downloads and dearmors the current Microsoft package key for the Azure CLI repo, but apt cache updates for the pre-existing legacy source cannot see that scoped key.

This copies the same dearmored Microsoft key to `/etc/apt/trusted.gpg.d/microsoft.gpg` before `apt_repository(update_cache=true)` runs, so legacy Microsoft apt sources already present on the base image can validate with the current Microsoft key.

## Why

Observed in `pull-azure-sigs` on PR #2049: only `sig-ubuntu-2604` failed. The failure was unrelated to SSH sysprep cleanup and came from apt refresh:

```
NO_PUBKEY EB3E94ADBE1229CF
https://packages.microsoft.com/ubuntu/18.04/prod bionic InRelease
```

The current Microsoft key at `https://packages.microsoft.com/keys/microsoft.asc` contains fingerprint `BC528686B50D79E339D3721CEB3E94ADBE1229CF`.

## Validation

- `git diff --check`
- YAML parse for `images/capi/ansible/roles/providers/tasks/azurecli.yml`
- `ansible-lint --project-dir images/capi images/capi/ansible/roles/providers/tasks/azurecli.yml` was attempted; it is blocked by pre-existing `var-naming[no-role-prefix]` findings for existing variables in this file (`ubuntu_version`, `host_arch`, `azure_cli_codename`).
