### PR TITLE
capi: exclude Ansible temp payloads from sysprep cleanup

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -127,8 +127,9 @@
 # A shallow search in /tmp and /var/tmp is used to declare which files or
 # directories will be removed as part of resetting temp space. The reason
 # a state absent->directory task isn't used is because Ansible's own data
-# directory on the remote host(s) is /tmp/.ansible. Thus, by removing /tmp,
-# Ansible can no longer access the remote host.
+# directory on the remote host(s) is /tmp/.ansible, and module payloads may
+# use temporary paths such as /tmp/ansible_*. Thus, by removing /tmp, Ansible
+# can no longer access the remote host.
 - name: Find temp files
   ansible.builtin.find:
     depth: 1
@@ -137,6 +138,11 @@
       - /tmp
       - /var/tmp
     pattern: "*"
+    excludes:
+      - .ansible
+      - .ansible_*
+      - ansible_*
+      - ansible-*
   register: temp_files
 
 - name: Reset temp space


### PR DESCRIPTION
## What this PR does

Adds `excludes` to the sysprep temp cleanup `ansible.builtin.find` task so the existing module-based cleanup does not delete Ansible runtime directories or module payloads such as `.ansible`, `.ansible_*`, `ansible_*`, and `ansible-*`.

This is related to a T-CaaS immutable image validation failure where sysprep deleted `/tmp/ansible_ansible.builtin.hostname_payload_*` and caused the following `Set hostname` task to fail with `FileNotFoundError` for `/tmp/ansible_ansible.builtin.hostname_payload_*/ansible_ansible.builtin.hostname_payload.zip`.

## Tests

- `git diff --check`
- `python3 - <<'PY' ... yaml.safe_load('images/capi/ansible/roles/sysprep/tasks/main.yml') ... PY`
- `ansible localhost -i localhost, -c local -m ansible.builtin.find -a "paths=$tmpdir depth=1 file_type=any pattern=* excludes=.ansible,.ansible_*,ansible_*,ansible-*"` with temp fixtures; returned only `keep-dir` and `keep-file`
- `yamllint images/capi/ansible/roles/sysprep/tasks/main.yml` fails on existing line-length/braces issues in this file
- `cd images/capi && ansible-lint --project-dir . ansible/roles/sysprep/tasks/main.yml` fails on existing sysprep role `var-naming[no-role-prefix]` issues
