### PR TITLE
capi: retry QEMU Ansible provisioners

### DIFF
--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -92,6 +92,7 @@
         "--scp-extra-args",
         "{{user `ansible_scp_extra_args`}}"
       ],
+      "max_retries": 5,
       "playbook_file": "./ansible/firstboot.yml",
       "type": "ansible",
       "user": "builder"
@@ -120,6 +121,7 @@
         "--scp-extra-args",
         "{{user `ansible_scp_extra_args`}}"
       ],
+      "max_retries": 5,
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
       "user": "builder"


### PR DESCRIPTION
#### What this PR does / why we need it:

QEMU image builds currently run the firstboot and node Ansible provisioners without Packer retries, while RAW builds already set `max_retries: 5` on the same provisioner flow. Transient SSH/guest readiness hiccups after install or reboot can therefore fail QEMU builds immediately even though the same kind of transient failure is retried for RAW.

This PR adds the same `max_retries: 5` setting to both QEMU Ansible provisioners.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This came out of downstream T-CaaS image-build hardening while validating QEMU-based immutable image builds. It is intentionally limited to QEMU parity with the existing RAW retry behavior.

#### Testing:

- `git diff --check`
- `jq empty images/capi/packer/qemu/packer.json.tmpl`
- `make -C images/capi validate-qemu-ubuntu-2404`