### PR TITLE
capi: normalize Ubuntu OVA seed ISO label

### DIFF
--- a/images/capi/packer/ova/ubuntu-2204-efi.json
+++ b/images/capi/packer/ova/ubuntu-2204-efi.json
@@ -4,7 +4,7 @@
   "boot_media_path": "/media/HTTP",
   "build_name": "ubuntu-2204-efi",
   "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/22.04.efi/*",
-  "cd_label": "cidata",
+  "cd_label": "CIDATA",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",
   "distro_version": "22.04",

--- a/images/capi/packer/ova/ubuntu-2204.json
+++ b/images/capi/packer/ova/ubuntu-2204.json
@@ -3,7 +3,7 @@
   "boot_disable_ipv6": "0",
   "build_name": "ubuntu-2204",
   "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
-  "cd_label": "cidata",
+  "cd_label": "CIDATA",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",
   "distro_version": "22.04",

--- a/images/capi/packer/ova/ubuntu-2404-efi.json
+++ b/images/capi/packer/ova/ubuntu-2404-efi.json
@@ -3,7 +3,7 @@
   "boot_disable_ipv6": "0",
   "build_name": "ubuntu-2404-efi",
   "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/24.04.efi/*",
-  "cd_label": "cidata",
+  "cd_label": "CIDATA",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",
   "distro_version": "24.04",

--- a/images/capi/packer/ova/ubuntu-2404.json
+++ b/images/capi/packer/ova/ubuntu-2404.json
@@ -3,7 +3,7 @@
   "boot_disable_ipv6": "0",
   "build_name": "ubuntu-2404",
   "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
-  "cd_label": "cidata",
+  "cd_label": "CIDATA",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",
   "distro_version": "24.04",

--- a/images/capi/packer/ova/ubuntu-2604-efi.json
+++ b/images/capi/packer/ova/ubuntu-2604-efi.json
@@ -3,7 +3,7 @@
   "boot_disable_ipv6": "0",
   "build_name": "ubuntu-2604-efi",
   "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/26.04.efi/*",
-  "cd_label": "cidata",
+  "cd_label": "CIDATA",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",
   "distro_version": "26.04",

--- a/images/capi/packer/ova/ubuntu-2604.json
+++ b/images/capi/packer/ova/ubuntu-2604.json
@@ -3,7 +3,7 @@
   "boot_disable_ipv6": "0",
   "build_name": "ubuntu-2604",
   "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
-  "cd_label": "cidata",
+  "cd_label": "CIDATA",
   "distro_arch": "amd64",
   "distro_name": "ubuntu",
   "distro_version": "26.04",


### PR DESCRIPTION
## What this PR does / why we need it

Normalize the Ubuntu OVA NoCloud seed ISO label to `CIDATA`, matching the conventional NoCloud seed volume label casing used by cloud-init examples and downstream image-builder consumers.

This only updates Ubuntu OVA var files. Other OVA operating systems still use lowercase `cidata`; Rocky Linux also references `LABEL=cidata` in its boot command, so those should be handled separately only with OS-specific evidence.

## Which issue(s) this PR fixes

None

## Special notes for your reviewer

This is a small configuration-only follow-up found while reducing downstream T-CaaS image-builder patches. It is intentionally separate from the open sysprep and node-TMPDIR PRs.

## Release note

```release-note
NONE
```

## Validation

- `git diff --check`
- `python3 -m json.tool` for all changed Ubuntu OVA JSON var files