### PR TITLE
capi: add final image hygiene goss checks

### DIFF
--- a/images/capi/packer/goss/goss-image-hygiene.yaml
+++ b/images/capi/packer/goss/goss-image-hygiene.yaml
@@ -1,6 +1,6 @@
 command:
 {{ if ne .Vars.OS "windows" }}
-  find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -print:
+  sh -c '! find /etc/ssh -xdev -type f -name "ssh_host_*_key" -print -quit | grep -q .':
     exit-status: 0
     stdout: []
     stderr: []
@@ -15,7 +15,7 @@ command:
     stdout: []
     stderr: []
     timeout: 5000
-  sh -c 'find / -xdev \( -name core.\* -o -name \*.core \) -print -quit 2>/dev/null':
+  sh -c 'found="$(find /var/crash /var/lib/systemd/coredump /var/tmp /tmp -xdev -type f \( -name core -o -name "core.*" -o -name "*.core" \) -print -quit 2>/dev/null || true)"; test -z "$found"':
     exit-status: 0
     stdout: []
     stderr: []

--- a/images/capi/packer/goss/goss-image-hygiene.yaml
+++ b/images/capi/packer/goss/goss-image-hygiene.yaml
@@ -1,0 +1,28 @@
+command:
+{{ if ne .Vars.OS "windows" }}
+  find /etc/ssh -xdev -type f -name 'ssh_host_*_key' -print:
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 5000
+  sh -c 'test ! -s /etc/machine-id || grep -qx uninitialized /etc/machine-id':
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 5000
+  test ! -e /var/lib/cloud/data/instance-id:
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 5000
+  sh -c 'find / -xdev \( -name core.\* -o -name \*.core \) -print -quit 2>/dev/null':
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 10000
+  du -sm /var/log | awk '{exit ($1 > 200)}':
+    exit-status: 0
+    stdout: []
+    stderr: []
+    timeout: 5000
+{{ end }}

--- a/images/capi/packer/goss/goss.yaml
+++ b/images/capi/packer/goss/goss.yaml
@@ -4,3 +4,4 @@ gossfile:
   goss-service.yaml: {}
   goss-package.yaml: {}
   goss-files.yaml: {}
+  goss-image-hygiene.yaml: {}


### PR DESCRIPTION
What this does
- Adds Linux-only Goss checks for final image hygiene after sysprep.
- Verifies SSH host private keys, machine-id, cloud-init instance identity, crash dumps, and oversized `/var/log` content are absent from captured images.
- Leaves Windows Goss rendering unchanged by guarding the checks on `OS != windows`.

Why
- These are generic final-image correctness checks and mirror cleanup that the sysprep role already performs.
- The checks are provider-neutral and contain no project-specific paths, cache plumbing, or credentials.
Validation
- `git diff --check`
- shell-semantics check proving the SSH-host-key and core-file commands fail when matching files exist
- `docker run --rm --platform linux/arm64/v8 -v "$PWD":/work -w /work/images/capi python:3.12-bookworm bash -lc ./scripts/ci-goss-populate.sh`

