### PR TITLE
capi: remove containerd wasm shim tarballs

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -230,7 +230,7 @@
 
 - name: Delete containerd-wasm-shims tarballs
   ansible.builtin.file:
-    path: /tmp/{{ item }}_wasm_shims.tar.gz
+    path: /tmp/{{ item }}_wasm_shim.tar.gz
     state: absent
   when: containerd_wasm_shims_runtimes | length > 0
   loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"


### PR DESCRIPTION
## What this PR does

Fixes the cleanup path for downloaded containerd wasm shim tarballs.

The role downloads and unpacks `/tmp/{{ item }}_wasm_shim.tar.gz`, but the cleanup task currently removes `/tmp/{{ item }}_wasm_shims.tar.gz` with an extra `s`. That leaves the downloaded tarballs in the image when wasm shims are enabled.

## Validation

- `rg -n "wasm_shim" images/capi/ansible/roles/containerd/tasks/main.yml`
- `git diff --check`
