### PR TITLE
capi: retry OpenStack Ansible provisioning

### DIFF
--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -55,7 +55,8 @@
     },
     {
       "ansible_env_vars": [
-        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'"
+        "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
+        "ANSIBLE_TIMEOUT={{user `ansible_timeout`}}"
       ],
       "extra_arguments": [
         "--scp-extra-args",
@@ -67,6 +68,7 @@
         "--extra-vars",
         "{{user `ansible_user_vars`}}"
       ],
+      "max_retries": 5,
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
       "user": "core"
@@ -113,6 +115,7 @@
   "variables": {
     "ansible_common_vars": "ansible_python_interpreter=/usr/bin/python3",
     "ansible_extra_vars": "",
+    "ansible_timeout": "60",
     "ansible_user_vars": "",
     "attach_config_drive": "false",
     "build_timestamp": "{{timestamp}}",


### PR DESCRIPTION
## What this PR does

Adds the same conservative Ansible retry behavior to OpenStack image builds that QEMU already uses for node provisioning:

- sets `max_retries` on the OpenStack Ansible provisioner
- exposes `ansible_timeout` with a default of `60` seconds via `ANSIBLE_TIMEOUT`

OpenStack builds can see transient SSH/network pauses during provisioning. Without retry/timeout parity, those transient failures fail the build earlier than equivalent QEMU builds.

## Validation

- `python3 -m json.tool images/capi/packer/openstack/packer.json`
- `git diff --check`
- `./images/capi/scripts/ci-json-sort.sh`
- `PACKER_FLAGS='-var volume_type=default' make validate-openstack-ubuntu-2404` reached the existing required OpenStack cloud inputs and failed before cloud auth because no OpenStack environment was configured locally.
- With dummy OpenStack env and required vars, `make validate-openstack-ubuntu-2404` parsed the changed template and then failed attempting to authenticate to the dummy endpoint, as expected without a real OpenStack cloud.
