### PR TITLE
capi: exclude Ansible temp payloads from sysprep cleanup

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -127,8 +127,9 @@
 # A shallow search in /tmp and /var/tmp is used to declare which files or
 # directories will be removed as part of resetting temp space. The reason
 # a state absent->directory task isn't used is because Ansible's own data
-# directory on the remote host(s) is /tmp/.ansible. Thus, by removing /tmp,
-# Ansible can no longer access the remote host.
+# directory on the remote host(s) is /tmp/.ansible, and module payloads may
+# use temporary paths such as /tmp/ansible_*. Thus, by removing /tmp, Ansible
+# can no longer access the remote host.
 - name: Find temp files
   ansible.builtin.find:
     depth: 1
@@ -137,6 +138,11 @@
       - /tmp
       - /var/tmp
     pattern: "*"
+    excludes:
+      - .ansible
+      - .ansible_*
+      - ansible_*
+      - ansible-*
   register: temp_files
 
 - name: Reset temp space


### PR DESCRIPTION
## What this PR does

The sysprep role already uses a shallow `find` over `/tmp` and `/var/tmp` so it can clean temp contents without removing the temp directory itself while Ansible is still running.

This PR keeps that module-based cleanup and adds explicit excludes for common Ansible temp payload names:

- `.ansible`
- `.ansible_*`
- `ansible_*`
- `ansible-*`

It also updates the nearby comment to cover module payload temp paths, not only `/tmp/.ansible`.

## Why it is needed

Without these excludes, sysprep can select Ansible's active remote temp payloads for deletion. Downstream T-CaaS image builds observed `/var/tmp/ansible-remote` being removed during sysprep; that build survived only because it currently overrides Ansible's module tmpdir to `/run`.

The cleanup should stay successful for ordinary temporary files, but it should not delete Ansible's own in-flight execution payloads.

## Validation

- `git diff --check origin/main...HEAD`
- `ansible-playbook -i 'localhost,' -c local images/capi/ansible/node.yml --syntax-check`
