### PR TITLE
capi: allow custom Ansible collection paths

### DIFF
--- a/images/capi/packer/openstack/packer.json
+++ b/images/capi/packer/openstack/packer.json
@@ -56,7 +56,9 @@
     {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
-        "ANSIBLE_TIMEOUT={{user `ansible_timeout`}}"
+        "ANSIBLE_TIMEOUT={{user `ansible_timeout`}}",
+        "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATH={{user `ansible_collections_path`}}{{end}}",
+        "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATHS={{user `ansible_collections_path`}}{{end}}"
       ],
       "extra_arguments": [
         "--scp-extra-args",
@@ -113,6 +115,7 @@
     }
   ],
   "variables": {
+    "ansible_collections_path": "",
     "ansible_common_vars": "ansible_python_interpreter=/usr/bin/python3",
     "ansible_extra_vars": "",
     "ansible_timeout": "60",

--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -80,6 +80,8 @@
     {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
+        "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATH={{user `ansible_collections_path`}}{{end}}",
+        "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATHS={{user `ansible_collections_path`}}{{end}}",
         "KUBEVIRT={{user `kubevirt`}}"
       ],
       "extra_arguments": [
@@ -109,6 +111,8 @@
       "pause_before": "30s",
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
+        "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATH={{user `ansible_collections_path`}}{{end}}",
+        "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATHS={{user `ansible_collections_path`}}{{end}}",
         "KUBEVIRT={{user `kubevirt`}}"
       ],
       "extra_arguments": [
@@ -179,6 +183,7 @@
   "variables": {
     "accelerator": "kvm",
     "ansible_common_vars": "",
+    "ansible_collections_path": "",
     "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
     "ansible_user_vars": "",
     "artifact_name": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",


### PR DESCRIPTION
#### What this PR does / why we need it

This adds an optional `ansible_collections_path` Packer user variable for CAPI QEMU and OpenStack image builds. When set, the Ansible provisioners receive both `ANSIBLE_COLLECTIONS_PATH` and `ANSIBLE_COLLECTIONS_PATHS`, allowing custom roles from external collections to be discovered without modifying the bundled playbooks.

The variable defaults to empty and the environment entries are conditionally rendered, so existing builds keep their current Ansible collection discovery behavior.

#### Which issue(s) this PR fixes

None

#### Special notes for your reviewer

This is split out from downstream T-CaaS immutable-image validation work. That downstream work needs to run upstream node playbooks while loading a custom collection path for additional post-node roles; the mechanism itself is generic and provider-neutral for QEMU/OpenStack.

#### Validation

- `packer validate -syntax-only images/capi/packer/qemu/packer.json`
- `packer validate -syntax-only images/capi/packer/openstack/packer.json`
- `make -C images/capi validate-qemu-ubuntu-2404`
- `./.local/bin/packer validate -var ansible_collections_path=/tmp/collections ... packer/qemu/packer.json`

OpenStack full validation was not completed locally because the provider prepare phase requires live OpenStack auth/source/flavor inputs and contacts the auth endpoint. The syntax-only validation for the edited OpenStack template passed.