### PR TITLE
capi: default Windows additional component flags to booleans

### DIFF
--- a/images/capi/ansible/windows/roles/load_additional_components/defaults/main.yml
+++ b/images/capi/ansible/windows/roles/load_additional_components/defaults/main.yml
@@ -13,10 +13,10 @@
 # limitations under the License.
 ---
 
-additional_registry_images: ""
+additional_registry_images: false
 additional_registry_images_list: ""
-additional_url_images: ""
+additional_url_images: false
 additional_url_images_list: ""
-additional_executables: ""
+additional_executables: false
 additional_executables_list: ""
 additional_executables_destination_path: ""


### PR DESCRIPTION
What this does:
- Aligns the Windows `load_additional_components` role defaults with the Linux role by using YAML booleans for the optional additional component feature flags.
- Keeps the list and destination defaults unchanged.

Why:
- These variables are consumed with `| bool`; using boolean defaults avoids stringly-typed false values and matches the current Linux role defaults.

Validation:
- `python3` YAML parse for `images/capi/ansible/windows/roles/load_additional_components/defaults/main.yml` and `tasks/main.yml`
- `git diff --check`
- `ansible-lint --project-dir images/capi images/capi/ansible/windows/roles/load_additional_components` was run and only reports pre-existing `var-naming[no-role-prefix]` issues for the role variables/registers.