### PR TITLE
capi: allow Ubuntu autoinstall mirror overrides

### DIFF
--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -87,6 +87,8 @@ Several variables can be used to customize the image build.
 | `containerd_service_url`                                                                                                   | Custom URL for the `containerd.service` unit file. By default image-builder renders the bundled unit template, avoiding a network download during provisioning.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `""`                          |
 | `enable_containerd_audit`                                                                                                  | If set to `"true"`, auditd will be configured with containerd specific audit controls.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `"false"`                     |
 | `kubernetes_enable_automatic_resource_sizing`                                                                              | If set to `"true"`, the kubelet will be configured to automatically size system-reserved for CPU and memory.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `"false"`                     |
+| `ubuntu_repo`                                                                                                              | Ubuntu apt mirror. Used both by the Ansible `setup` role and, for the Ubuntu autoinstall builds (qemu, maas, proxmox, including the 24.04 immutable target), by the installer's `apt.primary` mirror. See [Overriding the Ubuntu apt mirrors](#overriding-the-ubuntu-apt-mirrors).                                                                                          | `"http://us.archive.ubuntu.com/ubuntu"` |
+| `ubuntu_security_repo`                                                                                                     | Ubuntu apt security mirror, applied in the same places as `ubuntu_repo`.                                                                                                                                                                                                                                                                                                  | `"http://security.ubuntu.com/ubuntu"` |
 
 The variables found in `packer/config/*.json` or `packer/<provider>/*.json` should not need to be modified directly. For customization it is better to create a JSON file with your changes and provide it via the `PACKER_VAR_FILES` environment variable. Variables set in this file will override any previous values. Multiple files can be passed via `PACKER_VAR_FILES`, with the last file taking precedence over any others.
 
@@ -170,6 +172,90 @@ Then, execute the build (using a Photon OVA as an example) with the following:
 ```sh
 PACKER_VAR_FILES=internal_repos.json make build-node-ova-local-photon-5
 ```
+
+##### Overriding the Ubuntu apt mirrors
+
+The `ubuntu_repo` and `ubuntu_security_repo` variables point Ubuntu builds at a
+different apt mirror. They are applied in two places:
+
+* the Ansible `setup` role writes them into the image's apt sources, for every
+  Ubuntu target, and
+* the Ubuntu autoinstall `user-data` of the qemu, maas and proxmox targets,
+  including the 24.04 immutable target, so the installer itself already pulls
+  packages from the mirror.
+
+The 22.04 autoinstall templates carry no `apt` block, so the installer stage of
+the 22.04 targets is not covered by these variables and keeps Ubuntu's default
+mirrors. The Ansible `setup` role still applies them to the built image.
+
+```sh
+PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://mirror.example.com/ubuntu'" make build-qemu-ubuntu-2404
+```
+
+The same values can come from a var file instead:
+
+```json
+{
+  "ubuntu_repo": "http://mirror.example.com/ubuntu",
+  "ubuntu_security_repo": "http://mirror.example.com/ubuntu"
+}
+```
+
+```sh
+PACKER_VAR_FILES=mirror.json make build-qemu-ubuntu-2404
+```
+
+###### Precedence
+
+The autoinstall `user-data` is rendered per build target, from the same
+`-var`/`-var-file` sequence that target hands to Packer, so the mirrors in the
+installer are the mirrors Packer resolves. Packer's order for these templates,
+lowest to highest, is:
+
+1. the `variables` block of `packer/<provider>/packer.json`,
+2. every `-var-file`, in the order it appears on the command line, which for a
+   build target means `packer/config/*.json` first, then any `-var-file` inside
+   `PACKER_FLAGS`, then the target's own `packer/<provider>/<target>.json`, then
+   the files listed in `PACKER_VAR_FILES`,
+3. every `-var`, which wins over every `-var-file` regardless of position.
+
+So a `--var 'ubuntu_repo=...'` in `PACKER_FLAGS` always wins, while a value in
+`PACKER_VAR_FILES` wins over the target's own var file. This matters for the
+targets that ship their own mirrors, such as `build-maas-ubuntu-2404-arm64`,
+which defaults to `http://ports.ubuntu.com/ubuntu-ports`.
+
+###### Mirrors with credentials
+
+Put a mirror URL that carries credentials in a var file, either the target's own
+or one listed in `PACKER_VAR_FILES`, never in `PACKER_FLAGS`. Make echoes the
+recipe it runs, and `PACKER_FLAGS` is part of that recipe, so a `--var
+'ubuntu_repo=http://user:password@...'` ends up in the build log.
+
+The renderer itself never prints a variable value, and it restores the
+`user-data` that `hack/set-ssh-password.sh` wrote when the build target exits,
+whether Packer succeeded or not, so the substituted mirror does not stay in the
+work tree. While the target runs, the pre-render file sits next to it as
+`user-data.orig`; both names are git-ignored. Set `KEEP_RENDERED_AUTOINSTALL=1`
+to keep the rendered file for debugging.
+
+###### Targets that share an autoinstall directory
+
+Several targets are served from the same autoinstall directory, so their
+rendered `user-data` is the same file:
+
+* `build-qemu-<name>` and `build-kubevirt-<name>` (for example
+  `build-qemu-ubuntu-2404` and `build-kubevirt-qemu-ubuntu-2404`), which share
+  `packer/qemu/linux/ubuntu/http/24.04`,
+* `build-proxmox-ubuntu-2404` and `build-proxmox-ubuntu-2404-efi`, and the same
+  pair for 26.04,
+* `build-maas-ubuntu-2404-efi` and `build-qemu-ubuntu-2404-efi`, and the same
+  pair for 26.04.
+
+Run such targets one after another, not in the same `make -j` invocation. In
+parallel they render and restore the one file underneath each other, so a build
+can be served another target's mirrors or lose the file while Packer is still
+serving it. Sequential runs, including a plain `make build-qemu-all`, are
+unaffected.
 
 ##### Setting up an HTTP Proxy
 

--- a/docs/book/src/capi/capi.md
+++ b/docs/book/src/capi/capi.md
@@ -251,11 +251,10 @@ rendered `user-data` is the same file:
 * `build-maas-ubuntu-2404-efi` and `build-qemu-ubuntu-2404-efi`, and the same
   pair for 26.04.
 
-Run such targets one after another, not in the same `make -j` invocation. In
-parallel they render and restore the one file underneath each other, so a build
-can be served another target's mirrors or lose the file while Packer is still
-serving it. Sequential runs, including a plain `make build-qemu-all`, are
-unaffected.
+The Makefile serializes these renderer-backed targets, including their aggregate
+targets, so `make -j` cannot render or restore the shared file underneath a
+different Packer invocation. The renderer still restores the password-substituted
+file when each target exits.
 
 ##### Setting up an HTTP Proxy
 

--- a/docs/book/src/capi/immutable-qemu.md
+++ b/docs/book/src/capi/immutable-qemu.md
@@ -61,6 +61,14 @@ space, which must be large enough for `/var/lib/containerd`, kubelet state,
 logs, and bootstrap data. Increase `disk_size` when the workload or provider
 needs more writable runtime capacity.
 
+## Apt mirrors
+
+The autoinstall `user-data` of this target takes its `apt.primary` and
+`apt.security` mirrors from the `ubuntu_repo` and `ubuntu_security_repo` Packer
+variables, the same as the other Ubuntu autoinstall targets. See
+[Overriding the Ubuntu apt mirrors](./capi.md#overriding-the-ubuntu-apt-mirrors)
+for the resolution order and for how mirrors that carry credentials are handled.
+
 ## Validation
 
 Run the focused local checks after changing this target:

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -67,8 +67,6 @@ GET_UBUNTU_DOTTED_SEMVER=$(strip \
 	$(_UBUNTU_SEMVER) \
 )
 
-PACKER_VAR_FILE_FLAGS=$(foreach f,$(abspath $(PACKER_VAR_FILES)),--extra-var-file "$(f)" )
-
 ## --------------------------------------
 ## Dependencies
 ## --------------------------------------
@@ -232,8 +230,6 @@ verify-containerd-service-template: ## Verifies the bundled containerd.service t
 	hack/update-containerd-service-template.py
 
 .PHONY: set-ssh-password
-set-ssh-password: export PACKER_FLAGS := $(PACKER_FLAGS)
-set-ssh-password: export PACKER_VAR_FILES := $(PACKER_VAR_FILES)
 set-ssh-password:
 	hack/set-ssh-password.sh
 
@@ -372,6 +368,25 @@ PACKER_WINDOWS_NODE_FLAGS := $(foreach f,$(abspath $(COMMON_WINDOWS_VAR_FILES)),
 				$(PACKER_FLAGS)
 PACKER_POWERVS_NODE_FLAGS := $(foreach f,$(abspath $(COMMON_POWERVS_VAR_FILES)),-var-file="$(f)" ) \
 				$(PACKER_FLAGS)
+
+# The Ubuntu autoinstall user-data embeds the apt mirrors held by the
+# ubuntu_repo and ubuntu_security_repo Packer variables, which a target var
+# file, PACKER_VAR_FILES or PACKER_FLAGS may override. It is therefore rendered
+# per build target, from that target's own variables, instead of once for every
+# template: aggregate targets such as build-qemu-all and parallel `make -j` runs
+# must not render one target's user-data with another target's mirrors.
+#
+# Each recipe collects its Packer arguments into a shell array and passes the
+# same array to the renderer and to Packer, so the renderer sees the same
+# -var/-var-file sequence, in the same order, and applies Packer's precedence:
+# template defaults, then -var-file in command line order, then -var.
+#
+# A mirror URL can carry credentials, so the renderer never prints variable
+# values and the substitution is undone when the recipe exits, whether Packer
+# succeeded or not: the user-data set-ssh-password wrote is put back, because a
+# target sharing the same autoinstall directory still needs it. Set
+# KEEP_RENDERED_AUTOINSTALL=1 to keep the rendered file instead.
+RENDER_UBUNTU_AUTOINSTALL := python3 packer/qemu/scripts/render_ubuntu_autoinstall.py
 
 ## --------------------------------------
 ## Platform and version combinations
@@ -614,13 +629,17 @@ $(OXIDE_VALIDATE_TARGETS): deps-oxide
 
 .PHONY: $(QEMU_BUILD_TARGETS)
 $(QEMU_BUILD_TARGETS): deps-qemu set-ssh-password
-	python3 packer/qemu/scripts/render_ubuntu_autoinstall.py "$(abspath packer/qemu/$(subst build-,,$@).json)" $(PACKER_VAR_FILE_FLAGS)
-	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/qemu/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/qemu/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) build "$${packer_args[@]}" packer/qemu/packer.json
 
 .PHONY: $(QEMU_VALIDATE_TARGETS)
 $(QEMU_VALIDATE_TARGETS): deps-qemu set-ssh-password
-	python3 packer/qemu/scripts/render_ubuntu_autoinstall.py "$(abspath packer/qemu/$(subst validate-,,$@).json)" $(PACKER_VAR_FILE_FLAGS)
-	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/qemu/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/qemu/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) validate "$${packer_args[@]}" packer/qemu/packer.json
 
 .PHONY: test-qemu-immutable
 test-qemu-immutable: ## Runs immutable QEMU helper unit tests
@@ -630,13 +649,17 @@ validate-qemu-ubuntu-2404-immutable: test-qemu-immutable
 
 .PHONY: $(QEMU_KUBEVIRT_BUILD_TARGETS)
 $(QEMU_KUBEVIRT_BUILD_TARGETS): deps-qemu set-ssh-password
-	python3 packer/qemu/scripts/render_ubuntu_autoinstall.py "$(abspath packer/qemu/$(subst build-kubevirt-,,$@).json)" $(PACKER_VAR_FILE_FLAGS)
-	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-kubevirt-,,$@).json)" --var 'kubevirt=true' $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-kubevirt-,,$@).json)" --var 'kubevirt=true' $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/qemu/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/qemu/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) build "$${packer_args[@]}" packer/qemu/packer.json
 
 .PHONY: $(QEMU_KUBEVIRT_VALIDATE_TARGETS)
 $(QEMU_KUBEVIRT_VALIDATE_TARGETS): deps-qemu set-ssh-password
-	python3 packer/qemu/scripts/render_ubuntu_autoinstall.py "$(abspath packer/qemu/$(subst validate-kubevirt-,,$@).json)" $(PACKER_VAR_FILE_FLAGS)
-	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-kubevirt-,,$@).json)" --var 'kubevirt=true' $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-kubevirt-,,$@).json)" --var 'kubevirt=true' $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/qemu/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/qemu/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) validate "$${packer_args[@]}" packer/qemu/packer.json
 
 .PHONY: $(RAW_BUILD_TARGETS)
 $(RAW_BUILD_TARGETS): deps-raw set-ssh-password
@@ -696,11 +719,17 @@ $(HCLOUD_VALIDATE_TARGETS): deps-hcloud
 
 .PHONY: $(PROXMOX_BUILD_TARGETS)
 $(PROXMOX_BUILD_TARGETS): deps-proxmox set-ssh-password
-	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/proxmox/$(subst build-proxmox-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/proxmox/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/proxmox/$(subst build-proxmox-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/proxmox/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/proxmox/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) build "$${packer_args[@]}" packer/proxmox/packer.json
 
 .PHONY: $(PROXMOX_VALIDATE_TARGETS)
 $(PROXMOX_VALIDATE_TARGETS): deps-proxmox set-ssh-password
-	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/proxmox/$(subst validate-proxmox-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/proxmox/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/proxmox/$(subst validate-proxmox-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/proxmox/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/proxmox/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) validate "$${packer_args[@]}" packer/proxmox/packer.json
 
 .PHONY: $(VULTR_BUILD_TARGETS)
 $(VULTR_BUILD_TARGETS): deps-vultr
@@ -712,19 +741,31 @@ $(VULTR_VALIDATE_TARGETS): deps-vultr
 
 .PHONY: $(MAAS_BUILD_TARGETS)
 $(MAAS_BUILD_TARGETS): deps-qemu set-ssh-password
-	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst build-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) packer/maas/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst build-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/maas/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/maas/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) build "$${packer_args[@]}" packer/maas/packer.json
 
 .PHONY: $(MAAS_VALIDATE_TARGETS)
 $(MAAS_VALIDATE_TARGETS): deps-qemu set-ssh-password
-	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst validate-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) packer/maas/packer.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst validate-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/maas/packer.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/maas/packer.json -- "$${packer_args[@]}" && \
+	$(PACKER) validate "$${packer_args[@]}" packer/maas/packer.json
 
 .PHONY: $(MAAS_ARM64_BUILD_TARGETS)
 $(MAAS_ARM64_BUILD_TARGETS): deps-qemu set-ssh-password
-	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst build-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) packer/maas/packer-arm64.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst build-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/maas/packer-arm64.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/maas/packer-arm64.json -- "$${packer_args[@]}" && \
+	$(PACKER) build "$${packer_args[@]}" packer/maas/packer-arm64.json
 
 .PHONY: $(MAAS_ARM64_VALIDATE_TARGETS)
 $(MAAS_ARM64_VALIDATE_TARGETS): deps-qemu set-ssh-password
-	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst validate-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) packer/maas/packer-arm64.json
+	packer_args=( $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/maas/$(subst validate-,,$@).json)" --var="ansible_user_vars=provider=maas" $(ABSOLUTE_PACKER_VAR_FILES) ); \
+	trap '$(RENDER_UBUNTU_AUTOINSTALL) --clean --packer-template packer/maas/packer-arm64.json -- "$${packer_args[@]}"' EXIT; \
+	$(RENDER_UBUNTU_AUTOINSTALL) --packer-template packer/maas/packer-arm64.json -- "$${packer_args[@]}" && \
+	$(PACKER) validate "$${packer_args[@]}" packer/maas/packer-arm64.json
 
 .PHONY: $(SCALEWAY_BUILD_TARGETS)
 $(SCALEWAY_BUILD_TARGETS): deps-scaleway

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -232,6 +232,8 @@ verify-containerd-service-template: ## Verifies the bundled containerd.service t
 	hack/update-containerd-service-template.py
 
 .PHONY: set-ssh-password
+set-ssh-password: export PACKER_FLAGS := $(PACKER_FLAGS)
+set-ssh-password: export PACKER_VAR_FILES := $(PACKER_VAR_FILES)
 set-ssh-password:
 	hack/set-ssh-password.sh
 

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -521,6 +521,12 @@ MAAS_ARM64_VALIDATE_TARGETS 	:= $(addprefix validate-,$(MAAS_ARM64_BUILD_NAMES))
 SCALEWAY_BUILD_TARGETS		:= $(addprefix build-,$(SCALEWAY_BUILD_NAMES))
 SCALEWAY_VALIDATE_TARGETS	:= $(addprefix validate-,$(SCALEWAY_BUILD_NAMES))
 
+# These recipes render and restore shared autoinstall user-data files. Serialize
+# the invocation so parallel aggregate targets cannot serve another target's
+# mirrors. This is deliberately global because Make 3.81 cannot serialize leaf
+# recipes with a target-specific .NOTPARALLEL prerequisite list.
+.NOTPARALLEL:
+
 .PHONY: $(NODE_OVA_LOCAL_BUILD_TARGETS)
 $(NODE_OVA_LOCAL_BUILD_TARGETS): deps-ova set-ssh-password
     # This uses a packer file builder to input unattend variables into a JSON file to be consumed by the python script before running the vmware-iso provisioner

--- a/images/capi/hack/set-ssh-password.sh
+++ b/images/capi/hack/set-ssh-password.sh
@@ -20,6 +20,89 @@ set -o pipefail
 
 PACKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../packer" && pwd -P)"
 
+resolve_packer_var() {
+  local key="$1"
+  local default="$2"
+
+  PACKER_DIR="$PACKER_DIR" python3 - "$key" "$default" <<'PY'
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+key = sys.argv[1]
+value = sys.argv[2]
+packer_dir = Path(os.environ["PACKER_DIR"])
+cwd = Path.cwd()
+
+
+def resolve_path(path):
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    if (cwd / candidate).exists():
+        return cwd / candidate
+    return packer_dir.parent / candidate
+
+
+def load_var_file(path):
+    global value
+    candidate = resolve_path(path)
+    if not candidate.is_file():
+        return
+    with candidate.open(encoding="utf-8") as var_file:
+        data = json.load(var_file)
+    if key in data:
+        value = str(data[key])
+
+
+def parse_flags():
+    var_files = []
+    vars_from_flags = []
+    tokens = shlex.split(os.environ.get("PACKER_FLAGS", ""))
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in ("-var-file", "--var-file") and index + 1 < len(tokens):
+            var_files.append(tokens[index + 1])
+            index += 2
+            continue
+        if token.startswith("-var-file=") or token.startswith("--var-file="):
+            var_files.append(token.split("=", 1)[1])
+            index += 1
+            continue
+        if token in ("-var", "--var") and index + 1 < len(tokens):
+            vars_from_flags.append(tokens[index + 1])
+            index += 2
+            continue
+        if token.startswith("-var=") or token.startswith("--var="):
+            vars_from_flags.append(token.split("=", 1)[1])
+            index += 1
+            continue
+        index += 1
+    return var_files, vars_from_flags
+
+
+load_var_file(packer_dir / "config" / "common.json")
+for var_file in shlex.split(os.environ.get("PACKER_VAR_FILES", "")):
+    load_var_file(var_file)
+
+flag_var_files, flag_vars = parse_flags()
+for var_file in flag_var_files:
+    load_var_file(var_file)
+for item in flag_vars:
+    if item.startswith(f"{key}="):
+        value = item.split("=", 1)[1]
+
+print(value)
+PY
+}
+
+sed_escape_replacement() {
+  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
 openssl_binary=openssl11
 if ! command -v $openssl_binary >/dev/null 2>&1; then
   openssl_binary=openssl
@@ -43,15 +126,28 @@ fi
 
 export SSH_PASSWORD=${SSH_PASSWORD:-"$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)"}
 SALT=$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)
-export ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt $SALT -stdin <<< $SSH_PASSWORD)
+ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt "$SALT" -stdin <<< "$SSH_PASSWORD")
+export ENCRYPTED_SSH_PASSWORD
+export UBUNTU_REPO=${UBUNTU_REPO:-"$(resolve_packer_var ubuntu_repo "http://us.archive.ubuntu.com/ubuntu")"}
+export UBUNTU_SECURITY_REPO=${UBUNTU_SECURITY_REPO:-"$(resolve_packer_var ubuntu_security_repo "http://security.ubuntu.com/ubuntu")"}
 
-for file in $(find $PACKER_DIR -type f -name "*.tmpl"); do
+ssh_password_replacement="$(sed_escape_replacement "$SSH_PASSWORD")"
+encrypted_ssh_password_replacement="$(sed_escape_replacement "$ENCRYPTED_SSH_PASSWORD")"
+ubuntu_repo_replacement="$(sed_escape_replacement "$UBUNTU_REPO")"
+ubuntu_security_repo_replacement="$(sed_escape_replacement "$UBUNTU_SECURITY_REPO")"
+
+while IFS= read -r -d '' file; do
   if [ -f "${file%.*}" ]; then
     # HACK: There seems to be a case where this can actually
     # fail with the file not being found, leading to test failures.
     # If we fail to remove the file we just continue and assume
     # that the file was already removed.
-    rm ${file%.*} || true
+    rm "${file%.*}" || true
   fi
-  sed -e "s|\$SSH_PASSWORD|$SSH_PASSWORD|g" -e "s|\$ENCRYPTED_SSH_PASSWORD|$ENCRYPTED_SSH_PASSWORD|g" $file | tee ${file%.*}
-done
+  sed \
+    -e "s|\$SSH_PASSWORD|$ssh_password_replacement|g" \
+    -e "s|\$ENCRYPTED_SSH_PASSWORD|$encrypted_ssh_password_replacement|g" \
+    -e "s|\$UBUNTU_REPO|$ubuntu_repo_replacement|g" \
+    -e "s|\$UBUNTU_SECURITY_REPO|$ubuntu_security_repo_replacement|g" \
+    "$file" | tee "${file%.*}"
+done < <(find "$PACKER_DIR" -type f -name "*.tmpl" -print0)

--- a/images/capi/hack/set-ssh-password.sh
+++ b/images/capi/hack/set-ssh-password.sh
@@ -20,89 +20,6 @@ set -o pipefail
 
 PACKER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../packer" && pwd -P)"
 
-resolve_packer_var() {
-  local key="$1"
-  local default="$2"
-
-  PACKER_DIR="$PACKER_DIR" python3 - "$key" "$default" <<'PY'
-import json
-import os
-import shlex
-import sys
-from pathlib import Path
-
-key = sys.argv[1]
-value = sys.argv[2]
-packer_dir = Path(os.environ["PACKER_DIR"])
-cwd = Path.cwd()
-
-
-def resolve_path(path):
-    candidate = Path(path)
-    if candidate.is_absolute():
-        return candidate
-    if (cwd / candidate).exists():
-        return cwd / candidate
-    return packer_dir.parent / candidate
-
-
-def load_var_file(path):
-    global value
-    candidate = resolve_path(path)
-    if not candidate.is_file():
-        return
-    with candidate.open(encoding="utf-8") as var_file:
-        data = json.load(var_file)
-    if key in data:
-        value = str(data[key])
-
-
-def parse_flags():
-    var_files = []
-    vars_from_flags = []
-    tokens = shlex.split(os.environ.get("PACKER_FLAGS", ""))
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
-        if token in ("-var-file", "--var-file") and index + 1 < len(tokens):
-            var_files.append(tokens[index + 1])
-            index += 2
-            continue
-        if token.startswith("-var-file=") or token.startswith("--var-file="):
-            var_files.append(token.split("=", 1)[1])
-            index += 1
-            continue
-        if token in ("-var", "--var") and index + 1 < len(tokens):
-            vars_from_flags.append(tokens[index + 1])
-            index += 2
-            continue
-        if token.startswith("-var=") or token.startswith("--var="):
-            vars_from_flags.append(token.split("=", 1)[1])
-            index += 1
-            continue
-        index += 1
-    return var_files, vars_from_flags
-
-
-load_var_file(packer_dir / "config" / "common.json")
-for var_file in shlex.split(os.environ.get("PACKER_VAR_FILES", "")):
-    load_var_file(var_file)
-
-flag_var_files, flag_vars = parse_flags()
-for var_file in flag_var_files:
-    load_var_file(var_file)
-for item in flag_vars:
-    if item.startswith(f"{key}="):
-        value = item.split("=", 1)[1]
-
-print(value)
-PY
-}
-
-sed_escape_replacement() {
-  printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
-}
-
 openssl_binary=openssl11
 if ! command -v $openssl_binary >/dev/null 2>&1; then
   openssl_binary=openssl
@@ -126,28 +43,15 @@ fi
 
 export SSH_PASSWORD=${SSH_PASSWORD:-"$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)"}
 SALT=$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)
-ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt "$SALT" -stdin <<< "$SSH_PASSWORD")
-export ENCRYPTED_SSH_PASSWORD
-export UBUNTU_REPO=${UBUNTU_REPO:-"$(resolve_packer_var ubuntu_repo "http://us.archive.ubuntu.com/ubuntu")"}
-export UBUNTU_SECURITY_REPO=${UBUNTU_SECURITY_REPO:-"$(resolve_packer_var ubuntu_security_repo "http://security.ubuntu.com/ubuntu")"}
+export ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt $SALT -stdin <<< $SSH_PASSWORD)
 
-ssh_password_replacement="$(sed_escape_replacement "$SSH_PASSWORD")"
-encrypted_ssh_password_replacement="$(sed_escape_replacement "$ENCRYPTED_SSH_PASSWORD")"
-ubuntu_repo_replacement="$(sed_escape_replacement "$UBUNTU_REPO")"
-ubuntu_security_repo_replacement="$(sed_escape_replacement "$UBUNTU_SECURITY_REPO")"
-
-while IFS= read -r -d '' file; do
+for file in $(find $PACKER_DIR -type f -name "*.tmpl"); do
   if [ -f "${file%.*}" ]; then
     # HACK: There seems to be a case where this can actually
     # fail with the file not being found, leading to test failures.
     # If we fail to remove the file we just continue and assume
     # that the file was already removed.
-    rm "${file%.*}" || true
+    rm ${file%.*} || true
   fi
-  sed \
-    -e "s|\$SSH_PASSWORD|$ssh_password_replacement|g" \
-    -e "s|\$ENCRYPTED_SSH_PASSWORD|$encrypted_ssh_password_replacement|g" \
-    -e "s|\$UBUNTU_REPO|$ubuntu_repo_replacement|g" \
-    -e "s|\$UBUNTU_SECURITY_REPO|$ubuntu_security_repo_replacement|g" \
-    "$file" | tee "${file%.*}"
-done < <(find "$PACKER_DIR" -type f -name "*.tmpl" -print0)
+  sed -e "s|\$SSH_PASSWORD|$SSH_PASSWORD|g" -e "s|\$ENCRYPTED_SSH_PASSWORD|$ENCRYPTED_SSH_PASSWORD|g" $file | tee ${file%.*}
+done

--- a/images/capi/packer/maas/.gitignore
+++ b/images/capi/packer/maas/.gitignore
@@ -4,3 +4,4 @@ ks.cfg
 preseed.cfg
 preseed-efi.cfg
 user-data
+user-data.orig

--- a/images/capi/packer/maas/README.md
+++ b/images/capi/packer/maas/README.md
@@ -41,6 +41,12 @@ ARCH=arm64 PACKER_FLAGS="--var 'kubernetes_rpm_version=1.30.5' --var 'kubernetes
 P.S: In order to change disk size(defaults to 20GB as of 31.10.22) you can update PACKER_FLAGS with:
 --var 'disk_size=<disk size in mb>'
 
+Ubuntu autoinstall builds use the `ubuntu_repo` and `ubuntu_security_repo` Packer variables while rendering the installer user-data. For example:
+
+```
+PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'" make build-maas-ubuntu-2404-efi
+```
+
 # Uploading to MaaS
 
 To upload the generates images to MaaS, run the following command.

--- a/images/capi/packer/maas/README.md
+++ b/images/capi/packer/maas/README.md
@@ -47,6 +47,10 @@ Ubuntu autoinstall builds use the `ubuntu_repo` and `ubuntu_security_repo` Packe
 PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'" make build-maas-ubuntu-2404-efi
 ```
 
+The user-data is rendered per build target from that target's own Packer
+variables. See the [Ubuntu apt mirror docs](../../../../docs/book/src/capi/capi.md#overriding-the-ubuntu-apt-mirrors)
+for the resolution order and for mirrors that carry credentials.
+
 # Uploading to MaaS
 
 To upload the generates images to MaaS, run the following command.

--- a/images/capi/packer/maas/linux/ubuntu/http/23.04/user-data.tmpl
+++ b/images/capi/packer/maas/linux/ubuntu/http/23.04/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/maas/linux/ubuntu/http/24.04.arm64/user-data.tmpl
+++ b/images/capi/packer/maas/linux/ubuntu/http/24.04.arm64/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/maas/linux/ubuntu/http/24.04.efi/user-data.tmpl
+++ b/images/capi/packer/maas/linux/ubuntu/http/24.04.efi/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/maas/linux/ubuntu/http/24.04/user-data.tmpl
+++ b/images/capi/packer/maas/linux/ubuntu/http/24.04/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/maas/linux/ubuntu/http/26.04.efi/user-data.tmpl
+++ b/images/capi/packer/maas/linux/ubuntu/http/26.04.efi/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/maas/linux/ubuntu/http/26.04/user-data.tmpl
+++ b/images/capi/packer/maas/linux/ubuntu/http/26.04/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/proxmox/.gitignore
+++ b/images/capi/packer/proxmox/.gitignore
@@ -1,3 +1,4 @@
 packer.json
 ks.cfg
 user-data
+user-data.orig

--- a/images/capi/packer/proxmox/README.md
+++ b/images/capi/packer/proxmox/README.md
@@ -6,6 +6,12 @@ To build an image using a specific version of Kubernetes use the "PACKER_FLAGS" 
 PACKER_FLAGS="--var 'kubernetes_rpm_version=1.28.3' --var 'kubernetes_semver=v1.28.3' --var 'kubernetes_series=v1.28' --var 'kubernetes_deb_version=1.28.3-1.1'" make build-proxmox-ubuntu-2204
 ```
 
+Ubuntu autoinstall builds use the `ubuntu_repo` and `ubuntu_security_repo` Packer variables while rendering the installer user-data. For example:
+
+```
+PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'" make build-proxmox-ubuntu-2404
+```
+
 ## ISO files
 
 To use existing ISO files, set the `ISO_FILE` environment variable to the path of the ISO file.

--- a/images/capi/packer/proxmox/README.md
+++ b/images/capi/packer/proxmox/README.md
@@ -12,6 +12,10 @@ Ubuntu autoinstall builds use the `ubuntu_repo` and `ubuntu_security_repo` Packe
 PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'" make build-proxmox-ubuntu-2404
 ```
 
+The user-data is rendered per build target from that target's own Packer
+variables. See the [Ubuntu apt mirror docs](../../../../docs/book/src/capi/capi.md#overriding-the-ubuntu-apt-mirrors)
+for the resolution order and for mirrors that carry credentials.
+
 ## ISO files
 
 To use existing ISO files, set the `ISO_FILE` environment variable to the path of the ISO file.

--- a/images/capi/packer/proxmox/linux/ubuntu/http/24.04.efi/user-data.tmpl
+++ b/images/capi/packer/proxmox/linux/ubuntu/http/24.04.efi/user-data.tmpl
@@ -14,9 +14,14 @@ autoinstall:
   packages:
     - qemu-guest-agent
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/proxmox/linux/ubuntu/http/24.04/user-data.tmpl
+++ b/images/capi/packer/proxmox/linux/ubuntu/http/24.04/user-data.tmpl
@@ -14,9 +14,14 @@ autoinstall:
   packages:
     - qemu-guest-agent
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/proxmox/linux/ubuntu/http/26.04.efi/user-data.tmpl
+++ b/images/capi/packer/proxmox/linux/ubuntu/http/26.04.efi/user-data.tmpl
@@ -14,9 +14,14 @@ autoinstall:
   packages:
     - qemu-guest-agent
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/proxmox/linux/ubuntu/http/26.04/user-data.tmpl
+++ b/images/capi/packer/proxmox/linux/ubuntu/http/26.04/user-data.tmpl
@@ -14,9 +14,14 @@ autoinstall:
   packages:
     - qemu-guest-agent
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/qemu/.gitignore
+++ b/images/capi/packer/qemu/.gitignore
@@ -3,3 +3,4 @@ ks.cfg
 preseed.cfg
 preseed-efi.cfg
 user-data
+user-data.orig

--- a/images/capi/packer/qemu/README.md
+++ b/images/capi/packer/qemu/README.md
@@ -182,3 +182,9 @@ make test-qemu-boot-smoke QEMU_BOOT_SMOKE_IMAGE=/path/to/image.qcow2
 The smoke helper does not support `qemu-flatcar` images because they use
 Ignition instead of cloud-init. Set `QEMU_BOOT_SMOKE_OS=flatcar` when invoking
 the Make target to fail fast before attempting an unsupported SSH check.
+
+Ubuntu autoinstall builds use the `ubuntu_repo` and `ubuntu_security_repo` Packer variables while rendering the installer user-data. For example:
+
+```bash
+PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'" make build-qemu-ubuntu-2404
+```

--- a/images/capi/packer/qemu/README.md
+++ b/images/capi/packer/qemu/README.md
@@ -188,3 +188,7 @@ Ubuntu autoinstall builds use the `ubuntu_repo` and `ubuntu_security_repo` Packe
 ```bash
 PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'" make build-qemu-ubuntu-2404
 ```
+
+The user-data is rendered per build target from that target's own Packer
+variables. See the [Ubuntu apt mirror docs](../../../../docs/book/src/capi/capi.md#overriding-the-ubuntu-apt-mirrors)
+for the resolution order and for mirrors that carry credentials.

--- a/images/capi/packer/qemu/linux/ubuntu/http/23.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/23.04/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/qemu/linux/ubuntu/http/24.04.efi/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/24.04.efi/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/qemu/linux/ubuntu/http/24.04.immutable/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/24.04.immutable/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a root partition plus an optional persistent data partition.
   storage:
     grub:

--- a/images/capi/packer/qemu/linux/ubuntu/http/24.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/24.04/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/qemu/linux/ubuntu/http/26.04.efi/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/26.04.efi/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/qemu/linux/ubuntu/http/26.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/26.04/user-data.tmpl
@@ -26,9 +26,14 @@ autoinstall:
   keyboard:
     layout: us
   apt:
-    mirror-selection:
-      primary:
-          - uri: http://archive.ubuntu.com/ubuntu
+    preserve_sources_list: false
+    primary:
+      - arches: [default]
+        uri: $UBUNTU_REPO
+    security:
+      - arches: [default]
+        uri: $UBUNTU_SECURITY_REPO
+    geoip: false
   # Create a single-partition with no swap space. Kubernetes
   # really dislikes the idea of anyone else managing memory.
   # For more information on how partitioning is configured,

--- a/images/capi/packer/qemu/scripts/render_ubuntu_autoinstall.py
+++ b/images/capi/packer/qemu/scripts/render_ubuntu_autoinstall.py
@@ -14,16 +14,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+r"""Render the Ubuntu autoinstall user-data of a single Packer build target.
+
+Usage:
+
+    render_ubuntu_autoinstall.py [--clean] --packer-template <template>
+        -- <the exact -var/-var-file sequence given to packer>
+
+Every qemu, maas and proxmox build/validate recipe in the Makefile calls this
+script with the same argument vector it then passes to `packer build` or
+`packer validate`, so the values resolved here are the values Packer resolves.
+Precedence for legacy JSON templates, verified against Packer itself:
+
+  1. the `variables` block of the Packer template (lowest precedence),
+  2. every `-var-file`, in the order it appears on the command line,
+     later files overriding earlier ones,
+  3. every `-var`, which outranks every `-var-file` no matter where it
+     appears, later `-var` flags overriding earlier ones.
+
+Nested `{{user `name`}}` references inside a variable default are resolved,
+because Packer resolves them too.
+
+Rendering is per target and never global. The autoinstall directory is derived
+from the target's own `http_directory`, `autoinstall_profile` and
+`boot_command_prefix`, so aggregate targets such as `build-qemu-all` and
+parallel `make -j` runs cannot render one target's user-data with another
+target's variables.
+
+`ubuntu_repo` and `ubuntu_security_repo` may carry credentials, so this script
+never prints a variable value, and `--clean` undoes the substitution again when
+the build recipe exits. It restores the file as set-ssh-password.sh wrote it,
+kept alongside as `user-data.orig` while the build runs, because another target
+can share the same autoinstall directory. Set KEEP_RENDERED_AUTOINSTALL=1 to
+keep the rendered file for debugging.
+"""
+
 import argparse
 import json
 import os
 import pathlib
 import re
-import shlex
 import sys
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[2]
+# images/capi, the directory the Makefile runs from and the directory the
+# `http_directory` Packer variable is relative to.
+CAPI_ROOT = pathlib.Path(__file__).resolve().parents[3]
+PACKER_ROOT = CAPI_ROOT / "packer"
+
 IMMUTABLE_DEFAULTS = {
     "immutable_data_partition": "false",
     "immutable_data_partition_fstype": "ext4",
@@ -32,36 +70,128 @@ IMMUTABLE_DEFAULTS = {
     "immutable_root_partition_size": "12884901888",
 }
 
+# Autoinstall placeholder -> Packer variable holding its value.
+MIRROR_PLACEHOLDERS = (
+    ("$UBUNTU_SECURITY_REPO", "ubuntu_security_repo"),
+    ("$UBUNTU_REPO", "ubuntu_repo"),
+)
+
+# Placeholders that hack/set-ssh-password.sh substitutes. If one survives into
+# the file this script writes, the installer would set a literal password and
+# the image would be unusable, so refuse to write it.
+PASSWORD_PLACEHOLDERS = ("$ENCRYPTED_SSH_PASSWORD", "$SSH_PASSWORD")
+
+USER_VARIABLE = re.compile(r"\{\{\s*user\s+`([^`]+)`\s*\}\}")
+
+# The autoinstall data source in boot_command_prefix, for example
+# ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04/'. The path
+# component names the subdirectory of http_directory that Packer serves the
+# user-data from.
+BOOT_COMMAND_DATASOURCE = re.compile(
+    r"s=https?://\{\{\s*\.HTTPIP\s*\}\}:\{\{\s*\.HTTPPort\s*\}\}/([^'\" ]*)"
+)
+
+# A mirror URL is pasted into YAML unquoted, so reject anything that could end
+# the scalar or start a comment. The value is never echoed, it may hold a
+# password.
+MIRROR_URL = re.compile(r"\Ahttps?://[^\s'\"#]+\Z")
+
 
 def load_json(path):
-    with path.open(encoding="utf-8") as data:
+    with pathlib.Path(path).open(encoding="utf-8") as data:
         return json.load(data)
 
 
-def parse_packer_flags(flags):
-    values = {}
+def template_variables(packer_template):
+    """Return the defaults from a Packer JSON template's `variables` block.
+
+    Falls back to the .tmpl the Makefile renders the template from, so the
+    script also works before set-ssh-password.sh has run.
+    """
+    template = pathlib.Path(packer_template)
+    if not template.is_absolute():
+        template = CAPI_ROOT / template
+    if not template.is_file():
+        template = template.with_name(template.name + ".tmpl")
+    variables = load_json(template).get("variables") or {}
+    return {key: "" if value is None else str(value) for key, value in variables.items()}
+
+
+def parse_packer_args(packer_args):
+    """Split a Packer argument vector into its -var-file list and -var map."""
     var_files = []
-    tokens = shlex.split(flags or "")
+    flag_vars = {}
     index = 0
-    while index < len(tokens):
-        token = tokens[index]
+    while index < len(packer_args):
+        token = packer_args[index]
         value = None
-        if token in ("-var", "--var") and index + 1 < len(tokens):
+        if token in ("-var-file", "--var-file") and index + 1 < len(packer_args):
+            var_files.append(packer_args[index + 1])
+            index += 2
+            continue
+        if token.startswith("-var-file=") or token.startswith("--var-file="):
+            var_files.append(token.split("=", 1)[1])
+        elif token in ("-var", "--var") and index + 1 < len(packer_args):
+            value = packer_args[index + 1]
             index += 1
-            value = tokens[index]
         elif token.startswith("-var=") or token.startswith("--var="):
             value = token.split("=", 1)[1]
-        elif token in ("-var-file", "--var-file") and index + 1 < len(tokens):
-            index += 1
-            var_files.append(tokens[index])
-        elif token.startswith("-var-file=") or token.startswith("--var-file="):
-            var_files.append(token.split("=", 1)[1])
-
-        if value and "=" in value:
-            key, raw = value.split("=", 1)
-            values[key] = raw
+        if value is not None and "=" in value:
+            key, assigned = value.split("=", 1)
+            flag_vars[key] = assigned
         index += 1
-    return values, var_files
+    return var_files, flag_vars
+
+
+def resolve_values(packer_template, packer_args):
+    """Resolve Packer variables exactly the way Packer resolves them."""
+    values = template_variables(packer_template)
+
+    var_files, flag_vars = parse_packer_args(packer_args)
+    for var_file in var_files:
+        path = pathlib.Path(var_file)
+        if not path.is_absolute():
+            path = CAPI_ROOT / path
+        values.update({key: "" if val is None else str(val) for key, val in load_json(path).items()})
+
+    # -var beats every -var-file regardless of its position on the command line.
+    values.update(flag_vars)
+
+    for key, fallback in IMMUTABLE_DEFAULTS.items():
+        if not values.get(key, "").strip():
+            values[key] = fallback
+    return values
+
+
+def interpolate(value, values):
+    """Resolve `{{user `name`}}` references, as Packer does in variable defaults."""
+    for _ in range(4):
+        expanded = USER_VARIABLE.sub(lambda match: values.get(match.group(1), ""), value)
+        if expanded == value:
+            break
+        value = expanded
+    return value
+
+
+def autoinstall_dir(values):
+    """Return the directory Packer serves this target's user-data from."""
+    if values.get("distro_name", "") != "ubuntu":
+        return None
+
+    http_directory = interpolate(values.get("http_directory", ""), values).strip()
+    if not http_directory:
+        return None
+
+    profile = values.get("autoinstall_profile", "").strip().strip("/")
+    if not profile:
+        datasource = BOOT_COMMAND_DATASOURCE.search(values.get("boot_command_prefix", ""))
+        profile = datasource.group(1).strip("/") if datasource else ""
+
+    directory = (CAPI_ROOT / http_directory / profile).resolve()
+    packer_root = PACKER_ROOT.resolve()
+    if packer_root not in directory.parents:
+        raise ValueError(f"resolved autoinstall directory is outside {packer_root}")
+    return directory
 
 
 def as_bool(value):
@@ -120,71 +250,164 @@ def data_partition_config(values):
         path: {mount}"""
 
 
-def render_user_data(var_file, values):
-    profile = values.get("autoinstall_profile")
-    distro = values.get("distro_name")
-    if distro != "ubuntu" or not profile:
-        return
+def substitute_mirrors(content, values):
+    for placeholder, variable in MIRROR_PLACEHOLDERS:
+        if placeholder not in content:
+            continue
+        mirror = values.get(variable, "").strip()
+        if not mirror:
+            raise ValueError(f"{variable} is required to render {placeholder}")
+        if not MIRROR_URL.fullmatch(mirror):
+            # Deliberately without the value, it can contain a password.
+            raise ValueError(
+                f"{variable} must be an http(s) URL without whitespace, quotes or '#'"
+            )
+        content = content.replace(placeholder, mirror)
+    return content
 
-    profile_dir = ROOT / "qemu" / "linux" / "ubuntu" / "http" / str(profile)
-    user_data = profile_dir / "user-data"
-    template = profile_dir / "user-data.tmpl"
+
+def substitute_immutable(content, values):
+    if "${IMMUTABLE_AUTOINSTALL_ROOT_PARTITION_SIZE}" in content:
+        validate_root_size(values["immutable_root_partition_size"])
+        content = content.replace(
+            "${IMMUTABLE_AUTOINSTALL_ROOT_PARTITION_SIZE}",
+            str(values["immutable_root_partition_size"]),
+        )
+    if "${IMMUTABLE_AUTOINSTALL_DATA_PARTITION_CONFIG}" in content:
+        content = content.replace(
+            "${IMMUTABLE_AUTOINSTALL_DATA_PARTITION_CONFIG}",
+            data_partition_config(values),
+        )
+    return content
+
+
+def reject_password_placeholders(content):
+    for placeholder in PASSWORD_PLACEHOLDERS:
+        if placeholder in content:
+            raise ValueError(
+                f"{placeholder} is still unsubstituted, so the image would be "
+                "unusable. Run hack/set-ssh-password.sh before rendering."
+            )
+
+
+def render_user_data(directory, values):
+    template = directory / "user-data.tmpl"
+    user_data = directory / "user-data"
+    stash = directory / "user-data.orig"
+
+    # A run killed between the write below and the restore in clean_user_data
+    # leaves the stash behind. Put it back first so the stash always holds
+    # set-ssh-password's output rather than a mirror-substituted file.
+    if stash.is_file():
+        os.replace(stash, user_data)
+
     # Prefer the already-rendered user-data over the raw .tmpl: set-ssh-password
-    # runs before this script (see the Makefile's QEMU_BUILD_TARGETS recipe) and
-    # substitutes the real $ENCRYPTED_SSH_PASSWORD into user-data. Re-reading the
-    # pristine .tmpl here would discard that substitution and leave the literal
-    # placeholder in the rendered file.
-    if user_data.exists():
+    # runs first (see the build recipes in the Makefile) and substitutes the real
+    # $ENCRYPTED_SSH_PASSWORD into user-data. Re-reading the pristine .tmpl here
+    # would discard that substitution and leave the literal placeholder behind.
+    if user_data.is_file():
         content = user_data.read_text(encoding="utf-8")
-    elif template.exists():
+    elif template.is_file():
         content = template.read_text(encoding="utf-8")
     else:
-        raise FileNotFoundError(f"{user_data} or {template} is required")
+        return None
 
-    validate_root_size(values["immutable_root_partition_size"])
-    content = content.replace(
-        "${IMMUTABLE_AUTOINSTALL_ROOT_PARTITION_SIZE}",
-        str(values["immutable_root_partition_size"]),
-    )
-    content = content.replace(
-        "${IMMUTABLE_AUTOINSTALL_DATA_PARTITION_CONFIG}",
-        data_partition_config(values),
-    )
+    original = content
+    content = substitute_mirrors(content, values)
+    content = substitute_immutable(content, values)
+    reject_password_placeholders(content)
+
+    # Keep the pre-render file so clean_user_data can put it back. Another
+    # target may share this directory (build-qemu-<name> and
+    # build-kubevirt-<name> do) and set-ssh-password only runs once per make
+    # invocation, so deleting it would leave that target rendering from the
+    # pristine .tmpl.
+    if user_data.is_file():
+        stash.write_text(original, encoding="utf-8")
     user_data.write_text(content, encoding="utf-8")
-    print(f"Rendered Ubuntu autoinstall user-data for {var_file.name}: {user_data}")
+    return user_data
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("var_file", type=pathlib.Path)
-    parser.add_argument("--extra-var-file", action="append", default=[], type=pathlib.Path)
-    args = parser.parse_args()
+def clean_user_data(directory):
+    """Undo the mirror substitution so no credential survives the build.
 
-    # Mirror the precedence Packer itself applies on the CLI (see the Makefile's
-    # QEMU_BUILD_TARGETS recipe): PACKER_NODE_FLAGS -- which embeds any
-    # -var/-var-file supplied through PACKER_FLAGS -- comes first, then the
-    # per-target var-file (args.var_file), then PACKER_VAR_FILES last (passed
-    # here as --extra-var-file). Packer's -var/-var-file flags are last-wins,
-    # so values loaded later in this function must be the ones loaded later on
-    # the actual `packer build`/`packer validate` command line.
-    values = dict(IMMUTABLE_DEFAULTS)
+    The pre-render file is restored when there is one, leaving exactly what
+    set-ssh-password.sh wrote, so a target sharing this directory still finds
+    the real build password in it.
+    """
+    template = directory / "user-data.tmpl"
+    user_data = directory / "user-data"
+    stash = directory / "user-data.orig"
+    if stash.is_file():
+        os.replace(stash, user_data)
+        return "Restored", user_data
+    if template.is_file() and user_data.is_file():
+        user_data.unlink()
+        return "Removed", user_data
+    return None
 
-    packer_values, packer_var_files = parse_packer_flags(os.environ.get("PACKER_FLAGS", ""))
-    for var_file in [pathlib.Path(path) for path in packer_var_files]:
-        values.update(load_json(var_file))
-    values.update(packer_values)
 
-    values.update(load_json(args.var_file))
+def keep_rendered():
+    return os.environ.get("KEEP_RENDERED_AUTOINSTALL", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
 
-    for var_file in args.extra_var_file:
-        values.update(load_json(var_file))
 
-    render_user_data(args.var_file, values)
+def split_argv(argv):
+    """Split this script's own options from the Packer argument vector."""
+    if "--" in argv:
+        separator = argv.index("--")
+        return argv[:separator], argv[separator + 1 :]
+    return argv, []
+
+
+def main(argv=None):
+    script_args, packer_args = split_argv(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packer-template", required=True)
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="undo the substitution instead of writing it",
+    )
+    args = parser.parse_args(script_args)
+
+    values = resolve_values(args.packer_template, packer_args)
+    directory = autoinstall_dir(values)
+    if directory is None or not directory.is_dir():
+        return
+
+    if args.clean:
+        if keep_rendered():
+            return
+        cleaned = clean_user_data(directory)
+        if cleaned is not None:
+            verb, path = cleaned
+            print(f"{verb} rendered Ubuntu autoinstall user-data: {relative(path)}")
+        return
+
+    rendered = render_user_data(directory, values)
+    if rendered is not None:
+        print(f"Rendered Ubuntu autoinstall user-data: {relative(rendered)}")
+
+
+def relative(path):
+    try:
+        return path.relative_to(CAPI_ROOT)
+    except ValueError:
+        return path
 
 
 if __name__ == "__main__":
     try:
         main()
     except Exception as err:
+        # Cleanup must never turn a successful build into a failed one.
+        if "--clean" in sys.argv:
+            print(f"render_ubuntu_autoinstall.py: {err}", file=sys.stderr)
+            sys.exit(0)
         print(f"render_ubuntu_autoinstall.py: {err}", file=sys.stderr)
         sys.exit(1)

--- a/images/capi/packer/qemu/scripts/render_ubuntu_autoinstall_test.py
+++ b/images/capi/packer/qemu/scripts/render_ubuntu_autoinstall_test.py
@@ -14,17 +14,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import pathlib
-import sys
 import tempfile
 import unittest
 from unittest import mock
 
 
 SCRIPT = pathlib.Path(__file__).with_name("render_ubuntu_autoinstall.py")
+CAPI_DIR = pathlib.Path(__file__).resolve().parents[3]
+
+MIRROR_TEMPLATE = "\n".join(
+    [
+        "autoinstall:",
+        "  apt:",
+        "    primary:",
+        "      - arches: [default]",
+        "        uri: $UBUNTU_REPO",
+        "    security:",
+        "      - arches: [default]",
+        "        uri: $UBUNTU_SECURITY_REPO",
+        "",
+    ]
+)
+
+# What hack/set-ssh-password.sh leaves behind: the same template with the
+# password placeholder already substituted.
+PASSWORD_LINE = "        passwd: $6$salt$hash\n"
+SET_SSH_PASSWORD_OUTPUT = MIRROR_TEMPLATE + PASSWORD_LINE
+
+MIRRORS = {
+    "ubuntu_repo": "http://us.archive.ubuntu.com/ubuntu",
+    "ubuntu_security_repo": "http://security.ubuntu.com/ubuntu",
+}
 
 
 def load_renderer():
@@ -35,9 +61,291 @@ def load_renderer():
     return module
 
 
-class RenderUbuntuAutoinstallTests(unittest.TestCase):
+class RendererTestCase(unittest.TestCase):
     def setUp(self):
         self.renderer = load_renderer()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.capi_root = pathlib.Path(self.tmp.name).resolve()
+        self.renderer.CAPI_ROOT = self.capi_root
+        self.renderer.PACKER_ROOT = self.capi_root / "packer"
+        # Do not let a KEEP_RENDERED_AUTOINSTALL from the caller's environment
+        # decide what the cleanup tests observe.
+        environment = mock.patch.dict(os.environ, {"KEEP_RENDERED_AUTOINSTALL": ""})
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    def write_json(self, relative_path, payload):
+        path = self.capi_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def write_profile(self, relative_path, content):
+        directory = self.capi_root / relative_path
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "user-data.tmpl").write_text(content, encoding="utf-8")
+        return directory
+
+
+class VariablePrecedenceTests(RendererTestCase):
+    """Packer resolves legacy JSON template variables in this order:
+
+    template defaults, then every -var-file in command line order, then every
+    -var. Verified against `packer validate` on a probe template.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.template = self.write_json(
+            "packer/qemu/packer.json", {"variables": {"ubuntu_repo": "from-template"}}
+        )
+        self.write_json("packer/config/common.json", {"ubuntu_repo": "from-common"})
+        self.write_json("packer/qemu/qemu-ubuntu-2404.json", {"ubuntu_repo": "from-target"})
+        self.write_json("overrides.json", {"ubuntu_repo": "from-user-file"})
+
+    def resolve(self, *packer_args):
+        return self.renderer.resolve_values(self.template, list(packer_args))
+
+    def test_template_defaults_are_the_lowest_precedence(self):
+        self.assertEqual("from-template", self.resolve()["ubuntu_repo"])
+
+    def test_later_var_file_wins(self):
+        values = self.resolve(
+            "-var-file=packer/config/common.json",
+            "-var-file=packer/qemu/qemu-ubuntu-2404.json",
+            "-var-file=overrides.json",
+        )
+        self.assertEqual("from-user-file", values["ubuntu_repo"])
+
+    def test_var_file_order_is_honoured(self):
+        values = self.resolve(
+            "-var-file=overrides.json",
+            "-var-file=packer/config/common.json",
+        )
+        self.assertEqual("from-common", values["ubuntu_repo"])
+
+    def test_var_outranks_every_var_file_regardless_of_position(self):
+        values = self.resolve(
+            "--var",
+            "ubuntu_repo=from-flag",
+            "-var-file=packer/qemu/qemu-ubuntu-2404.json",
+            "-var-file=overrides.json",
+        )
+        self.assertEqual("from-flag", values["ubuntu_repo"])
+
+    def test_last_var_wins(self):
+        values = self.resolve("-var=ubuntu_repo=first", "--var", "ubuntu_repo=second")
+        self.assertEqual("second", values["ubuntu_repo"])
+
+    def test_parse_packer_args_supports_every_flag_form(self):
+        var_files, flag_vars = self.renderer.parse_packer_args(
+            [
+                "-var-file",
+                "a.json",
+                '--var-file=b.json',
+                "--var",
+                "one=1",
+                "-var=two=2",
+                "-only=qemu",
+            ]
+        )
+        self.assertEqual(["a.json", "b.json"], var_files)
+        self.assertEqual({"one": "1", "two": "2"}, flag_vars)
+
+
+class AutoinstallDirectoryTests(RendererTestCase):
+    def test_directory_comes_from_the_boot_command_datasource(self):
+        values = {
+            "distro_name": "ubuntu",
+            "http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/",
+            "boot_command_prefix": (
+                "c<wait>linux /casper/vmlinuz --- autoinstall "
+                "ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04/'<enter>"
+            ),
+        }
+
+        directory = self.renderer.autoinstall_dir(values)
+
+        self.assertEqual(self.capi_root / "packer/qemu/linux/ubuntu/http/24.04", directory)
+
+    def test_autoinstall_profile_wins_over_the_boot_command(self):
+        values = {
+            "distro_name": "ubuntu",
+            "autoinstall_profile": "24.04.immutable",
+            "http_directory": "./packer/qemu/linux/ubuntu/http/",
+            "boot_command_prefix": "ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04/'",
+        }
+
+        directory = self.renderer.autoinstall_dir(values)
+
+        self.assertEqual(
+            self.capi_root / "packer/qemu/linux/ubuntu/http/24.04.immutable", directory
+        )
+
+    def test_target_http_directory_overrides_the_template_default(self):
+        values = {
+            "distro_name": "ubuntu",
+            "http_directory": "./packer/maas/linux/ubuntu/http/24.04.arm64",
+            "boot_command_prefix": "ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/' ---",
+        }
+
+        directory = self.renderer.autoinstall_dir(values)
+
+        self.assertEqual(
+            self.capi_root / "packer/maas/linux/ubuntu/http/24.04.arm64", directory
+        )
+
+    def test_non_ubuntu_targets_are_skipped(self):
+        values = {
+            "distro_name": "flatcar",
+            "http_directory": "./packer/files/flatcar/ignition/",
+        }
+
+        self.assertIsNone(self.renderer.autoinstall_dir(values))
+
+    def test_directory_outside_packer_is_rejected(self):
+        values = {"distro_name": "ubuntu", "http_directory": "../../etc"}
+
+        with self.assertRaisesRegex(ValueError, "outside"):
+            self.renderer.autoinstall_dir(values)
+
+
+class MirrorRenderingTests(RendererTestCase):
+    def test_mirror_placeholders_are_replaced(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+
+        self.renderer.render_user_data(directory, dict(MIRRORS))
+
+        rendered = (directory / "user-data").read_text(encoding="utf-8")
+        self.assertIn("uri: http://us.archive.ubuntu.com/ubuntu", rendered)
+        self.assertIn("uri: http://security.ubuntu.com/ubuntu", rendered)
+        self.assertNotIn("$UBUNTU", rendered)
+
+    def test_rendering_starts_from_the_password_substituted_user_data(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+        (directory / "user-data").write_text(SET_SSH_PASSWORD_OUTPUT, encoding="utf-8")
+
+        self.renderer.render_user_data(directory, dict(MIRRORS))
+
+        rendered = (directory / "user-data").read_text(encoding="utf-8")
+        self.assertIn("passwd: $6$salt$hash", rendered)
+        self.assertNotIn("$UBUNTU", rendered)
+
+    def test_clean_restores_the_password_substituted_user_data(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+        user_data = directory / "user-data"
+        user_data.write_text(SET_SSH_PASSWORD_OUTPUT, encoding="utf-8")
+
+        self.renderer.render_user_data(directory, dict(MIRRORS))
+        self.assertEqual(
+            SET_SSH_PASSWORD_OUTPUT,
+            (directory / "user-data.orig").read_text(encoding="utf-8"),
+        )
+
+        self.assertEqual(("Restored", user_data), self.renderer.clean_user_data(directory))
+
+        # set-ssh-password.sh runs once per make invocation, so a target sharing
+        # this directory has to find its output here, not a pristine template.
+        self.assertEqual(SET_SSH_PASSWORD_OUTPUT, user_data.read_text(encoding="utf-8"))
+        self.assertFalse((directory / "user-data.orig").exists())
+
+    def test_second_target_in_the_same_directory_keeps_the_password(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+        (directory / "user-data").write_text(SET_SSH_PASSWORD_OUTPUT, encoding="utf-8")
+
+        for _ in range(2):
+            self.renderer.render_user_data(directory, dict(MIRRORS))
+            rendered = (directory / "user-data").read_text(encoding="utf-8")
+            self.assertIn("passwd: $6$salt$hash", rendered)
+            self.assertIn("uri: http://us.archive.ubuntu.com/ubuntu", rendered)
+            self.renderer.clean_user_data(directory)
+
+    def test_render_recovers_a_stash_left_by_an_interrupted_run(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+        user_data = directory / "user-data"
+        # As if a run had been killed after writing the rendered file.
+        user_data.write_text(
+            SET_SSH_PASSWORD_OUTPUT.replace("$UBUNTU_REPO", "http://stale/ubuntu"),
+            encoding="utf-8",
+        )
+        (directory / "user-data.orig").write_text(SET_SSH_PASSWORD_OUTPUT, encoding="utf-8")
+
+        self.renderer.render_user_data(directory, dict(MIRRORS))
+        self.renderer.clean_user_data(directory)
+
+        self.assertEqual(SET_SSH_PASSWORD_OUTPUT, user_data.read_text(encoding="utf-8"))
+
+    def test_unsubstituted_password_placeholder_is_refused(self):
+        directory = self.write_profile(
+            "packer/qemu/linux/ubuntu/http/24.04",
+            MIRROR_TEMPLATE + "        passwd: $ENCRYPTED_SSH_PASSWORD\n",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"\$ENCRYPTED_SSH_PASSWORD"):
+            self.renderer.render_user_data(directory, dict(MIRRORS))
+
+        # Nothing was written, so no half-rendered file is left for Packer.
+        self.assertFalse((directory / "user-data").exists())
+
+    def test_plain_ssh_password_placeholder_is_refused(self):
+        directory = self.write_profile(
+            "packer/qemu/linux/ubuntu/http/24.04",
+            MIRROR_TEMPLATE + "        password: $SSH_PASSWORD\n",
+        )
+
+        with self.assertRaisesRegex(ValueError, r"\$SSH_PASSWORD"):
+            self.renderer.render_user_data(directory, dict(MIRRORS))
+
+    def test_missing_mirror_variable_is_an_error(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+
+        with self.assertRaisesRegex(ValueError, "ubuntu_security_repo"):
+            self.renderer.render_user_data(directory, {"ubuntu_repo": MIRRORS["ubuntu_repo"]})
+
+    def test_mirror_that_would_break_the_yaml_scalar_is_rejected(self):
+        directory = self.write_profile("packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE)
+        values = dict(MIRRORS)
+        values["ubuntu_repo"] = "http://mirror.example.com/ubuntu # trailing"
+
+        with self.assertRaises(ValueError) as raised:
+            self.renderer.render_user_data(directory, values)
+
+        # The message names the variable, never the value: it can hold a password.
+        self.assertIn("ubuntu_repo", str(raised.exception))
+        self.assertNotIn("mirror.example.com", str(raised.exception))
+
+
+class ImmutableRenderingTests(RendererTestCase):
+    def test_immutable_placeholders_are_applied(self):
+        directory = self.write_profile(
+            "packer/qemu/linux/ubuntu/http/24.04.immutable",
+            "\n".join(
+                [
+                    "storage:",
+                    "  config:",
+                    "    - id: partition-root",
+                    "      size: ${IMMUTABLE_AUTOINSTALL_ROOT_PARTITION_SIZE}",
+                    "${IMMUTABLE_AUTOINSTALL_DATA_PARTITION_CONFIG}",
+                    "",
+                ]
+            ),
+        )
+        values = dict(self.renderer.IMMUTABLE_DEFAULTS)
+        values.update(
+            {
+                "immutable_data_partition": "true",
+                "immutable_data_partition_mount": "/var/lib/cluster-api-data",
+            }
+        )
+
+        self.renderer.render_user_data(directory, values)
+
+        rendered = (directory / "user-data").read_text(encoding="utf-8")
+        self.assertIn("size: 12884901888", rendered)
+        self.assertIn("label: CAPI-DATA", rendered)
+        self.assertIn("path: /var/lib/cluster-api-data", rendered)
+        self.assertNotIn("${IMMUTABLE_AUTOINSTALL", rendered)
 
     def test_data_partition_config_is_empty_when_disabled(self):
         values = dict(self.renderer.IMMUTABLE_DEFAULTS)
@@ -82,123 +390,117 @@ class RenderUbuntuAutoinstallTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "currently supports only ext4"):
             self.renderer.data_partition_config(values)
 
-    def test_render_user_data_applies_immutable_placeholders(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = pathlib.Path(tmp) / "packer"
-            profile_dir = root / "qemu" / "linux" / "ubuntu" / "http" / "24.04.immutable"
-            profile_dir.mkdir(parents=True)
-            (profile_dir / "user-data.tmpl").write_text(
-                "\n".join(
-                    [
-                        "storage:",
-                        "  config:",
-                        "    - id: partition-root",
-                        "      size: ${IMMUTABLE_AUTOINSTALL_ROOT_PARTITION_SIZE}",
-                        "${IMMUTABLE_AUTOINSTALL_DATA_PARTITION_CONFIG}",
-                        "",
-                    ]
-                ),
-                encoding="utf-8",
-            )
-            var_file = pathlib.Path(tmp) / "qemu-ubuntu-2404-immutable.json"
-            var_file.write_text(
-                json.dumps(
-                    {
-                        "autoinstall_profile": "24.04.immutable",
-                        "distro_name": "ubuntu",
-                        "immutable_data_partition": "true",
-                        "immutable_data_partition_label": "CAPI-DATA",
-                        "immutable_data_partition_mount": "/var/lib/cluster-api-data",
-                        "immutable_root_partition_size": "12884901888",
-                    }
-                ),
-                encoding="utf-8",
-            )
-            self.renderer.ROOT = root
 
-            values = dict(self.renderer.IMMUTABLE_DEFAULTS)
-            values.update(self.renderer.load_json(var_file))
-            self.renderer.render_user_data(var_file, values)
-
-            rendered = (profile_dir / "user-data").read_text(encoding="utf-8")
-            self.assertIn("size: 12884901888", rendered)
-            self.assertIn("label: CAPI-DATA", rendered)
-            self.assertIn("path: /var/lib/cluster-api-data", rendered)
-            self.assertNotIn("${IMMUTABLE_AUTOINSTALL", rendered)
-
-    def test_parse_packer_flags_supports_var_and_var_file_forms(self):
-        values, var_files = self.renderer.parse_packer_flags(
-            "--var immutable_data_partition_label=RUNTIME-DATA "
-            "--var='immutable_data_partition_mount=/runtime-data' "
-            "--var-file overrides.json"
+class MainTests(RendererTestCase):
+    def setUp(self):
+        super().setUp()
+        self.template = self.write_json(
+            "packer/qemu/packer.json",
+            {"variables": {"http_directory": "./packer/qemu/linux/{{user `distro_name`}}/http/"}},
         )
-
-        self.assertEqual("RUNTIME-DATA", values["immutable_data_partition_label"])
-        self.assertEqual("/runtime-data", values["immutable_data_partition_mount"])
-        self.assertEqual(["overrides.json"], var_files)
-
-    def test_main_applies_target_var_file_after_packer_flags_var_file(self):
-        # Reproduces the ordering Packer itself uses on the CLI: PACKER_NODE_FLAGS
-        # (which embeds -var-file entries supplied through PACKER_FLAGS) is placed
-        # before the per-target -var-file on the actual `packer build`/`packer
-        # validate` command line, so the target file's values must win.
-        with tempfile.TemporaryDirectory() as tmp:
-            root = pathlib.Path(tmp) / "packer"
-            profile_dir = root / "qemu" / "linux" / "ubuntu" / "http" / "24.04.immutable"
-            profile_dir.mkdir(parents=True)
-            (profile_dir / "user-data.tmpl").write_text(
-                "\n".join(
-                    [
-                        "storage:",
-                        "  config:",
-                        "    - id: partition-data",
-                        "${IMMUTABLE_AUTOINSTALL_DATA_PARTITION_CONFIG}",
-                        "",
-                    ]
+        self.write_json(
+            "packer/config/common.json",
+            {
+                "ubuntu_repo": "http://us.archive.ubuntu.com/ubuntu",
+                "ubuntu_security_repo": "http://security.ubuntu.com/ubuntu",
+            },
+        )
+        self.write_json(
+            "packer/qemu/qemu-ubuntu-2404.json",
+            {
+                "distro_name": "ubuntu",
+                "boot_command_prefix": (
+                    "ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04/'"
                 ),
-                encoding="utf-8",
+            },
+        )
+        self.directory = self.write_profile(
+            "packer/qemu/linux/ubuntu/http/24.04", MIRROR_TEMPLATE
+        )
+        self.packer_args = [
+            "-var-file=packer/config/common.json",
+            "-var-file=packer/qemu/qemu-ubuntu-2404.json",
+        ]
+
+    def run_main(self, *extra):
+        # The renderer's progress lines would otherwise land in the output of
+        # `make test-qemu-immutable`.
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.renderer.main(
+                ["--packer-template", str(self.template), *extra, "--", *self.packer_args]
             )
 
-            packer_flags_var_file = pathlib.Path(tmp) / "packer-flags-vars.json"
-            packer_flags_var_file.write_text(
-                json.dumps({"immutable_data_partition_label": "RUNTIME-DATA"}),
-                encoding="utf-8",
-            )
+    def test_only_the_selected_target_is_rendered(self):
+        other = self.write_profile("packer/qemu/linux/ubuntu/http/26.04", MIRROR_TEMPLATE)
 
-            target_var_file = pathlib.Path(tmp) / "qemu-ubuntu-2404-immutable.json"
-            target_var_file.write_text(
-                json.dumps(
-                    {
-                        "autoinstall_profile": "24.04.immutable",
-                        "distro_name": "ubuntu",
-                        "immutable_data_partition": "true",
-                        "immutable_data_partition_label": "CAPI-DATA",
-                        "immutable_data_partition_mount": "/.capi-data",
-                        "immutable_root_partition_size": "12884901888",
-                    }
-                ),
-                encoding="utf-8",
-            )
+        self.run_main()
 
-            self.renderer.ROOT = root
-            argv = ["render_ubuntu_autoinstall.py", str(target_var_file)]
-            env = {"PACKER_FLAGS": f'-var-file="{packer_flags_var_file}"'}
-            with mock.patch.object(sys, "argv", argv), mock.patch.dict(os.environ, env):
-                self.renderer.main()
+        self.assertIn("us.archive.ubuntu.com", (self.directory / "user-data").read_text())
+        self.assertFalse((other / "user-data").exists())
 
-            rendered = (profile_dir / "user-data").read_text(encoding="utf-8")
-            self.assertIn("label: CAPI-DATA", rendered)
-            self.assertNotIn("RUNTIME-DATA", rendered)
+    def test_command_line_var_overrides_the_var_files(self):
+        self.packer_args += ["--var", "ubuntu_repo=http://mirror.example.com/ubuntu"]
+
+        self.run_main()
+
+        rendered = (self.directory / "user-data").read_text(encoding="utf-8")
+        self.assertIn("uri: http://mirror.example.com/ubuntu", rendered)
+
+    def test_clean_removes_the_rendered_user_data(self):
+        self.run_main()
+        self.assertTrue((self.directory / "user-data").exists())
+
+        self.run_main("--clean")
+
+        self.assertFalse((self.directory / "user-data").exists())
+        self.assertTrue((self.directory / "user-data.tmpl").exists())
+
+    def test_clean_keeps_the_rendered_user_data_on_request(self):
+        self.run_main()
+
+        with mock.patch.dict(os.environ, {"KEEP_RENDERED_AUTOINSTALL": "1"}):
+            self.run_main("--clean")
+
+        self.assertTrue((self.directory / "user-data").exists())
+
+    def test_nothing_is_printed_that_could_expose_a_mirror_credential(self):
+        self.packer_args += ["--var", "ubuntu_repo=http://user:pass@mirror.example.com/ubuntu"]
+
+        with mock.patch("builtins.print") as printed:
+            self.run_main()
+
+        output = " ".join(str(call.args[0]) for call in printed.call_args_list)
+        self.assertNotIn("pass", output)
+        self.assertIn("user-data", output)
+
+
+class RepositoryTemplateTests(unittest.TestCase):
+    """Checks against the templates as they are checked in."""
+
+    def profile(self, *parts):
+        return (CAPI_DIR / "packer").joinpath(*parts) / "user-data.tmpl"
+
+    def test_active_ubuntu_autoinstall_templates_use_the_mirror_variables(self):
+        profiles = [
+            ("qemu", "linux/ubuntu/http/24.04"),
+            ("qemu", "linux/ubuntu/http/24.04.efi"),
+            ("qemu", "linux/ubuntu/http/24.04.immutable"),
+            ("qemu", "linux/ubuntu/http/26.04"),
+            ("qemu", "linux/ubuntu/http/26.04.efi"),
+            ("maas", "linux/ubuntu/http/24.04.arm64"),
+            ("proxmox", "linux/ubuntu/http/24.04"),
+            ("proxmox", "linux/ubuntu/http/26.04"),
+        ]
+        for platform, profile in profiles:
+            with self.subTest(profile=f"{platform}/{profile}"):
+                template = self.profile(platform, profile).read_text(encoding="utf-8")
+                self.assertIn("uri: $UBUNTU_REPO", template)
+                self.assertIn("uri: $UBUNTU_SECURITY_REPO", template)
 
     def test_immutable_template_runs_cleanup_in_target(self):
-        template = (
-            pathlib.Path(__file__).resolve().parents[1]
-            / "linux"
-            / "ubuntu"
-            / "http"
-            / "24.04.immutable"
-            / "user-data.tmpl"
-        ).read_text(encoding="utf-8")
+        template = self.profile("qemu", "linux/ubuntu/http/24.04.immutable").read_text(
+            encoding="utf-8"
+        )
 
         self.assertIn("curtin in-target --target=/target -- swapoff -a", template)
         self.assertIn("curtin in-target --target=/target -- apt-get clean", template)


### PR DESCRIPTION
## What this does

Ubuntu autoinstall user-data templates for QEMU, MAAS and Proxmox hard-code the archive mirror used by the installer. This makes the installer use the existing `ubuntu_repo` and `ubuntu_security_repo` Packer variables, so users can point it at a local mirror or cache before Ansible runs. The 24.04 immutable QEMU template is covered as well. The 22.04 templates carry no `apt` block and keep Ubuntu's defaults for the installer stage; the Ansible `setup` role still applies the variables to the built image.

The defaults still come from `packer/config/common.json`. Callers override them the way they override any Packer variable: in the target's var file, in a file listed in `PACKER_VAR_FILES`, or with `--var` in `PACKER_FLAGS`.

## How it is rendered

`hack/set-ssh-password.sh` is unchanged from main and only handles the build password. The substitution lives in `packer/qemu/scripts/render_ubuntu_autoinstall.py`, which every qemu, kubevirt, proxmox and maas build and validate recipe calls with the same `-var`/`-var-file` vector it then passes to Packer:

- Variables are resolved with Packer's precedence for legacy JSON templates: template defaults, then every `-var-file` in command line order, then every `-var`, which outranks any `-var-file` wherever it appears. `PACKER_VAR_FILE_FLAGS` and the `--extra-var-file` option are gone.
- The autoinstall directory comes from the target's own `http_directory`, `autoinstall_profile` and `boot_command_prefix`, so `build-qemu-all` and parallel `make -j` runs cannot render one target's user-data with another target's mirrors.
- A mirror URL can carry credentials, so the renderer never prints a variable value and rejects URLs that could break the YAML scalar. An `EXIT` trap in each recipe runs `--clean`, which restores the user-data that `set-ssh-password.sh` wrote from a `user-data.orig` stash, whether Packer succeeded or not. A stash left by a killed run is put back before the next render. `user-data.orig` is git-ignored. `KEEP_RENDERED_AUTOINSTALL=1` keeps the rendered file for debugging.
- The renderer refuses to write a user-data that still contains `$SSH_PASSWORD` or `$ENCRYPTED_SSH_PASSWORD`, so a missing `set-ssh-password` run fails the target instead of producing an unusable image.

Targets can share an autoinstall directory (QEMU/KubeVirt, Proxmox EFI pairs, and MAAS/QEMU EFI pairs). The Makefile now uses GNU Make 3.81-compatible `.NOTPARALLEL:` to serialize recipes, including aggregate targets and a single `make -j` invocation, so their render/build/restore steps do not overlap. Separate simultaneous Make processes in the same checkout are not supported; use separate checkouts for those.

Documentation is added to `docs/book/src/capi/capi.md` (variables, precedence, mirrors with credentials, shared directories) and `docs/book/src/capi/immutable-qemu.md`, plus a note in the qemu, maas and proxmox READMEs.

## Validation

- `make test-qemu-immutable` (45 tests): precedence and flag parsing, per-target directory resolution, mirror substitution, restore from `user-data.orig` on clean, stash recovery after an interrupted run, refusal of unsubstituted password placeholders, no variable value in any output, and a check that every active Ubuntu autoinstall template uses the mirror placeholders
- `git diff --check`
- `make validate-qemu-ubuntu-2404 PACKER_FLAGS="--var 'ubuntu_repo=http://mirror.example.com/ubuntu' --var 'ubuntu_security_repo=http://security.example.com/ubuntu'"`
- `make validate-qemu-ubuntu-2404-efi PACKER_FLAGS="..."` with the same flags
- `make validate-maas-ubuntu-2404-efi PACKER_FLAGS="..."` with the same flags
- `env PROXMOX_URL=https://example.invalid:8006/api2/json PROXMOX_USERNAME=root@pam PROXMOX_TOKEN=dummy PROXMOX_NODE=pve1 PROXMOX_ISO_POOL=local PROXMOX_BRIDGE=vmbr0 PROXMOX_STORAGE_POOL=local-lvm make validate-proxmox-ubuntu-2404 PACKER_FLAGS="..."` with the same flags
- each validate run logs one `Rendered` and one `Restored` line for its own user-data, and `git status` afterwards shows no `user-data` or `user-data.orig` changes under `packer/`
