### PR TITLE
capi: use modules for sysprep log cleanup

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -211,19 +211,48 @@
     - ansible_facts['os_family'] == "Flatcar"
     - not (defer_ssh_cleanup_to_packer | bool)
 
-- name: Truncate all remaining log files in /var/log
-  ansible.builtin.shell: |
-    set -o pipefail
-    find /var/log -type f -iname '*.log' | xargs truncate -s 0
-  args:
-    executable: /bin/bash
+- name: Find remaining log files in /var/log
+  ansible.builtin.find:
+    file_type: file
+    hidden: true
+    paths: /var/log
+    patterns: "(?i).*\\.log$"
+    recurse: true
+    use_regex: true
+  register: sysprep_log_files
+  when: ansible_facts['os_family'] != "Flatcar"
 
+- name: Truncate all remaining log files in /var/log
+  ansible.builtin.command:
+    argv:
+      - truncate
+      - "-s"
+      - "0"
+      - "{{ item.path }}"
+  changed_when: true
+  loop: "{{ sysprep_log_files.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: ansible_facts['os_family'] != "Flatcar"
+
+- name: Find logrotated logs in /var/log
+  ansible.builtin.find:
+    file_type: file
+    hidden: true
+    paths: /var/log
+    patterns: ".*[0-9z]$"
+    recurse: true
+    use_regex: true
+  register: sysprep_logrotated_logs
   when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Delete all logrotated logs
-  ansible.builtin.shell:
-    cmd: |
-      find /var/log -type f -regex '.*[0-9z]$' -exec rm {} +
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ sysprep_logrotated_logs.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
   when: ansible_facts['os_family'] != "Flatcar"
 
 - name: Remove swapfile


### PR DESCRIPTION
## Change description

Replace the sysprep role's shell-backed `/var/log` cleanup with Ansible module-backed discovery/removal where modules exist:

- use `ansible.builtin.find` to discover remaining `.log` files
- keep truncation as `ansible.builtin.command` with `argv` because ansible-core does not provide a truncate module that preserves existing file metadata
- use `ansible.builtin.find` plus `ansible.builtin.file` to remove logrotated files

This keeps the current non-Flatcar behavior while removing shell `find`, `xargs`, and `rm` usage from these cleanup tasks.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

- Fixes #

## Additional context

Validation run locally:

- `ansible-playbook -i localhost, --syntax-check ansible/node.yml`
- `make validate-qemu-ubuntu-2404`
- `git -c core.fsmonitor=false diff --check`

I also ran `make lint` and `ansible-lint --project-dir . ansible/roles/sysprep/tasks/main.yml`; both are still blocked by pre-existing `var-naming[no-role-prefix]` debt in the repository/role. The new registers introduced here use the `sysprep_` prefix and were not among the reported violations.

This is intentionally not a revival of the closed temp-cleanup PRs (#2061/#2069); it only addresses the `/var/log` cleanup tasks.
