### PR TITLE
capi: add Ubuntu 24.04 QEMU cloud image target

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -413,7 +413,7 @@ OPENSTACK_BUILD_NAMES		?=	openstack-ubuntu-2204 openstack-ubuntu-2404 openstack-
 
 OSC_BUILD_NAMES 			?=	osc-ubuntu-2204 osc-ubuntu-2404 osc-ubuntu-2604 osc-flatcar
 
-QEMU_BUILD_NAMES			?=	qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2404 qemu-ubuntu-2404-efi qemu-ubuntu-2604 qemu-ubuntu-2604-efi qemu-ubuntu-2204-efi qemu-centos-9 qemu-rhel-9 qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
+QEMU_BUILD_NAMES			?=	qemu-ubuntu-2204 qemu-ubuntu-2204-cloudimg qemu-ubuntu-2404 qemu-ubuntu-2404-cloudimg qemu-ubuntu-2404-efi qemu-ubuntu-2604 qemu-ubuntu-2604-efi qemu-ubuntu-2204-efi qemu-centos-9 qemu-rhel-9 qemu-rockylinux-9 qemu-rockylinux-9-cloudimg qemu-flatcar
 
 QEMU_KUBEVIRT_BUILD_NAMES	:= $(addprefix kubevirt-,$(QEMU_BUILD_NAMES))
 
@@ -853,6 +853,7 @@ build-qemu-ubuntu-2204: ## Builds Ubuntu 22.04 QEMU image
 build-qemu-ubuntu-2204-cloudimg: ## Builds Ubuntu 22.04 QEMU image using cloud image
 build-qemu-ubuntu-2204-efi: ## Builds Ubuntu 22.04 QEMU image that EFI boots
 build-qemu-ubuntu-2404: ## Builds Ubuntu 24.04 QEMU image
+build-qemu-ubuntu-2404-cloudimg: ## Builds Ubuntu 24.04 QEMU image using cloud image
 build-qemu-ubuntu-2404-efi: ## Builds Ubuntu 24.04 QEMU image that EFI boots
 build-qemu-ubuntu-2604: ## Builds Ubuntu 26.04 QEMU image
 build-qemu-ubuntu-2604-efi: ## Builds Ubuntu 26.04 QEMU image that EFI boots
@@ -1020,6 +1021,7 @@ validate-qemu-ubuntu-2204: ## Validates Ubuntu 22.04 QEMU image packer config
 validate-qemu-ubuntu-2204-cloudimg: ## Validates Ubuntu 22.04 QEMU image packer config using cloud image
 validate-qemu-ubuntu-2204-efi: ## Validates Ubuntu 22.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2404: ## Validates Ubuntu 24.04 QEMU image packer config
+validate-qemu-ubuntu-2404-cloudimg: ## Validates Ubuntu 24.04 QEMU image packer config using cloud image
 validate-qemu-ubuntu-2404-efi: ## Validates Ubuntu 24.04 QEMU EFI image packer config
 validate-qemu-ubuntu-2604: ## Validates Ubuntu 26.04 QEMU image packer config
 validate-qemu-ubuntu-2604-efi: ## Validates Ubuntu 26.04 QEMU EFI image packer config

--- a/images/capi/packer/qemu/qemu-ubuntu-2404-cloudimg.json
+++ b/images/capi/packer/qemu/qemu-ubuntu-2404-cloudimg.json
@@ -1,0 +1,13 @@
+{
+  "build_name": "ubuntu-2404",
+  "cd_files": "./packer/qemu/cloud-init/*",
+  "disk_image": "true",
+  "distribution_version": "2404",
+  "distro_name": "ubuntu",
+  "guest_os_type": "ubuntu-64",
+  "iso_checksum": "https://cloud-images.ubuntu.com/noble/current/SHA256SUMS",
+  "iso_checksum_type": "file",
+  "iso_url": "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img",
+  "os_display_name": "Ubuntu 24.04",
+  "shutdown_command": "shutdown -P now"
+}


### PR DESCRIPTION
## Change description

Add an opt-in `qemu-ubuntu-2404-cloudimg` build/validation target that mirrors the existing `qemu-ubuntu-2204-cloudimg` pattern for Ubuntu 24.04.

The new target uses Canonical's Noble current cloud image and SHA256SUMS file:

- `https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img`
- `https://cloud-images.ubuntu.com/noble/current/SHA256SUMS`

No existing QEMU target behavior changes; this only adds a new build name and matching validate target.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

- Fixes #

## Additional context

Validation run locally:

- `curl -fsSI https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img` returned 200
- `curl -fsSI https://cloud-images.ubuntu.com/noble/current/SHA256SUMS` returned 200
- `jq . images/capi/packer/qemu/qemu-ubuntu-2404-cloudimg.json >/dev/null`
- `make validate-qemu-ubuntu-2404-cloudimg`
- `git -c core.fsmonitor=false diff --check`
