### PR TITLE
capi: use current Goss file contents key

### DIFF
--- a/images/capi/packer/goss/goss-files.yaml
+++ b/images/capi/packer/goss/goss-files.yaml
@@ -8,7 +8,7 @@ file:
   {{ $name }}:
     exists: {{ $vers.exists }}
     filetype: {{ $vers.filetype }}
-    contains: {{ range $vers.contains }}
+    contents: {{ range $vers.contains }}
     - {{.}}
   {{end}}
 {{end}}
@@ -17,7 +17,7 @@ file:
   "/etc/modprobe.d/blocklist-nouveau.conf":
     exists: true
     filetype: file
-    contains:
+    contents:
       - "blacklist nouveau"
       - "options nouveau modeset=0"
 {{if eq .Vars.block_nouveau_loading "true"}}
@@ -29,13 +29,13 @@ file:
   "/boot/grub/grub.cfg":
     exists: true
     filetype: file
-    contains:
+    contents:
       - {{ .Vars.extra_kernel_boot_params }}
 {{end}}
 {{if eq .Vars.containerd_enable_limit_no_file "true"}}
   "/etc/systemd/system/containerd.service.d/limit-nofile.conf":
     exists: true
     filetype: file
-    contains:
+    contents:
       - "LimitNOFILE=1048576"
 {{end}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Goss v0.4 uses the `contents` field for file content assertions. The CAPI Goss template still emits `contains`, so these checks are not expressed with the current file schema.

This updates the generated file assertions in `goss-files.yaml` to use `contents` while keeping the existing input variable names unchanged.

Downstream T-CaaS image validation hit the same issue while updating Goss-based image hygiene checks, and this is the generic upstream part of that fix.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is intentionally limited to the rendered Goss assertion key. The values under `goss-vars.yaml` still use `contains` as local template data and are read via `$vers.contains`.

#### Testing done:

```console
cd images/capi
make validate-qemu-ubuntu-2404
```

The validation succeeded locally. The checkout printed existing `fatal: No tags can describe ...` messages while deriving version metadata, but Packer validation completed with `The configuration is valid.`
