### PR TITLE
capi: wait for qemu post-reboot systemd state

### DIFF
--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -108,7 +108,17 @@
       "type": "shell"
     },
     {
-      "pause_before": "30s",
+      "inline": [
+        "echo \"Post-reboot SSH ready at $(date -Is)\"",
+        "echo 'Waiting for rebooted systemd state to settle...'",
+        "if ! timeout 180s sudo systemctl is-system-running --wait; then sudo systemctl --failed --no-pager || true; fi",
+        "uname -a"
+      ],
+      "inline_shebang": "/bin/bash -e",
+      "pause_before": "20s",
+      "type": "shell"
+    },
+    {
       "ansible_env_vars": [
         "ANSIBLE_SSH_ARGS='{{user `existing_ansible_ssh_args`}} {{user `ansible_common_ssh_args`}}'",
         "{{if user `ansible_collections_path`}}ANSIBLE_COLLECTIONS_PATH={{user `ansible_collections_path`}}{{end}}",


### PR DESCRIPTION
#### What this PR does / why we need it:

QEMU Linux builds currently rely on a fixed `pause_before: 30s` after the firstboot reboot before starting the main node Ansible playbook. On slower boots, SSH can be reachable before systemd has finished settling, which makes early fact gathering and package/service tasks more timing-sensitive.

This replaces that passive fixed wait with a short post-reboot shell provisioner. The provisioner waits for `systemctl is-system-running --wait`, prints failed units when the wait times out or returns non-zero, and then lets the existing Ansible/Goss checks decide whether the image is valid.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The wait is intentionally diagnostic and non-fatal. Some distributions can legitimately report `degraded`; failing remains the responsibility of the subsequent Ansible and Goss checks.

#### Testing done:

```console
cd images/capi
make validate-qemu-ubuntu-2404
```

The validation succeeded locally. The checkout printed existing `fatal: No tags can describe ...` messages while deriving version metadata, but Packer validation completed with `The configuration is valid.`

