### PR TITLE
capi: wait for Azure apt package locks

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -44,6 +44,7 @@
     name: "{{ packages }}"
     state: present
     force_apt_get: true
+    lock_timeout: 300
   vars:
     packages:
       - iptables-persistent
@@ -69,6 +70,7 @@
     name: "{{ packages }}"
     state: present
     force_apt_get: true
+    lock_timeout: 300
   vars:
     packages:
       - netbase


### PR DESCRIPTION
## What this PR does

Adds `lock_timeout: 300` to the Azure provider `ansible.builtin.apt` package installs for `iptables-persistent`, `netbase`, and `nfs-common`.

This keeps the existing module-native apt tasks and lets Ansible wait for the dpkg frontend lock instead of failing immediately when another apt process is still exiting.

## Why

`pull-azure-sigs` for #2073 failed in normal Ubuntu SIG builds after the early apt-daily wait had already completed:

- `sig-ubuntu-2204`: `providers : Install iptables persistence` failed with `/var/lib/dpkg/lock-frontend` held by `apt`.
- `sig-ubuntu-2404`: `providers : Install netbase and nfs-common` failed with the same dpkg frontend lock.

These are provider package installs, so the timeout belongs on the affected `apt` module calls instead of adding another shell wait.

## Validation

- `ansible-playbook --syntax-check ansible/node.yml -e provider=azure`
- `/opt/homebrew/bin/packer validate -syntax-only packer/azure/packer.json`
- `git diff --check`

Note: targeted `ansible-lint --project-dir . ansible/roles/providers/tasks/azure.yml` is currently blocked by pre-existing var-naming findings in `ansible/roles/providers/tasks/azurecli.yml` (`ubuntu_version`, `host_arch`, `azure_cli_codename`), unrelated to this diff.