### PR TITLE
capi: trust Microsoft key in Azure provider builds

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -42,6 +42,24 @@
     mode: "0644"
   when: http_proxy is defined or https_proxy is defined
 
+- name: Trust Microsoft key for legacy Microsoft apt repositories
+  block:
+    - name: Check for legacy Microsoft apt source
+      ansible.builtin.find:
+        paths: /etc/apt/sources.list.d
+        patterns:
+          - "*.list"
+          - "*.sources"
+        contains: ".*packages\\.microsoft\\.com.*"
+      register: setup_ms_legacy_source
+
+    - name: Download Microsoft Package Repository Key for legacy sources
+      ansible.builtin.get_url:
+        url: https://packages.microsoft.com/keys/microsoft.asc
+        dest: /etc/apt/trusted.gpg.d/microsoft.asc
+        mode: "0644"
+      when: setup_ms_legacy_source.matched > 0
+
 - name: Ensure cloud-final is in a running state
   ansible.builtin.service:
     name: cloud-final


### PR DESCRIPTION
## What this PR does

Extends the Microsoft legacy apt repository key handling to normal Azure provider builds.

The task is conditional: it only downloads the Microsoft key into apt's trusted key directory when an existing apt source under `/etc/apt/sources.list.d` references `packages.microsoft.com`.

## Why

`pull-azure-sigs` for #2074 failed in `sig-ubuntu-2604` during the Kubernetes apt cache refresh:

`NO_PUBKEY EB3E94ADBE1229CF` for `https://packages.microsoft.com/ubuntu/18.04/prod bionic`.

#2060 added the same class of fix under `azurecli.yml`, but that file is imported only when `debug_tools` is true. The failing SIG build runs with `debug_tools=false`, so normal Azure builds still do not trust the legacy Microsoft source before later apt cache refreshes.

## Validation

- `ansible-playbook --syntax-check ansible/node.yml -e provider=azure`
- `/opt/homebrew/bin/packer validate -syntax-only packer/azure/packer.json`
- `git diff --check`

Note: targeted `ansible-lint --project-dir . ansible/roles/providers/tasks/azure.yml` is currently blocked by pre-existing var-naming findings in `ansible/roles/providers/tasks/azurecli.yml` (`ubuntu_version`, `host_arch`, `azure_cli_codename`), unrelated to this diff.