### PR TITLE
capi: prefix Azure CLI role variables

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azurecli.yml
+++ b/images/capi/ansible/roles/providers/tasks/azurecli.yml
@@ -52,26 +52,26 @@
     - name: Find Ubuntu Version
       ansible.builtin.command:
         cmd: lsb_release -cs
-      register: ubuntu_version
+      register: providers_ubuntu_version
       changed_when: false
 
     - name: Find Host Architecture
       ansible.builtin.command:
         cmd: dpkg --print-architecture
-      register: host_arch
+      register: providers_host_arch
       changed_when: false
 
     # TODO: drop once packages.microsoft.com publishes a resolute repo
     - name: Map unsupported codenames to nearest supported codename
       ansible.builtin.set_fact:
-        azure_cli_codename: "{{ 'noble' if ubuntu_version.stdout == 'resolute' else ubuntu_version.stdout }}"
+        providers_azure_cli_codename: "{{ 'noble' if providers_ubuntu_version.stdout == 'resolute' else providers_ubuntu_version.stdout }}"
 
     - name: Add Microsoft Package Repository
       ansible.builtin.apt_repository:
         repo: >-
-          deb [arch={{ host_arch.stdout }} signed-by=/etc/apt/keyrings/microsoft.gpg]
+          deb [arch={{ providers_host_arch.stdout }} signed-by=/etc/apt/keyrings/microsoft.gpg]
           https://packages.microsoft.com/repos/azure-cli/
-          {{ azure_cli_codename }} main
+          {{ providers_azure_cli_codename }} main
         state: present
         update_cache: true
 


### PR DESCRIPTION
## What this PR does

Renames Azure CLI role-local variables to use the `providers_` prefix expected for variables inside the `providers` role.

This is behavior-preserving:

- `ubuntu_version` -> `providers_ubuntu_version`
- `host_arch` -> `providers_host_arch`
- `azure_cli_codename` -> `providers_azure_cli_codename`

## Why

While validating the Azure provider fixes, targeted `ansible-lint --project-dir . ansible/roles/providers/tasks/azurecli.yml` failed on these pre-existing `var-naming[no-role-prefix]` findings. This PR keeps that cleanup separate from the Azure build-failure fixes.

## Validation

- `ansible-lint --project-dir . ansible/roles/providers/tasks/azurecli.yml`
- `ansible-playbook --syntax-check ansible/node.yml -e provider=azure`
- `git diff --check`