### PR TITLE
capi: add optional QEMU boot smoke helper

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -227,6 +227,11 @@ deps-scaleway: deps-common
 set-ssh-password:
 	hack/set-ssh-password.sh
 
+.PHONY: test-qemu-boot-smoke
+test-qemu-boot-smoke: ## Boots a local QEMU image and verifies SSH
+	@test -n "$(QEMU_BOOT_SMOKE_IMAGE)" || (echo "QEMU_BOOT_SMOKE_IMAGE is required" >&2; exit 1)
+	hack/qemu-boot-smoke.sh "$(QEMU_BOOT_SMOKE_IMAGE)" $(QEMU_BOOT_SMOKE_ARGS)
+
 ## --------------------------------------
 ## Container variables
 ## --------------------------------------

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -230,7 +230,7 @@ set-ssh-password:
 .PHONY: test-qemu-boot-smoke
 test-qemu-boot-smoke: ## Boots a local QEMU image and verifies SSH
 	@test -n "$(QEMU_BOOT_SMOKE_IMAGE)" || (echo "QEMU_BOOT_SMOKE_IMAGE is required" >&2; exit 1)
-	hack/qemu-boot-smoke.sh "$(QEMU_BOOT_SMOKE_IMAGE)" $(QEMU_BOOT_SMOKE_ARGS)
+	QEMU_IMAGE_OS="$(QEMU_BOOT_SMOKE_OS)" hack/qemu-boot-smoke.sh "$(QEMU_BOOT_SMOKE_IMAGE)" $(QEMU_BOOT_SMOKE_ARGS)
 
 ## --------------------------------------
 ## Container variables

--- a/images/capi/hack/qemu-boot-smoke.sh
+++ b/images/capi/hack/qemu-boot-smoke.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ -n ${DEBUG:-} ]] && set -o xtrace
+
+usage() {
+  cat <<'EOF' >&2
+usage: qemu-boot-smoke.sh IMAGE_OR_OUTPUT_DIR [-- QEMU_ARGS...]
+
+Boot a local QEMU image with a copy-on-write overlay and verify that the guest
+accepts SSH on a host-forwarded port. By default, a temporary NoCloud seed ISO
+creates the SSH user, so the source image is not modified.
+
+Environment:
+  QEMU_BINARY              QEMU binary to run. Default: qemu-system-x86_64
+  QEMU_IMG                 qemu-img binary to run. Default: qemu-img
+  QEMU_IMAGE_FORMAT        Backing image format. Default: detected by qemu-img
+  QEMU_ACCELERATOR         QEMU accelerator. Default: kvm on Linux with /dev/kvm,
+                           hvf on macOS, otherwise tcg
+  QEMU_MACHINE             QEMU machine type. Default: pc
+  QEMU_CPUS                vCPU count. Default: 2
+  QEMU_MEMORY              Guest memory. Default: 2048
+  QEMU_SSH_PORT            Host port forwarded to guest port 22. Default: 2222
+  QEMU_SSH_TIMEOUT         Seconds to wait for SSH. Default: 600
+  QEMU_SSH_INTERVAL        Seconds between SSH checks. Default: 5
+  QEMU_SSH_USER            SSH user to verify. Default: capi
+  QEMU_SSH_PRIVATE_KEY     SSH private key. Default: cloudinit/id_rsa.capi
+  QEMU_SSH_PUBLIC_KEY      SSH public key. Default: cloudinit/id_rsa.capi.pub
+  QEMU_SMOKE_COMMAND       Command to run over SSH. Default: true
+  QEMU_SEED                cloud-init or none. Default: cloud-init
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+capi_dir="$(cd "${script_dir}/.." && pwd -P)"
+
+image_arg="${1}"
+shift
+
+qemu_extra_args=()
+if [[ ${1:-} == "--" ]]; then
+  shift
+  qemu_extra_args=("${@}")
+elif [[ $# -gt 0 ]]; then
+  usage
+  exit 1
+fi
+
+QEMU_BINARY="${QEMU_BINARY:-qemu-system-x86_64}"
+QEMU_IMG="${QEMU_IMG:-qemu-img}"
+QEMU_MACHINE="${QEMU_MACHINE:-pc}"
+QEMU_CPUS="${QEMU_CPUS:-2}"
+QEMU_MEMORY="${QEMU_MEMORY:-2048}"
+QEMU_SSH_PORT="${QEMU_SSH_PORT:-2222}"
+QEMU_SSH_TIMEOUT="${QEMU_SSH_TIMEOUT:-600}"
+QEMU_SSH_INTERVAL="${QEMU_SSH_INTERVAL:-5}"
+QEMU_SSH_USER="${QEMU_SSH_USER:-capi}"
+QEMU_SSH_PRIVATE_KEY="${QEMU_SSH_PRIVATE_KEY:-${capi_dir}/cloudinit/id_rsa.capi}"
+QEMU_SSH_PUBLIC_KEY="${QEMU_SSH_PUBLIC_KEY:-${capi_dir}/cloudinit/id_rsa.capi.pub}"
+QEMU_SMOKE_COMMAND="${QEMU_SMOKE_COMMAND:-true}"
+QEMU_SEED="${QEMU_SEED:-cloud-init}"
+
+require_command() {
+  if ! command -v "${1}" >/dev/null 2>&1; then
+    echo "${1} must be in PATH" >&2
+    exit 1
+  fi
+}
+
+abs_path() {
+  local path="${1}"
+  local dir
+  local base
+
+  dir="$(dirname "${path}")"
+  base="$(basename "${path}")"
+  echo "$(cd "${dir}" && pwd -P)/${base}"
+}
+
+resolve_image() {
+  local input="${1}"
+  local matches
+  local count
+
+  if [[ -d "${input}" ]]; then
+    matches="$(find "${input}" -maxdepth 1 -type f \( -name "*.qcow2" -o -name "*.raw" -o -name "*.img" \) -print | sort)"
+    count="$(printf '%s\n' "${matches}" | sed '/^$/d' | wc -l | tr -d ' ')"
+    if [[ "${count}" != "1" ]]; then
+      echo "expected exactly one *.qcow2, *.raw, or *.img file in ${input}; found ${count}" >&2
+      exit 1
+    fi
+    printf '%s\n' "${matches}"
+    return
+  fi
+
+  if [[ ! -f "${input}" ]]; then
+    echo "image does not exist: ${input}" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "${input}"
+}
+
+detect_accelerator() {
+  case "$(uname -s)" in
+  Linux)
+    if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+      echo kvm
+    else
+      echo tcg
+    fi
+    ;;
+  Darwin)
+    echo hvf
+    ;;
+  *)
+    echo tcg
+    ;;
+  esac
+}
+
+detect_image_format() {
+  local image="${1}"
+  local format
+
+  require_command python3
+  format="$("${QEMU_IMG}" info --output=json "${image}" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("format", ""))')"
+  if [[ -z "${format}" ]]; then
+    echo "could not detect image format for ${image}; set QEMU_IMAGE_FORMAT" >&2
+    exit 1
+  fi
+  echo "${format}"
+}
+
+write_seed_iso() {
+  local seed_dir="${1}"
+  local seed_iso="${2}"
+  local public_key="${3}"
+
+  mkdir -p "${seed_dir}"
+  cat >"${seed_dir}/meta-data" <<EOF
+instance-id: qemu-boot-smoke-$(date +%s)
+local-hostname: qemu-boot-smoke
+EOF
+  cat >"${seed_dir}/user-data" <<EOF
+#cloud-config
+ssh_pwauth: false
+users:
+  - default
+  - name: ${QEMU_SSH_USER}
+    lock_passwd: true
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ${public_key}
+EOF
+
+  if command -v cloud-localds >/dev/null 2>&1; then
+    cloud-localds "${seed_iso}" "${seed_dir}/user-data" "${seed_dir}/meta-data"
+  elif command -v genisoimage >/dev/null 2>&1; then
+    (cd "${seed_dir}" && genisoimage -output "${seed_iso}" -volid cidata -joliet -rock user-data meta-data >/dev/null)
+  elif command -v mkisofs >/dev/null 2>&1; then
+    (cd "${seed_dir}" && mkisofs -output "${seed_iso}" -volid cidata -joliet -rock user-data meta-data >/dev/null)
+  elif command -v xorriso >/dev/null 2>&1; then
+    (cd "${seed_dir}" && xorriso -as mkisofs -output "${seed_iso}" -volid cidata -joliet -rock user-data meta-data >/dev/null)
+  elif command -v hdiutil >/dev/null 2>&1; then
+    hdiutil makehybrid -o "${seed_iso}" -hfs -joliet -iso -default-volume-name cidata "${seed_dir}" >/dev/null
+  else
+    echo "cloud-localds, genisoimage, mkisofs, xorriso, or hdiutil is required to create the seed ISO" >&2
+    exit 1
+  fi
+}
+
+# shellcheck disable=SC2329 # Called from the EXIT trap.
+stop_qemu() {
+  local pid="${1:-}"
+
+  if [[ -z "${pid}" ]]; then
+    return
+  fi
+  if ! kill -0 "${pid}" >/dev/null 2>&1; then
+    return
+  fi
+  kill "${pid}" >/dev/null 2>&1 || true
+  sleep 2
+  if kill -0 "${pid}" >/dev/null 2>&1; then
+    kill -9 "${pid}" >/dev/null 2>&1 || true
+  fi
+}
+
+require_command "${QEMU_BINARY}"
+require_command "${QEMU_IMG}"
+require_command ssh
+
+image="$(abs_path "$(resolve_image "${image_arg}")")"
+if [[ ! -r "${QEMU_SSH_PRIVATE_KEY}" ]]; then
+  echo "SSH private key is not readable: ${QEMU_SSH_PRIVATE_KEY}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/qemu-boot-smoke.XXXXXX")"
+qemu_pid=""
+# shellcheck disable=SC2329 # Called from the EXIT trap.
+cleanup() {
+  stop_qemu "${qemu_pid}"
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+ssh_key="${tmp_dir}/ssh_key"
+cp "${QEMU_SSH_PRIVATE_KEY}" "${ssh_key}"
+chmod 0600 "${ssh_key}"
+
+if [[ -r "${QEMU_SSH_PUBLIC_KEY}" ]]; then
+  public_key="$(cat "${QEMU_SSH_PUBLIC_KEY}")"
+else
+  require_command ssh-keygen
+  public_key="$(ssh-keygen -y -f "${ssh_key}")"
+fi
+
+backing_format="${QEMU_IMAGE_FORMAT:-$(detect_image_format "${image}")}"
+runtime_disk="${tmp_dir}/disk.qcow2"
+"${QEMU_IMG}" create -f qcow2 -F "${backing_format}" -b "${image}" "${runtime_disk}" >/dev/null
+
+seed_args=()
+case "${QEMU_SEED}" in
+cloud-init)
+  seed_iso="${tmp_dir}/cidata.iso"
+  write_seed_iso "${tmp_dir}/seed" "${seed_iso}" "${public_key}"
+  seed_args=(-drive "file=${seed_iso},media=cdrom,readonly=on")
+  ;;
+none)
+  ;;
+*)
+  echo "unsupported QEMU_SEED=${QEMU_SEED}; expected cloud-init or none" >&2
+  exit 1
+  ;;
+esac
+
+QEMU_ACCELERATOR="${QEMU_ACCELERATOR:-$(detect_accelerator)}"
+serial_log="${tmp_dir}/serial.log"
+pidfile="${tmp_dir}/qemu.pid"
+
+"${QEMU_BINARY}" \
+  -accel "${QEMU_ACCELERATOR}" \
+  -machine "${QEMU_MACHINE}" \
+  -m "${QEMU_MEMORY}" \
+  -smp "${QEMU_CPUS}" \
+  -drive "file=${runtime_disk},if=virtio,format=qcow2" \
+  "${seed_args[@]}" \
+  -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${QEMU_SSH_PORT}-:22" \
+  -device "virtio-net-pci,netdev=net0" \
+  -display none \
+  -serial "file:${serial_log}" \
+  -monitor none \
+  -no-reboot \
+  -pidfile "${pidfile}" \
+  -daemonize \
+  "${qemu_extra_args[@]}"
+
+qemu_pid="$(cat "${pidfile}")"
+deadline=$((SECONDS + QEMU_SSH_TIMEOUT))
+
+echo "Waiting up to ${QEMU_SSH_TIMEOUT}s for SSH on 127.0.0.1:${QEMU_SSH_PORT}..."
+while ((SECONDS < deadline)); do
+  if ! kill -0 "${qemu_pid}" >/dev/null 2>&1; then
+    echo "QEMU exited before SSH became available" >&2
+    sed -n '1,160p' "${serial_log}" >&2 || true
+    exit 1
+  fi
+
+  if ssh \
+    -F /dev/null \
+    -o BatchMode=yes \
+    -o ConnectTimeout=5 \
+    -o IdentitiesOnly=yes \
+    -o LogLevel=ERROR \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -i "${ssh_key}" \
+    -p "${QEMU_SSH_PORT}" \
+    "${QEMU_SSH_USER}@127.0.0.1" \
+    "${QEMU_SMOKE_COMMAND}" >/dev/null; then
+    echo "QEMU boot smoke succeeded for ${image}"
+    exit 0
+  fi
+
+  sleep "${QEMU_SSH_INTERVAL}"
+done
+
+echo "Timed out waiting for SSH on 127.0.0.1:${QEMU_SSH_PORT}" >&2
+sed -n '1,160p' "${serial_log}" >&2 || true
+exit 1

--- a/images/capi/hack/qemu-boot-smoke.sh
+++ b/images/capi/hack/qemu-boot-smoke.sh
@@ -28,12 +28,19 @@ Boot a local QEMU image with a copy-on-write overlay and verify that the guest
 accepts SSH on a host-forwarded port. By default, a temporary NoCloud seed ISO
 creates the SSH user, so the source image is not modified.
 
+Flatcar (qemu-flatcar) images are not supported: Flatcar uses Ignition rather
+than cloud-init, and the build removes the SSH user before shutdown, so no
+supported QEMU_SEED value can authenticate to it.
+
 Environment:
   QEMU_BINARY              QEMU binary to run. Default: qemu-system-x86_64
   QEMU_IMG                 qemu-img binary to run. Default: qemu-img
   QEMU_IMAGE_FORMAT        Backing image format. Default: detected by qemu-img
   QEMU_ACCELERATOR         QEMU accelerator. Default: kvm on Linux with /dev/kvm,
-                           hvf on macOS, otherwise tcg
+                           hvf on macOS, otherwise tcg. hvf/kvm are only
+                           selected when QEMU_BINARY's target architecture
+                           matches the host architecture; e.g. running
+                           qemu-system-x86_64 on arm64 macOS defaults to tcg
   QEMU_MACHINE             QEMU machine type. Default: pc
   QEMU_CPUS                vCPU count. Default: 2
   QEMU_MEMORY              Guest memory. Default: 2048
@@ -99,6 +106,12 @@ abs_path() {
   echo "$(cd "${dir}" && pwd -P)/${base}"
 }
 
+is_flatcar_image() {
+  local image="${1}"
+
+  [[ "${image,,}" == *flatcar* ]]
+}
+
 resolve_image() {
   local input="${1}"
   local matches
@@ -123,17 +136,62 @@ resolve_image() {
   printf '%s\n' "${input}"
 }
 
+normalize_arch() {
+  case "${1}" in
+  x86_64 | amd64)
+    echo x86_64
+    ;;
+  aarch64 | arm64)
+    echo aarch64
+    ;;
+  *)
+    echo "${1}"
+    ;;
+  esac
+}
+
+qemu_binary_arch() {
+  case "$(basename "${1}")" in
+  qemu-system-x86_64)
+    echo x86_64
+    ;;
+  qemu-system-aarch64)
+    echo aarch64
+    ;;
+  *)
+    echo ""
+    ;;
+  esac
+}
+
+# detect_accelerator picks a default accelerator for the given QEMU binary.
+# hvf and kvm both require the QEMU binary's target architecture to match the
+# host architecture; e.g. running qemu-system-x86_64 on an arm64 macOS host to
+# boot an amd64 image cannot use hvf and must fall back to tcg.
 detect_accelerator() {
+  local qemu_binary="${1}"
+  local host_arch
+  local binary_arch
+
+  host_arch="$(normalize_arch "$(uname -m)")"
+  binary_arch="$(qemu_binary_arch "${qemu_binary}")"
+
   case "$(uname -s)" in
   Linux)
-    if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+    if [[ -n "${binary_arch}" && "${binary_arch}" != "${host_arch}" ]]; then
+      echo tcg
+    elif [[ -r /dev/kvm && -w /dev/kvm ]]; then
       echo kvm
     else
       echo tcg
     fi
     ;;
   Darwin)
-    echo hvf
+    if [[ -n "${binary_arch}" && "${binary_arch}" != "${host_arch}" ]]; then
+      echo tcg
+    else
+      echo hvf
+    fi
     ;;
   *)
     echo tcg
@@ -215,6 +273,10 @@ require_command "${QEMU_IMG}"
 require_command ssh
 
 image="$(abs_path "$(resolve_image "${image_arg}")")"
+if is_flatcar_image "${image}"; then
+  echo "qemu-boot-smoke.sh does not support Flatcar images: Flatcar uses Ignition, not cloud-init, and the build removes the SSH user before shutdown, so neither QEMU_SEED=cloud-init nor QEMU_SEED=none can authenticate. Image: ${image}" >&2
+  exit 1
+fi
 if [[ ! -r "${QEMU_SSH_PRIVATE_KEY}" ]]; then
   echo "SSH private key is not readable: ${QEMU_SSH_PRIVATE_KEY}" >&2
   exit 1
@@ -259,7 +321,7 @@ none)
   ;;
 esac
 
-QEMU_ACCELERATOR="${QEMU_ACCELERATOR:-$(detect_accelerator)}"
+QEMU_ACCELERATOR="${QEMU_ACCELERATOR:-$(detect_accelerator "${QEMU_BINARY}")}"
 serial_log="${tmp_dir}/serial.log"
 pidfile="${tmp_dir}/qemu.pid"
 

--- a/images/capi/hack/qemu-boot-smoke.sh
+++ b/images/capi/hack/qemu-boot-smoke.sh
@@ -30,7 +30,8 @@ creates the SSH user, so the source image is not modified.
 
 Flatcar (qemu-flatcar) images are not supported: Flatcar uses Ignition rather
 than cloud-init, and the build removes the SSH user before shutdown, so no
-supported QEMU_SEED value can authenticate to it.
+supported QEMU_SEED value can authenticate to it. Set QEMU_IMAGE_OS=flatcar
+to fail fast when invoking this helper for a Flatcar artifact.
 
 Environment:
   QEMU_BINARY              QEMU binary to run. Default: qemu-system-x86_64
@@ -52,6 +53,8 @@ Environment:
   QEMU_SSH_PUBLIC_KEY      SSH public key. Default: cloudinit/id_rsa.capi.pub
   QEMU_SMOKE_COMMAND       Command to run over SSH. Default: true
   QEMU_SEED                cloud-init or none. Default: cloud-init
+  QEMU_IMAGE_OS            Set to flatcar to fail before an unsupported smoke
+                           test is attempted. Default: unset
 EOF
 }
 
@@ -88,6 +91,7 @@ QEMU_SSH_PRIVATE_KEY="${QEMU_SSH_PRIVATE_KEY:-${capi_dir}/cloudinit/id_rsa.capi}
 QEMU_SSH_PUBLIC_KEY="${QEMU_SSH_PUBLIC_KEY:-${capi_dir}/cloudinit/id_rsa.capi.pub}"
 QEMU_SMOKE_COMMAND="${QEMU_SMOKE_COMMAND:-true}"
 QEMU_SEED="${QEMU_SEED:-cloud-init}"
+QEMU_IMAGE_OS="${QEMU_IMAGE_OS:-}"
 
 require_command() {
   if ! command -v "${1}" >/dev/null 2>&1; then
@@ -106,10 +110,8 @@ abs_path() {
   echo "$(cd "${dir}" && pwd -P)/${base}"
 }
 
-is_flatcar_image() {
-  local image="${1}"
-
-  [[ "${image,,}" == *flatcar* ]]
+is_flatcar_requested() {
+  [[ "${QEMU_IMAGE_OS}" == "flatcar" ]]
 }
 
 resolve_image() {
@@ -178,7 +180,7 @@ detect_accelerator() {
 
   case "$(uname -s)" in
   Linux)
-    if [[ -n "${binary_arch}" && "${binary_arch}" != "${host_arch}" ]]; then
+    if [[ -z "${binary_arch}" || "${binary_arch}" != "${host_arch}" ]]; then
       echo tcg
     elif [[ -r /dev/kvm && -w /dev/kvm ]]; then
       echo kvm
@@ -187,7 +189,7 @@ detect_accelerator() {
     fi
     ;;
   Darwin)
-    if [[ -n "${binary_arch}" && "${binary_arch}" != "${host_arch}" ]]; then
+    if [[ -z "${binary_arch}" || "${binary_arch}" != "${host_arch}" ]]; then
       echo tcg
     else
       echo hvf
@@ -273,7 +275,7 @@ require_command "${QEMU_IMG}"
 require_command ssh
 
 image="$(abs_path "$(resolve_image "${image_arg}")")"
-if is_flatcar_image "${image}"; then
+if is_flatcar_requested; then
   echo "qemu-boot-smoke.sh does not support Flatcar images: Flatcar uses Ignition, not cloud-init, and the build removes the SSH user before shutdown, so neither QEMU_SEED=cloud-init nor QEMU_SEED=none can authenticate. Image: ${image}" >&2
   exit 1
 fi

--- a/images/capi/packer/qemu/README.md
+++ b/images/capi/packer/qemu/README.md
@@ -138,8 +138,9 @@ should:
    `/etc/machine-id` is non-empty after first boot.
 
 For a local pre-CAPI boot smoke, boot the produced artifact with QEMU and a
-temporary NoCloud seed. The smoke should use the same checks as above, plus a
-reboot/persistence check, before the image is promoted to provider CAPI tests.
+temporary NoCloud seed. The smoke checks SSH reachability and runs one command
+before the image is promoted to provider CAPI tests. It does not verify reboot
+persistence, immutable-image behavior, or the full CAPI test set.
 
 ## Boot smoke test
 

--- a/images/capi/packer/qemu/README.md
+++ b/images/capi/packer/qemu/README.md
@@ -177,3 +177,7 @@ QEMU_SSH_USER=builder \
 QEMU_SSH_PRIVATE_KEY=/path/to/key \
 make test-qemu-boot-smoke QEMU_BOOT_SMOKE_IMAGE=/path/to/image.qcow2
 ```
+
+The smoke helper does not support `qemu-flatcar` images because they use
+Ignition instead of cloud-init. Set `QEMU_BOOT_SMOKE_OS=flatcar` when invoking
+the Make target to fail fast before attempting an unsupported SSH check.

--- a/images/capi/packer/qemu/README.md
+++ b/images/capi/packer/qemu/README.md
@@ -140,3 +140,40 @@ should:
 For a local pre-CAPI boot smoke, boot the produced artifact with QEMU and a
 temporary NoCloud seed. The smoke should use the same checks as above, plus a
 reboot/persistence check, before the image is promoted to provider CAPI tests.
+
+## Boot smoke test
+
+After building a QEMU image, you can run an optional local boot smoke test
+against the output image:
+
+```bash
+make test-qemu-boot-smoke QEMU_BOOT_SMOKE_IMAGE=output/ubuntu-2404-kube-v1.33.0
+```
+
+The target starts the image with QEMU, using a temporary copy-on-write overlay so
+the built artifact is not modified. By default it also attaches a temporary
+NoCloud seed ISO that creates an SSH user from `cloudinit/id_rsa.capi.pub`, then
+waits for SSH on `127.0.0.1:2222`.
+
+The smoke test is opt-in and is not wired into required CI. It is intended for
+local validation of already-built QEMU images. Common overrides:
+
+```bash
+QEMU_SSH_PORT=2223 \
+QEMU_SSH_TIMEOUT=900 \
+QEMU_SMOKE_COMMAND='cloud-init status --wait' \
+make test-qemu-boot-smoke QEMU_BOOT_SMOKE_IMAGE=output/ubuntu-2404-kube-v1.33.0
+```
+
+Use `QEMU_BOOT_SMOKE_ARGS='-- ...'` to pass additional QEMU arguments, such as
+firmware options for an EFI image.
+
+For images that already contain test SSH access, disable the generated cloud-init
+seed and provide the matching credentials:
+
+```bash
+QEMU_SEED=none \
+QEMU_SSH_USER=builder \
+QEMU_SSH_PRIVATE_KEY=/path/to/key \
+make test-qemu-boot-smoke QEMU_BOOT_SMOKE_IMAGE=/path/to/image.qcow2
+```


### PR DESCRIPTION
## Change description

Add an opt-in local QEMU boot smoke helper for already-built CAPI QEMU images.

The helper boots a local image through a temporary qcow2 copy-on-write overlay, optionally attaches a generated NoCloud seed ISO, forwards guest SSH to localhost, and verifies a configurable SSH command. The source image is not modified.

The Makefile target is intentionally manual-only and is not wired into required CI.

- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n/a
- If adding a new provider, are you a representative of that provider? (y/n) n/a

## Related issues

None.

## Validation
- `bash -n images/capi/hack/qemu-boot-smoke.sh`
- `shellcheck -x images/capi/hack/qemu-boot-smoke.sh`
- `git diff --check`
- `make -C images/capi -n test-qemu-boot-smoke QEMU_BOOT_SMOKE_IMAGE=/tmp/example.qcow2`
- `make -C images/capi help | rg test-qemu-boot-smoke`

A real QEMU boot was not run in this local environment because `qemu-system-x86_64` and `qemu-img` are not installed here.

