### PR TITLE
capi: avoid duplicate phased custom roles

### DIFF
--- a/images/capi/ansible/node.yml
+++ b/images/capi/ansible/node.yml
@@ -54,7 +54,15 @@
     - name: Include post-node custom roles
       ansible.builtin.include_role:
         name: "{{ role }}"
-      loop: "{{ custom_role_names.split() + node_custom_roles_post.split() }}"
+      loop: >-
+        {{
+          (
+            custom_role_names.split()
+            | reject('in', node_custom_roles_pre.split() + node_custom_roles_post_sysprep.split())
+            | list
+          )
+          + node_custom_roles_post.split()
+        }}
       loop_control:
         loop_var: role
       when: custom_role_names != "" or node_custom_roles_post != ""

--- a/images/capi/ansible/windows/node_windows.yml
+++ b/images/capi/ansible/windows/node_windows.yml
@@ -103,7 +103,15 @@
     - name: Include custom post-configuration roles
       ansible.builtin.include_role:
         name: "{{ role }}"
-      loop: "{{ custom_role_names.split() + node_custom_roles_post.split() }}"
+      loop: >-
+        {{
+          (
+            custom_role_names.split()
+            | reject('in', node_custom_roles_pre.split())
+            | list
+          )
+          + node_custom_roles_post.split()
+        }}
       loop_control:
         loop_var: role
       when: custom_role_names != "" or node_custom_roles_post != ""


### PR DESCRIPTION
## What this PR does

Filters roles assigned to phase-specific hooks out of the generic post-node custom-role loop.

Linux now excludes roles from `custom_role_names` when they are already assigned to:

- `node_custom_roles_pre`
- `node_custom_roles_post_sysprep`

Windows now excludes roles from `custom_role_names` when they are already assigned to:

- `node_custom_roles_pre`

Roles explicitly listed in `node_custom_roles_post` still run in the post-node/post-configuration phase.

## Why it is needed

Downstream validation found that some build flows need a role listed in `custom_role_names` for custom-role wiring, while also assigning that same role to a phase-specific hook. With the current node playbooks, that role is then executed again by the generic post-node loop.

That is surprising for hook users and can run setup or validation roles in the wrong phase. The new filtering keeps the existing `custom_role_names` behavior for normal post-node roles, while avoiding duplicate execution for roles that have a more specific phase assignment.

## Validation

- `git diff --check`
- `ansible-playbook --syntax-check images/capi/ansible/node.yml -i localhost,`
- `ansible-playbook --syntax-check images/capi/ansible/windows/node_windows.yml -i localhost,`
