### PR TITLE
capi: preserve Ansible temp dirs during sysprep

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -137,6 +137,10 @@
       - /tmp
       - /var/tmp
     pattern: "*"
+    excludes:
+      - .ansible
+      - ansible-tmp-*
+      - ansible_*_payload_*
   register: temp_files
 
 - name: Reset temp space


### PR DESCRIPTION
## What this PR does / why we need it

The CAPI sysprep role removes all top-level entries from `/tmp` and `/var/tmp`. With newer Ansible versions, module payloads can be extracted below `/tmp/ansible_*_payload_*`, and Ansible remote tmp entries can live below `/tmp/.ansible` or `/tmp/ansible-tmp-*`. Removing those entries while the play is still running can make a later module fail because its own payload zip disappeared before result serialization.

This keeps sysprep cleanup behavior, but excludes Ansible's active temp/payload directories from the `find` result before `Reset temp space` removes entries.

## Validation

```
git diff --check
cd images/capi && ansible-playbook -i localhost, ansible/node.yml --syntax-check -e python_path=/tmp -e node_custom_roles_post_sysprep=
cd images/capi && make validate-gce-ubuntu-2404 PACKER_FLAGS='-syntax-only'
```

Also ran:

```
cd images/capi && ansible-lint --project-dir . ansible/roles/sysprep
```

That still fails on existing sysprep `var-naming[no-role-prefix]` findings in unchanged files, including existing registers such as `temp_files`, plus other pre-existing ignored warnings.
