### PR TITLE
capi: isolate Azure CI CLI auth per SIG build

### DIFF
--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -80,6 +80,8 @@ get_random_cvm_region() {
 
 export PATH=${PWD}/.local/bin:$PATH
 export PATH=${PYTHON_BIN_DIR:-"/root/.local/bin"}:$PATH
+export AZURE_CONFIG_DIR="${AZURE_CONFIG_DIR:-${ARTIFACTS}/azure-cli/main}"
+mkdir -p "${AZURE_CONFIG_DIR}"
 
 export AZURE_LOCATION="${AZURE_LOCATION:-$(get_random_region)}"
 export RESOURCE_GROUP_NAME="image-builder-e2e-$(head /dev/urandom | LC_ALL=C tr -dc a-z0-9 | head -c 6 ; echo '')"
@@ -117,11 +119,22 @@ export FLATCAR_VERSION="$(get_flatcar_version)"
 # Disable them for CI runs so don't run into timeouts
 export PACKER_VAR_FILES="packer/azure/scripts/disable-windows-prepull.json scripts/ci-disable-goss-inspect.json"
 
-declare -A PIDS
-for target in ${SIG_CI_TARGETS[@]};
-do
+run_sig_target() {
+    local target="$1"
+    local location="${2:-${AZURE_LOCATION}}"
+
+    export AZURE_CONFIG_DIR="${ARTIFACTS}/azure-cli/${target}"
+    export AZURE_LOCATION="${location}"
+    mkdir -p "${AZURE_CONFIG_DIR}"
+
     login
-    make build-azure-sig-${target} > ${ARTIFACTS}/azure-sigs/${target}.log 2>&1 &
+    make "build-azure-sig-${target}"
+}
+
+declare -A PIDS
+for target in "${SIG_CI_TARGETS[@]}";
+do
+    run_sig_target "${target}" > "${ARTIFACTS}/azure-sigs/${target}.log" 2>&1 &
     PIDS["sig-${target}"]=$!
 done
 
@@ -132,10 +145,9 @@ if [[ ! " ${VALID_CVM_LOCATIONS[*]} " =~ " ${SELECTED_LOCATION} " ]]; then
     echo "Selected location is ${SELECTED_LOCATION}."
 fi
 
-for target in ${SIG_CVM_CI_TARGETS[@]};
+for target in "${SIG_CVM_CI_TARGETS[@]}";
 do
-    login
-    AZURE_LOCATION="${SELECTED_LOCATION}" make build-azure-sig-${target} > ${ARTIFACTS}/azure-sigs/${target}.log 2>&1 &
+    run_sig_target "${target}" "${SELECTED_LOCATION}" > "${ARTIFACTS}/azure-sigs/${target}.log" 2>&1 &
     PIDS["sig-${target}"]=$!
 done
 

--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -155,8 +155,7 @@ done
 set +o errexit
 exit_err=false
 for target in "${!PIDS[@]}"; do
-  wait ${PIDS[$target]}
-  if [[ $? -ne 0 ]]; then
+  if ! wait "${PIDS[$target]}"; then
     exit_err=true
     echo "${target}: FAILED. See logs in the artifacts folder."
   else


### PR DESCRIPTION
## What this does

The Azure SIG presubmit starts many SIG builds in the background. Today all children share the same Azure CLI config directory while Packer is using Azure CLI auth, which can leave a child without a visible default subscription.

This gives each background SIG build its own `AZURE_CONFIG_DIR`, logs in inside that child, and keeps the selected Azure location scoped to that child. The parent still logs in once for shared setup such as Flatcar version discovery and cleanup.

## Why

This addresses an Azure SIG CI race observed while maintaining the open image-builder PR train. A target failed immediately after `init-sig.sh` had successfully created the resource group/gallery:

```text
error fetching tenantID and subscriptionID from Azure CLI (are you logged on using `az login`?): Unable to find default subscription
```

The same target succeeded in another PR, which points at a CI auth race rather than a target-specific build regression.

## Validation

- `bash -n images/capi/scripts/ci-azure-e2e.sh`
- `git diff --check`
- `shellcheck images/capi/scripts/ci-azure-e2e.sh` still reports pre-existing findings from `main`; the unquoted array expansion errors and the changed `wait` PID handling are fixed by this PR.
- `NO_COLOR=1 make lint` fails locally on unrelated pre-existing Ansible `var-naming[no-role-prefix]` violations under `images/capi/ansible/`; no changed shell-script syntax failure was reported.
