### PR TITLE
fix(outscale): use ansible_facts for os_family with inject_facts_as_vars disabled

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/outscale.yml
+++ b/images/capi/ansible/roles/providers/tasks/outscale.yml
@@ -9,7 +9,7 @@
       - cloud-init
       - cloud-guest-utils
       - cloud-initramfs-dyn-netconf
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Install Debian specific packages
   ansible.builtin.apt:


### PR DESCRIPTION
**What this PR does / why we need it**:

`images/capi/ansible.cfg` sets `inject_facts_as_vars = False`, so the bare
`ansible_os_family` variable is no longer injected into the play namespace.

The cloud-init task added to `roles/providers/tasks/outscale.yml` in #1986 still
guards on the bare fact:

```yaml
  when: ansible_os_family == "Debian"
```

With injection disabled this evaluates against an **undefined variable** on
Outscale (OSC) builds. This PR switches it to the `ansible_facts[...]` accessor,
matching the two sibling tasks in the same file (lines 18/24) and the facts
migration from #1981:

```yaml
  when: ansible_facts['os_family'] == "Debian"
```

Scope is OSC-only — this is the sole remaining bare-fact read under
`roles/providers`. `roles/node/tasks/main.yml` only *sets* `ansible_os_family`
(Flatcar override), which is unaffected.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
No behavioural change intended: `ansible_facts['os_family']` resolves to the
same value the bare fact previously did.

**Release note**:

```release-note
Fix Outscale image builds failing on an undefined `ansible_os_family` variable when `inject_facts_as_vars` is disabled.
```