### PR TITLE
outscale: bump base images & packer provider

### DIFF
--- a/images/capi/packer/outscale/config.pkr.hcl
+++ b/images/capi/packer/outscale/config.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     outscale = {
       source =  "github.com/outscale/outscale"
-      version = "~> 1.5.0"
+      version = "~> 1.6.0"
     }
   }
 }

--- a/images/capi/packer/outscale/flatcar.json
+++ b/images/capi/packer/outscale/flatcar.json
@@ -4,7 +4,7 @@
   "distribution": "flatcar",
   "distribution_release": "{{env `FLATCAR_CHANNEL`}}",
   "distribution_version": "{{env `FLATCAR_CHANNEL`}}-{{env `FLATCAR_VERSION`}}",
-  "image_name": "Ubuntu-24.04-2026-01-12",
+  "image_name": "Ubuntu-24.04-2026-06-17",
   "kubernetes_cni_source_type": "http",
   "kubernetes_source_type": "http",
   "python_path": "/opt/pypy/site-packages",

--- a/images/capi/packer/outscale/ubuntu-2204.json
+++ b/images/capi/packer/outscale/ubuntu-2204.json
@@ -3,5 +3,5 @@
   "distribution": "ubuntu",
   "distribution_release": "ubuntu",
   "distribution_version": "2204",
-  "image_name": "Ubuntu-22.04-2026-01-12"
+  "image_name": "Ubuntu-22.04-2026-06-17"
 }

--- a/images/capi/packer/outscale/ubuntu-2404.json
+++ b/images/capi/packer/outscale/ubuntu-2404.json
@@ -3,5 +3,5 @@
   "distribution": "ubuntu",
   "distribution_release": "ubuntu",
   "distribution_version": "2404",
-  "image_name": "Ubuntu-24.04-2026-01-12"
+  "image_name": "Ubuntu-24.04-2026-06-17"
 }

--- a/images/capi/packer/outscale/ubuntu-2604.json
+++ b/images/capi/packer/outscale/ubuntu-2604.json
@@ -3,5 +3,5 @@
   "distribution": "ubuntu",
   "distribution_release": "ubuntu",
   "distribution_version": "2604",
-  "image_name": "Ubuntu-26.04-2026-04-22"
+  "image_name": "Ubuntu-26.04-2026-06-17"
 }


### PR DESCRIPTION
## Change description

This PR upgrades the Outscale Packer provider to the latest v1.6.0 and base images to 2026-06-17.

## Related issues

## Additional context
