### PR TITLE
capi: detect Microsoft apt source in apt root

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -46,7 +46,10 @@
   block:
     - name: Check for legacy Microsoft apt source
       ansible.builtin.find:
-        paths: /etc/apt/sources.list.d
+        depth: 1
+        paths:
+          - /etc/apt
+          - /etc/apt/sources.list.d
         patterns:
           - "*.list"
           - "*.sources"


### PR DESCRIPTION
#### What this PR does / why we need it

Extends the legacy Microsoft apt source detection in the Debian setup role to
also inspect `/etc/apt/sources.list` in addition to `/etc/apt/sources.list.d`.

Azure Ubuntu images can inherit the legacy Microsoft repository as:

```console
deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main
```

When that source is present outside `sources.list.d`, the existing setup task
does not detect it and therefore does not install the Microsoft key before the
first apt cache refresh. That can fail later with `NO_PUBKEY EB3E94ADBE1229CF`
for `packages.microsoft.com/ubuntu/18.04/prod`.

The change keeps the existing module-native `ansible.builtin.find` and
`ansible.builtin.get_url` approach. It only broadens the searched apt source
locations and keeps the key download conditional on finding a Microsoft source.

#### Which issue(s) this PR fixes

None

#### Special notes for your reviewer

This is a small follow-up to the existing legacy Microsoft apt key handling. It
covers apt sources in `/etc/apt/sources.list`, which is the same directory scope
already used by the public-repository disable logic.

#### Testing

```console
git diff --check
python3 - <<'PY'
from pathlib import Path
import yaml
p = Path('images/capi/ansible/roles/setup/tasks/debian.yml')
with p.open() as f:
    data = yaml.safe_load(f)
assert isinstance(data, list)
block = next(t for t in data if t.get('name') == 'Trust Microsoft key for legacy Microsoft apt repositories')
find_task = block['block'][0]
assert '/etc/apt' in find_task['ansible.builtin.find']['paths']
assert '/etc/apt/sources.list.d' in find_task['ansible.builtin.find']['paths']
assert find_task['ansible.builtin.find']['depth'] == 1
print('ok')
PY
cd images/capi && ansible-playbook --syntax-check ansible/node.yml -e provider=azure
```

