### PR TITLE
capi: remove new subiquity cloud-init networking disable file

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -151,10 +151,13 @@
     - _stat_update_grub.stat.exists
     - sysprep_require_grub_file|default(true)|bool
 
-- name: Removing subiquity disable cloud-init networking config
+- name: Removing subiquity disable cloud-init networking configs
   ansible.builtin.file:
-    path: /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+    path: "{{ item }}"
     state: absent
+  loop:
+    - /etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg
+    - /etc/cloud/cloud.cfg.d/00-subiquity-disable-cloudinit-networking.cfg
   when: ansible_facts['distribution_version'] is version('22.04', '>=')
 
 - name: Removing 99-installer.cfg which sets the cloud-init datasource to None


### PR DESCRIPTION
#### What this PR does / why we need it

Removes both known Subiquity cloud-init networking disable filenames during
Debian sysprep:

- `/etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg`
- `/etc/cloud/cloud.cfg.d/00-subiquity-disable-cloudinit-networking.cfg`

Subiquity changed the filename for newer Ubuntu releases. If the new filename is
left behind, first-boot cloud-init networking can stay disabled and provider
static network data is ignored.

This keeps the existing module-native `ansible.builtin.file` cleanup and extends
it with a loop over both filenames.

#### Which issue(s) this PR fixes

Fixes #2057

#### Testing

```console
git diff --check
python3 - <<'PY'
from pathlib import Path
import yaml
p = Path('images/capi/ansible/roles/sysprep/tasks/debian.yml')
with p.open() as f:
    data = yaml.safe_load(f)
task = next(t for t in data if t.get('name') == 'Removing subiquity disable cloud-init networking configs')
assert task['ansible.builtin.file']['path'] == '{{ item }}'
assert '/etc/cloud/cloud.cfg.d/subiquity-disable-cloudinit-networking.cfg' in task['loop']
assert '/etc/cloud/cloud.cfg.d/00-subiquity-disable-cloudinit-networking.cfg' in task['loop']
print('ok')
PY
cd images/capi && ansible-playbook --syntax-check ansible/node.yml
```

