### PR TITLE
capi: re-enable Ubuntu 26.04 OVA CI

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -29,12 +29,10 @@ export ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
 # The following are currently having issues running in the
 # test environment so are specifically excluded for now
 # - Photon-4
-# - Ubuntu 26.04 (autoinstall never completes, hanging the job; see #2035)
 TARGETS=( $(make build-node-ova-vsphere-all --recon -d | grep "Must remake" | \
   grep -v build-node-ova-vsphere-all | \
   grep -E -v 'rhel|windows|efi' | \
   grep -v build-node-ova-vsphere-photon-4 | \
-  grep -v build-node-ova-vsphere-ubuntu-2604 | \
   grep -E -o 'build-node-ova-vsphere-[a-zA-Z0-9\-]+' ) )
 
 export BOSKOS_RESOURCE_OWNER=image-builder


### PR DESCRIPTION
## What this PR does / why we need it

Re-enables the Ubuntu 26.04 vSphere OVA build in `pull-ova-all`.

It was temporarily excluded in #2036 because #2035 showed the installer hanging before provisioning. Since then, #2064 normalized the Ubuntu OVA NoCloud seed label to `CIDATA`, matching cloud-init documented seed ISO examples, and #2093 removed the shared SSH password race in parallel OVA CI. The remaining `ci-ova.sh` filter now prevents CI from proving the target is healthy again.

Draft until `pull-ova-all` confirms the re-enabled target.

Refs #2035.

## Release note

```release-note
NONE
```

## Validation

- `bash -n images/capi/scripts/ci-ova.sh`
- `cd images/capi && make build-node-ova-vsphere-all --recon -d | grep "Must remake" | grep -v build-node-ova-vsphere-all | grep -E -v 'rhel|windows|efi' | grep -v build-node-ova-vsphere-photon-4 | grep -E -o 'build-node-ova-vsphere-[a-zA-Z0-9\-]+' | sort` includes `build-node-ova-vsphere-ubuntu-2604`
- `git diff --check`
- `make validate-node-ova-local-ubuntu-2604`
- `shellcheck images/capi/scripts/ci-ova.sh` reports only the same pre-existing warnings as `upstream/main`