### PR TITLE
capi: skip Windows debug tools in Azure CI

### DIFF
--- a/images/capi/packer/azure/scripts/disable-windows-debug-tools.json
+++ b/images/capi/packer/azure/scripts/disable-windows-debug-tools.json
@@ -1,0 +1,3 @@
+{
+  "debug_tools": "false"
+}

--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -117,7 +117,7 @@ export FLATCAR_VERSION="$(get_flatcar_version)"
 
 # Pre-pulling windows images takes 10-20 mins
 # Disable them for CI runs so don't run into timeouts
-export PACKER_VAR_FILES="packer/azure/scripts/disable-windows-prepull.json scripts/ci-disable-goss-inspect.json"
+export PACKER_VAR_FILES="packer/azure/scripts/disable-windows-prepull.json packer/azure/scripts/disable-windows-debug-tools.json scripts/ci-disable-goss-inspect.json"
 
 run_sig_target() {
     local target="$1"


### PR DESCRIPTION
## What
- Disables optional Windows debug tools in Azure presubmit builds through the existing CI-only `PACKER_VAR_FILES` mechanism.
- Leaves normal Windows image defaults unchanged.
- Avoids downloading Microsoft SDN debug scripts during `pull-azure-sigs`.

## Validation
- `bash -n images/capi/scripts/ci-azure-e2e.sh`
- `shellcheck -e SC2207,SC1091,SC2155,SC2086,SC2076 images/capi/scripts/ci-azure-e2e.sh`
- `jq empty images/capi/packer/azure/scripts/disable-windows-debug-tools.json`
- `git diff --check`
- `packer validate -syntax-only ... -var-file=packer/azure/scripts/disable-windows-debug-tools.json -only=sig-windows-2022-containerd-cvm packer/azure/packer-windows.json`

Plain `shellcheck images/capi/scripts/ci-azure-e2e.sh` still reports existing warnings unrelated to this change.
