### PR TITLE
capi: initialize GCE CI test status

### DIFF
--- a/images/capi/scripts/ci-gce.sh
+++ b/images/capi/scripts/ci-gce.sh
@@ -28,6 +28,8 @@ set -o pipefail
 CAPI_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 cd "${CAPI_ROOT}" || exit 1
 
+test_status=0
+
 # shellcheck source=ensure-go.sh
 source "./hack/ensure-go.sh"
 # shellcheck source=ensure-boskosctl.sh

--- a/images/capi/scripts/ci-gce.sh
+++ b/images/capi/scripts/ci-gce.sh
@@ -43,6 +43,9 @@ function boskosctlwrapper() {
 }
 
 cleanup() {
+  # Capture the status that triggered this EXIT trap before running any other
+  # command, otherwise it gets clobbered by the cleanup steps below.
+  local trap_status=$?
   echo "Cleaning up image"
   if [ -n "${GCP_PROJECT:-}" ]; then
     filter="name~cluster-api-ubuntu-*"
@@ -58,9 +61,24 @@ cleanup() {
       | bash ) || true
   fi
 
+  # If the guarded build below didn't already record a failure, fall back to
+  # whatever failure actually triggered this EXIT trap (e.g. an expired GCP
+  # key, or a failed post-build image lookup), so it isn't masked by the
+  # initialized test_status=0.
+  if [ "${test_status}" -eq 0 ] && [ "${trap_status}" -ne 0 ]; then
+    test_status="${trap_status}"
+  fi
+
   # stop boskos heartbeat
   if [ -n "${BOSKOS_HOST:-}" ] && [ -n "${RESOURCE_NAME:-}" ]; then
-    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state dirty || true
+    local release_status=0
+    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state dirty || release_status="${?}"
+    # Only let a release failure fail the job if the run was otherwise
+    # successful; a real build/test (or other trapped) failure always takes
+    # priority over a release error.
+    if [ "${test_status}" -eq 0 ] && [ "${release_status}" -ne 0 ]; then
+      test_status="${release_status}"
+    fi
   fi
 
   exit "${test_status}"

--- a/images/capi/scripts/ci-gce.sh
+++ b/images/capi/scripts/ci-gce.sh
@@ -44,21 +44,23 @@ function boskosctlwrapper() {
 
 cleanup() {
   echo "Cleaning up image"
-  filter="name~cluster-api-ubuntu-*"
-  (gcloud compute images list --project "$GCP_PROJECT" \
-    --no-standard-images --format="table[no-heading](name)" --filter="${filter}" \
-    | awk '{print "gcloud compute images delete --quiet --project '"$GCP_PROJECT"' "$1" " "\n"}' \
-    | bash ) || true
+  if [ -n "${GCP_PROJECT:-}" ]; then
+    filter="name~cluster-api-ubuntu-*"
+    (gcloud compute images list --project "$GCP_PROJECT" \
+      --no-standard-images --format="table[no-heading](name)" --filter="${filter}" \
+      | awk '{print "gcloud compute images delete --quiet --project '"$GCP_PROJECT"' "$1" " "\n"}' \
+      | bash ) || true
 
-  filter="name~cluster-api-rhel-*"
-  (gcloud compute images list --project "$GCP_PROJECT" \
-    --no-standard-images --format="table[no-heading](name)" --filter="${filter}" \
-    | awk '{print "gcloud compute images delete --quiet --project '"$GCP_PROJECT"' "$1" " "\n"}' \
-    | bash ) || true
+    filter="name~cluster-api-rhel-*"
+    (gcloud compute images list --project "$GCP_PROJECT" \
+      --no-standard-images --format="table[no-heading](name)" --filter="${filter}" \
+      | awk '{print "gcloud compute images delete --quiet --project '"$GCP_PROJECT"' "$1" " "\n"}' \
+      | bash ) || true
+  fi
 
   # stop boskos heartbeat
-  if [ -n "${BOSKOS_HOST:-}" ]; then
-    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state dirty
+  if [ -n "${BOSKOS_HOST:-}" ] && [ -n "${RESOURCE_NAME:-}" ]; then
+    boskosctlwrapper release --name "${RESOURCE_NAME}" --target-state dirty || true
   fi
 
   exit "${test_status}"
@@ -92,15 +94,16 @@ fi
 groupadd -r packer && useradd -m -s /bin/bash -r -g packer packer
 chown -R packer:packer /home/prow/go/src/sigs.k8s.io/image-builder
 # use the packer user to run the build
-su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=scripts/ci-disable-goss-inspect.json make deps-gce build-gce-all'"
-test_status="${?}"
+su - packer -c "bash -c 'cd /home/prow/go/src/sigs.k8s.io/image-builder/images/capi && PATH=$PATH:~packer/.local/bin:/home/prow/go/src/sigs.k8s.io/image-builder/images/capi/.local/bin GCP_PROJECT_ID=$GCP_PROJECT GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS PACKER_VAR_FILES=scripts/ci-disable-goss-inspect.json make deps-gce build-gce-all'" || test_status="${?}"
 
-echo "Displaying the generated image information for Ubuntu"
-filter="name~cluster-api-ubuntu-*"
-gcloud compute images list --project "$GCP_PROJECT" --no-standard-images --filter="${filter}"
+if [ "${test_status}" -eq 0 ]; then
+  echo "Displaying the generated image information for Ubuntu"
+  filter="name~cluster-api-ubuntu-*"
+  gcloud compute images list --project "$GCP_PROJECT" --no-standard-images --filter="${filter}"
 
-echo "Displaying the generated image information for RHEL"
-filter="name~cluster-api-rhel-*"
-gcloud compute images list --project "$GCP_PROJECT" --no-standard-images --filter="${filter}"
+  echo "Displaying the generated image information for RHEL"
+  filter="name~cluster-api-rhel-*"
+  gcloud compute images list --project "$GCP_PROJECT" --no-standard-images --filter="${filter}"
+fi
 
 exit "${test_status}"


### PR DESCRIPTION
## What
- Initializes `test_status` before the GCE CI cleanup trap can read it.
- Preserves the `su - packer` build exit status under `errexit` instead of exiting before `test_status` is assigned.
- Guards cleanup when `GCP_PROJECT`, `BOSKOS_HOST`, or `RESOURCE_NAME` are unavailable.
- Skips post-build image listing after failed builds so cleanup exits with the original build failure.

## Validation
- `git diff --check`
- `bash -n images/capi/scripts/ci-gce.sh`
- `shellcheck images/capi/scripts/ci-gce.sh`

Plain ShellCheck still reports existing source/include and export-assignment warnings unrelated to this change.