### PR TITLE
capi: batch debian sysprep package holds

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -47,28 +47,39 @@
 # The apt-daily/unattended-upgrades services may still be running from before
 # they were disabled above. Retry package selection changes until the dpkg frontend
 # lock is released to avoid a flaky race with concurrent apt activity.
+- name: Define installed packages for package selection changes
+  ansible.builtin.set_fact:
+    sysprep_installed_packages: "{{ ansible_facts.packages.keys() | list | sort }}"
+    sysprep_grub_packages: "{{ ansible_facts.packages.keys() | select('search', 'grub') | list | sort }}"
+  when: sysprep_hold_installed_packages | default(true) | bool
+
+# ansible.builtin.dpkg_selections only changes one package per module call.
+# Feed dpkg's native batch format once to avoid hundreds of SSH round trips.
 - name: Pin all installed packages
-  ansible.builtin.dpkg_selections:
-    name: "{{ item }}"
-    selection: hold
-  loop: "{{ ansible_facts.packages.keys() }}"
+  ansible.builtin.command:
+    cmd: dpkg --set-selections
+    stdin: "{{ sysprep_installed_packages | map('regex_replace', '$', ' hold') | join('\n') }}"
   register: sysprep_dpkg_selections_hold
   until: sysprep_dpkg_selections_hold is not failed
   retries: 30
   delay: 10
-  when: sysprep_hold_installed_packages | default(true) | bool
+  changed_when: sysprep_installed_packages | length > 0
+  when:
+    - sysprep_hold_installed_packages | default(true) | bool
+    - sysprep_installed_packages | length > 0
 
 - name: Unpin grub packages for MaaS
-  ansible.builtin.dpkg_selections:
-    name: "{{ item }}"
-    selection: install
-  loop: "{{ ansible_facts.packages.keys() | select('search', 'grub') | list }}"
+  ansible.builtin.command:
+    cmd: dpkg --set-selections
+    stdin: "{{ sysprep_grub_packages | map('regex_replace', '$', ' install') | join('\n') }}"
   register: sysprep_dpkg_selections_unhold_grub
   until: sysprep_dpkg_selections_unhold_grub is not failed
   retries: 30
   delay: 10
+  changed_when: sysprep_grub_packages | length > 0
   when:
     - sysprep_hold_installed_packages | default(true) | bool
+    - sysprep_grub_packages | length > 0
     - provider is defined and provider is search('maas')
 
 - name: Remove extra repos


### PR DESCRIPTION
## What
- Replaces the Debian sysprep per-package `dpkg_selections` loop with batch `dpkg --set-selections` calls.
- Keeps the existing `sysprep_hold_installed_packages` behavior and retry handling.
- Keeps the MaaS grub package unhold behavior, also batched.

## Why
The Ansible module changes one package per remote module invocation. On QEMU validation runs this can spend many minutes or hours in sysprep package holds even though `dpkg --set-selections` accepts the same selection data in one batch.

## Validation
- `ansible-playbook --syntax-check ansible/node.yml`
- `ansible-lint --project-dir . --skip-list var-naming ansible/roles/sysprep/tasks/debian.yml`
  - The skipped `var-naming` findings are pre-existing in this file.
- `git diff --check`
- Ubuntu 24.04 container check: `printf "bash hold\ncoreutils hold\n" | dpkg --set-selections` followed by `dpkg --get-selections`, then the same for `install`.
