### PR TITLE
capi: avoid Hyper-V daemon starts in qemu builds

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/qemu.yml
+++ b/images/capi/ansible/roles/providers/tasks/qemu.yml
@@ -35,12 +35,18 @@
       - cloud-utils-growpart
   when: ansible_facts['os_family'] == "RedHat"
 
-- name: Disable Hyper-V KVP protocol daemon on Ubuntu
+- name: Disable Hyper-V daemons on Ubuntu
   ansible.builtin.systemd:
-    name: hv-kvp-daemon
+    name: "{{ item }}"
     state: stopped
     enabled: false
-  when: ansible_facts['os_family'] == "Debian" and ansible_facts['architecture'] != "aarch64"
+  loop:
+    - hv-fcopy-daemon
+    - hv-kvp-daemon
+    - hv-vss-daemon
+  when:
+    - ansible_facts['os_family'] == "Debian"
+    - ansible_facts['architecture'] != "aarch64"
 
 - name: Create directory for DHCP chrony server files
   ansible.builtin.file:

--- a/images/capi/ansible/roles/setup/defaults/main.yml
+++ b/images/capi/ansible/roles/setup/defaults/main.yml
@@ -26,3 +26,14 @@ disable_public_repos: false
 external_binary_path: "{{ '/opt/bin' if ansible_facts['os_family'] == 'Flatcar' else '/usr/local/bin' }}"
 extra_repos: ""
 pip_conf_file: ""
+setup_qemu_hyperv_daemons:
+  - hv-fcopy-daemon
+  - hv-kvp-daemon
+  - hv-vss-daemon
+setup_block_qemu_hyperv_daemons: >-
+  {{
+    (packer_builder_type | default('')) is search('qemu')
+    and ansible_facts['architecture'] != 'aarch64'
+  }}
+setup_policy_rc_d_backup: >-
+  /tmp/image-builder-policy-rc.d.{{ inventory_hostname | regex_replace('[^A-Za-z0-9_.-]', '_') }}

--- a/images/capi/ansible/roles/setup/tasks/debian.yml
+++ b/images/capi/ansible/roles/setup/tasks/debian.yml
@@ -112,47 +112,106 @@
     replace: nullbootctl --no-tpm --no-efivars
   when: packer_build_name is search('cvm')
 
-- name: Perform a dist-upgrade
-  ansible.builtin.apt:
-    force_apt_get: true
-    update_cache: true
-    upgrade: dist
-  register: apt_lock_status
-  until: apt_lock_status is not failed
-  retries: 5
-  delay: 10
+- name: Install packages
+  block:
+    - name: Check for existing policy-rc.d
+      ansible.builtin.stat:
+        path: /usr/sbin/policy-rc.d
+      register: setup_policy_rc_d
+      when: setup_block_qemu_hyperv_daemons | bool
 
-- name: Install baseline dependencies  # noqa: package-latest
-  ansible.builtin.apt:
-    force_apt_get: true
-    update_cache: true
-    name: "{{ debs }}"
-    state: latest
-  register: apt_lock_status
-  until: apt_lock_status is not failed
-  retries: 5
-  delay: 10
+    - name: Preserve existing policy-rc.d
+      ansible.builtin.command:
+        argv:
+          - mv
+          - /usr/sbin/policy-rc.d
+          - "{{ setup_policy_rc_d_backup }}"
+      args:
+        creates: "{{ setup_policy_rc_d_backup }}"
+        removes: /usr/sbin/policy-rc.d
+      when:
+        - setup_block_qemu_hyperv_daemons | bool
+        - setup_policy_rc_d.stat.exists | default(false)
 
-- name: Install extra debs  # noqa: package-latest
-  ansible.builtin.apt:
-    force_apt_get: true
-    name: "{{ extra_debs.split() }}"
-    state: latest
-  register: apt_lock_status
-  until: apt_lock_status is not failed
-  retries: 5
-  delay: 10
+    - name: Prevent Hyper-V daemons from starting during QEMU apt installs
+      ansible.builtin.copy:
+        content: |
+          #!/bin/sh
+          for service in {{ setup_qemu_hyperv_daemons | join(' ') }}; do
+            if [ "$1" = "$service" ] || [ "$1" = "$service.service" ]; then
+              exit 101
+            fi
+          done
 
-- name: Install pinned debs
-  ansible.builtin.apt:
-    force_apt_get: true
-    name: "{{ pinned_debs }}"
-    state: present
-    force: true
-  register: apt_lock_status
-  until: apt_lock_status is not failed
-  retries: 5
-  delay: 10
+          if [ -x "{{ setup_policy_rc_d_backup }}" ]; then
+            exec "{{ setup_policy_rc_d_backup }}" "$@"
+          fi
+
+          exit 0
+        dest: /usr/sbin/policy-rc.d
+        mode: "0755"
+      when: setup_block_qemu_hyperv_daemons | bool
+
+    - name: Perform a dist-upgrade
+      ansible.builtin.apt:
+        force_apt_get: true
+        update_cache: true
+        upgrade: dist
+      register: apt_lock_status
+      until: apt_lock_status is not failed
+      retries: 5
+      delay: 10
+
+    - name: Install baseline dependencies  # noqa: package-latest
+      ansible.builtin.apt:
+        force_apt_get: true
+        update_cache: true
+        name: "{{ debs }}"
+        state: latest
+      register: apt_lock_status
+      until: apt_lock_status is not failed
+      retries: 5
+      delay: 10
+
+    - name: Install extra debs  # noqa: package-latest
+      ansible.builtin.apt:
+        force_apt_get: true
+        name: "{{ extra_debs.split() }}"
+        state: latest
+      register: apt_lock_status
+      until: apt_lock_status is not failed
+      retries: 5
+      delay: 10
+
+    - name: Install pinned debs
+      ansible.builtin.apt:
+        force_apt_get: true
+        name: "{{ pinned_debs }}"
+        state: present
+        force: true
+      register: apt_lock_status
+      until: apt_lock_status is not failed
+      retries: 5
+      delay: 10
+  always:
+    - name: Remove temporary QEMU policy-rc.d
+      ansible.builtin.file:
+        path: /usr/sbin/policy-rc.d
+        state: absent
+      when: setup_block_qemu_hyperv_daemons | bool
+
+    - name: Restore existing policy-rc.d
+      ansible.builtin.command:
+        argv:
+          - mv
+          - "{{ setup_policy_rc_d_backup }}"
+          - /usr/sbin/policy-rc.d
+      args:
+        creates: /usr/sbin/policy-rc.d
+        removes: "{{ setup_policy_rc_d_backup }}"
+      when:
+        - setup_block_qemu_hyperv_daemons | bool
+        - setup_policy_rc_d.stat.exists | default(false)
 
 - name: Remove '--no-tpm --no-efivars' from nullboot post install script
   ansible.builtin.replace:


### PR DESCRIPTION
QEMU Ubuntu builds install `linux-cloud-tools-virtual` during firstboot. Its maintainer scripts can ask systemd to start the Hyper-V guest daemons, which are not useful in non-Hyper-V QEMU guests and can delay provisioning while systemd waits for missing vmbus devices.

This change keeps that behavior scoped to QEMU Debian-family builds:

- temporarily installs a `policy-rc.d` hook around the apt package phase
- denies starts only for `hv-fcopy-daemon`, `hv-kvp-daemon`, and `hv-vss-daemon`
- preserves and restores any existing `policy-rc.d`
- disables all three Hyper-V daemons in the final QEMU image

Validation:

- `git diff --check upstream/main...HEAD`
- `cd images/capi && ansible-playbook --syntax-check ansible/firstboot.yml -i ansible/hosts.ini --extra-vars 'packer_builder_type=qemu build_target=virt packer_build_name=ubuntu-2404 extra_repos= extra_debs= pinned_debs=[] disable_public_repos=false'`
- `cd images/capi && make validate-qemu-ubuntu-2404-cloudimg`

`yamllint` and `ansible-lint` still report pre-existing findings in the touched files, but no branch-introduced syntax or Packer validation failures were found.
