### PR TITLE
capi/qemu: skip shell cleanup during reboot handoff

### DIFF
--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -102,7 +102,7 @@
     {
       "expect_disconnect": true,
       "inline": [
-        "sudo reboot now"
+        "sudo systemd-run --unit=image-builder-reboot --on-active=1s /usr/sbin/reboot"
       ],
       "inline_shebang": "/bin/bash -e",
       "type": "shell"

--- a/images/capi/packer/qemu/packer.json.tmpl
+++ b/images/capi/packer/qemu/packer.json.tmpl
@@ -102,9 +102,10 @@
     {
       "expect_disconnect": true,
       "inline": [
-        "sudo systemd-run --unit=image-builder-reboot --on-active=1s /usr/sbin/reboot"
+        "sudo reboot now"
       ],
       "inline_shebang": "/bin/bash -e",
+      "skip_clean": true,
       "type": "shell"
     },
     {
@@ -115,7 +116,9 @@
         "uname -a"
       ],
       "inline_shebang": "/bin/bash -e",
-      "pause_before": "20s",
+      "pause_before": "60s",
+      "skip_clean": true,
+      "start_retry_timeout": "10m",
       "type": "shell"
     },
     {


### PR DESCRIPTION
#### What this PR does
- Leaves the intermediate QEMU reboot as the existing foreground `sudo reboot now` shell provisioner.
- Adds `skip_clean: true` to the reboot provisioner and the first post-reboot provisioner so Packer does not try to remove temporary shell scripts while SSH is dropping or recovering.
- Extends the post-reboot wait and SSH retry window before the existing `systemctl is-system-running --wait` check runs.

#### Why
When the guest reboots, SSH can disappear after the reboot command succeeds but before Packer removes the uploaded shell script. That cleanup failure can make a successful reboot look like a provisioner failure. Skipping cleanup across this reboot handoff keeps reconnect and readiness validation in the post-reboot provisioner.

#### Validation
- `git diff --check`
- `cd images/capi && make validate-qemu-ubuntu-2404-cloudimg`
