### PR TITLE
Guard OVA Boskos cleanup before resource acquire

### DIFF
--- a/images/capi/scripts/ci-ova.sh
+++ b/images/capi/scripts/ci-ova.sh
@@ -36,8 +36,8 @@ TARGETS=( $(make build-node-ova-vsphere-all --recon -d | grep "Must remake" | \
   grep -E -o 'build-node-ova-vsphere-[a-zA-Z0-9\-]+' ) )
 
 export BOSKOS_RESOURCE_OWNER=image-builder
-if [[ "${JOB_NAME}" != "" ]]; then
-  export BOSKOS_RESOURCE_OWNER="${JOB_NAME}/${BUILD_ID}"
+if [[ "${JOB_NAME:-}" != "" ]]; then
+  export BOSKOS_RESOURCE_OWNER="${JOB_NAME}/${BUILD_ID:-}"
 fi
 export BOSKOS_RESOURCE_TYPE="gcve-vsphere-project"
 
@@ -45,8 +45,10 @@ on_exit() {
   # Stop boskos heartbeat
   [[ -z ${HEART_BEAT_PID:-} ]] || kill -9 "${HEART_BEAT_PID}"
 
-  # If Boskos is being used then release the vsphere project.
-  [ -z "${BOSKOS_HOST:-}" ] || docker run -e VSPHERE_USERNAME -e VSPHERE_PASSWORD gcr.io/k8s-staging-capi-vsphere/extra/boskosctl:latest release --boskos-host="${BOSKOS_HOST}" --resource-owner="${BOSKOS_RESOURCE_OWNER}" --resource-name="${BOSKOS_RESOURCE_NAME}" --vsphere-server="${VSPHERE_SERVER}" --vsphere-tls-thumbprint="${VSPHERE_TLS_THUMBPRINT}" --vsphere-folder="${BOSKOS_RESOURCE_FOLDER}" --vsphere-resource-pool="${BOSKOS_RESOURCE_POOL}"
+  # If Boskos allocated a resource then release the vsphere project.
+  if [[ -n "${BOSKOS_HOST:-}" && -n "${BOSKOS_RESOURCE_NAME:-}" ]]; then
+    docker run -e VSPHERE_USERNAME -e VSPHERE_PASSWORD gcr.io/k8s-staging-capi-vsphere/extra/boskosctl:latest release --boskos-host="${BOSKOS_HOST}" --resource-owner="${BOSKOS_RESOURCE_OWNER}" --resource-name="${BOSKOS_RESOURCE_NAME}" --vsphere-server="${VSPHERE_SERVER:-}" --vsphere-tls-thumbprint="${VSPHERE_TLS_THUMBPRINT:-}" --vsphere-folder="${BOSKOS_RESOURCE_FOLDER:-}" --vsphere-resource-pool="${BOSKOS_RESOURCE_POOL:-}"
+  fi
 }
 
 trap on_exit EXIT
@@ -105,14 +107,22 @@ if [ -n "${BOSKOS_HOST:-}" ]; then
   # Check out the account from Boskos and store the produced environment
   # variables in a temporary file.
   account_env_var_file="$(mktemp)"
+  set +o errexit
   docker run gcr.io/k8s-staging-capi-vsphere/extra/boskosctl:latest acquire --boskos-host="${BOSKOS_HOST}" --resource-owner="${BOSKOS_RESOURCE_OWNER}" --resource-type="${BOSKOS_RESOURCE_TYPE}" 1>"${account_env_var_file}"
   checkout_account_status="${?}"
+  set -o errexit
+
+  if [ ! "${checkout_account_status}" = "0" ]; then
+    echo "error getting vsphere project from Boskos" 1>&2
+    rm -f "${account_env_var_file}"
+    exit "${checkout_account_status}"
+  fi
 
   # If the checkout process was a success then load the account's
   # environment variables into this process.
   # shellcheck disable=SC1090
-  [ "${checkout_account_status}" = "0" ] && . "${account_env_var_file}"
-  export BOSKOS_RESOURCE_NAME=${BOSKOS_RESOURCE_NAME}
+  . "${account_env_var_file}"
+  export BOSKOS_RESOURCE_NAME="${BOSKOS_RESOURCE_NAME}"
   # Drop absolute prefix because packer needs the relative path.
   export VSPHERE_FOLDER="$(echo "${BOSKOS_RESOURCE_FOLDER}" | sed "s@/${GOVC_DATACENTER}/vm/@@")"
   export VSPHERE_RESOURCE_POOL="$(echo "${BOSKOS_RESOURCE_POOL}" | sed "s@/${GOVC_DATACENTER}/host/${GOVC_CLUSTER}/Resources/@@")"
@@ -120,11 +130,6 @@ if [ -n "${BOSKOS_HOST:-}" ]; then
   # Always remove the account environment variable file. It contains
   # sensitive information.
   rm -f "${account_env_var_file}"
-
-  if [ ! "${checkout_account_status}" = "0" ]; then
-    echo "error getting vsphere project from Boskos" 1>&2
-    exit "${checkout_account_status}"
-  fi
 
   # Run the heartbeat to tell boskos periodically that we are still
   # using the checked out account.


### PR DESCRIPTION
#### What this PR does
- Makes the OVA CI cleanup trap release Boskos resources only after a resource name was acquired.
- Handles optional Prow job metadata safely under `set -u`.
- Captures Boskos acquire failures explicitly before loading the generated environment file.

#### Why
When OVA CI exits before acquiring a Boskos resource, the cleanup trap can fail on unset resource variables and obscure the original error. The trap should preserve the primary failure while still releasing resources that were actually checked out.

#### Validation
- `git -c core.fsmonitor=false diff --check`
- `bash -n images/capi/scripts/ci-ova.sh`
- `shellcheck -e SC2207,SC2155,SC2001 images/capi/scripts/ci-ova.sh`