### PR TITLE
capi: normalize crictl archive ownership

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/crictl-url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/crictl-url.yml
@@ -32,6 +32,9 @@
     remote_src: true
     src: /tmp/{{ crictl_filename }}
     dest: "{{ sysusrlocal_prefix }}/bin"
+    owner: root
+    group: root
+    mode: "0755"
     extra_opts:
       - --no-overwrite-dir
 


### PR DESCRIPTION
#### What this PR does / why we need it

Ensures the crictl binary extracted from the upstream cri-tools archive is installed as `root:root` with executable mode. The archive currently carries its build-time numeric owner, so images can end up with `/usr/local/bin/crictl` owned by that numeric UID/GID.

#### Which issue(s) this PR fixes

None

#### Testing

- `git diff --check`
- `ansible-playbook --syntax-check ansible/node.yml -e packer_build_name=qemu -e packer_builder_type=qemu -e ansible_python_interpreter=/usr/bin/python3`
