### PR TITLE
capi: import Kubernetes RPM repository key

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/azurelinux.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/azurelinux.yml
@@ -20,6 +20,12 @@
     gpgcheck: "{{ kubernetes_rpm_gpg_check }}"
     gpgkey: "{{ kubernetes_rpm_gpg_key }}"
 
+- name: Import the Kubernetes RPM repository key
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ kubernetes_rpm_gpg_key }}"
+  when: kubernetes_rpm_gpg_check | bool
+
 - name: Install Kubernetes
   ansible.builtin.dnf:
     name: "{{ packages }}"

--- a/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/redhat.yml
@@ -20,6 +20,12 @@
     gpgcheck: "{{ kubernetes_rpm_gpg_check }}"
     gpgkey: "{{ kubernetes_rpm_gpg_key }}"
 
+- name: Import the Kubernetes RPM repository key
+  ansible.builtin.rpm_key:
+    state: present
+    key: "{{ kubernetes_rpm_gpg_key }}"
+  when: kubernetes_rpm_gpg_check | bool
+
 - name: Install Kubernetes
   ansible.builtin.dnf:
     name: "{{ packages }}"


### PR DESCRIPTION
<!-- This PR is intentionally draft while CI coverage is collected. -->

## What this PR does

Imports the configured Kubernetes RPM repository key with `ansible.builtin.rpm_key` before installing Kubernetes packages on RPM-based images.

## Why

Some RPM builds can fail package signature validation even when the repository file contains `gpgkey=`. Importing the key explicitly makes the package install path deterministic while keeping GPG checks enabled.

## Validation

- `git diff --check`
- `cd images/capi && ansible-playbook --syntax-check -i localhost, ansible/node.yml -e packer_builder_type=azure-arm -e kubernetes_rpm_gpg_check=True -e kubernetes_rpm_gpg_key=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/repodata/repomd.xml.key -e kubernetes_rpm_repo=https://pkgs.k8s.io/core:/stable:/v1.36/rpm/ -e kubernetes_rpm_version=1.36.1 -e kubernetes_cni_rpm_version= -e kubernetes_source_type=pkg -e kubernetes_cni_source_type=pkg`
