### PR TITLE
Bump containerd to 2.3.2 and runc to 1.4.3

### DIFF
--- a/images/capi/ansible/roles/containerd/defaults/main.yml
+++ b/images/capi/ansible/roles/containerd/defaults/main.yml
@@ -20,5 +20,5 @@ containerd_baseurl: https://github.com/containerd/containerd/releases/download/v
 containerd_filename: "containerd-{{ containerd_version }}-{{ system }}-{{ arch }}.tar.gz"
 containerd_url: "{{ containerd_baseurl }}/{{ containerd_filename }}"
 containerd_runc_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.{{ arch }}"
-runc_version: "1.4.2"
+runc_version: "1.4.3"
 containerd_runc_checksum_url: "https://github.com/opencontainers/runc/releases/download/v{{ runc_version }}/runc.sha256sum"

--- a/images/capi/packer/config/containerd.json
+++ b/images/capi/packer/config/containerd.json
@@ -5,6 +5,6 @@
   "containerd_gvisor_runtime": "false",
   "containerd_gvisor_version": "latest",
   "containerd_image_pull_progress_timeout": null,
-  "containerd_version": "2.3.1",
-  "runc_version": "1.4.2"
+  "containerd_version": "2.3.2",
+  "runc_version": "1.4.3"
 }

--- a/images/capi/packer/config/ppc64le/containerd.json
+++ b/images/capi/packer/config/ppc64le/containerd.json
@@ -1,5 +1,5 @@
 {
   "containerd_image_pull_progress_timeout": null,
-  "containerd_sha256": "cb5bcdb38c79fb78dc7b4e7c02d0c0e41b486446f646a49ed7e6c35c077d8d33",
-  "containerd_version": "2.3.1"
+  "containerd_sha256": "bf562d89874b2850b0aaa9934135f297b4a0b028312aa5f46d1871b3f907fb0c",
+  "containerd_version": "2.3.2"
 }


### PR DESCRIPTION
## Change description

Bumps containerd from 2.3.1 to 2.3.2 and runc from 1.4.2 to 1.4.3.

containerd 2.3.2 fixes CVE-2026-53488 (CVSS 9.4): the CRI plugin
propagated image config labels (Dockerfile `LABEL`) to containers without
validation, allowing a crafted image to trigger arbitrary command
execution as root during a normal image pull.

runc is bumped to 1.4.3 to match the version vendored by containerd
2.3.2 (also fixes CVE-2026-41579).

Updated the ppc64le containerd config with the 2.3.2 tarball sha256.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

N/A

## Additional context

- https://github.com/containerd/containerd/releases/tag/v2.3.2
- https://github.com/opencontainers/runc/releases/tag/v1.4.3