### PR TITLE
capi: extend Azure credential provider download timeout

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -99,9 +99,11 @@
     url: https://github.com/kubernetes-sigs/cloud-provider-azure/releases/latest/download/azure-acr-credential-provider-linux-amd64
     dest: /var/lib/kubelet/credential-provider/acr-credential-provider
     mode: "0755"
+    timeout: 120
 
 - name: Download OOT credential provider config file
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/examples/out-of-tree/credential-provider-config.yaml
     dest: /var/lib/kubelet/credential-provider-config.yaml
     mode: "0644"
+    timeout: 120

--- a/images/capi/ansible/windows/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/windows/roles/providers/tasks/azure.yml
@@ -74,6 +74,7 @@
   ansible.windows.win_get_url:
     url: https://github.com/kubernetes-sigs/cloud-provider-azure/releases/latest/download/azure-acr-credential-provider-windows-amd64.exe
     dest: C:\var\lib\kubelet\credential-provider\acr-credential-provider.exe
+    url_timeout: 120
 
 # It is a workaround for K8s < 1.30.
 # Detail: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/4533
@@ -84,3 +85,4 @@
   ansible.windows.win_get_url:
     url: https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/examples/out-of-tree/credential-provider-config-win.yaml
     dest: C:\var\lib\kubelet\credential-provider-config.yaml
+    url_timeout: 120


### PR DESCRIPTION
## Summary
- extend Azure credential-provider binary and config download timeouts to 120 seconds
- cover both Linux and Windows Azure provider tasks
- reduce transient Azure SIG build failures when GitHub reads are slow

## Validation
- git diff --check
- ansible-lint --project-dir . ansible/windows/roles/providers/tasks/azure.yml
- ansible-lint --project-dir . ansible/ (local ansible-lint 26.4 reports existing repo-wide var-naming failures unrelated to this patch)
