### PR TITLE
Fix Windows Azure OSProvisioningTimedOut on sysprep

### DIFF
--- a/images/capi/packer/azure/scripts/sysprep.ps1
+++ b/images/capi/packer/azure/scripts/sysprep.ps1
@@ -25,6 +25,14 @@ if ($telemetryService) {
 }
 Write-Output '>>> Waiting for GA Service (WindowsAzureGuestAgent) to start ...'
 while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }
+# Sysprep leaves the built-in Administrator flagged "must change password at next
+# logon", which hangs Azure first-boot OOBE and causes intermittent
+# OSProvisioningTimedOut. Disable it (its normal Azure state) and stop the packer
+# user's password expiring during a slow validation.
+Write-Output '>>> Preparing built-in accounts for generalize ...'
+net accounts /maxpwage:unlimited
+Disable-LocalUser -Name Administrator -ErrorAction SilentlyContinue
+
 Write-Output '>>> Sysprepping VM ...'
 if( Test-Path $Env:SystemRoot\system32\Sysprep\unattend.xml ) {
   Remove-Item $Env:SystemRoot\system32\Sysprep\unattend.xml -Force


### PR DESCRIPTION
Windows Azure images built by image-builder intermittently fail to provision with `OSProvisioningTimedOut`. After `sysprep /generalize`, the built-in Administrator is left flagged "user must change password at next logon", so on first boot the OOBE auto-logon blocks on the LogonUI password-change dialog and cloudbase-init never signals provisioning-ready. Because it is a timing race, the same image sometimes provisions and sometimes times out.

This disables the built-in Administrator (its normal state on Azure; cloudbase-init creates and renames the real admin in the post-OOBE phase) and sets max password age to unlimited so the packer build user credential cannot expire during a slow validation. Verified against Windows Server 2022 and 2025 builds.