### PR TITLE
capi: fix swap removal in qemu Ubuntu autoinstall templates

### DIFF
--- a/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi.qemu/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi.qemu/user-data.tmpl
@@ -101,8 +101,8 @@ autoinstall:
   late-commands:
     - apt install -y efibootmgr
     - efibootmgr -o $(efibootmgr | grep -oP 'Boot[0-9]+[*]\s+ubuntu' | grep -oP '000[0-9]+' | head -n 1)
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/22.04.efi/user-data.tmpl
@@ -99,8 +99,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/22.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/22.04/user-data.tmpl
@@ -79,8 +79,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/23.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/23.04/user-data.tmpl
@@ -86,8 +86,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/24.04.efi/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/24.04.efi/user-data.tmpl
@@ -109,8 +109,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/24.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/24.04/user-data.tmpl
@@ -86,8 +86,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/26.04.efi/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/26.04.efi/user-data.tmpl
@@ -109,8 +109,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean

--- a/images/capi/packer/qemu/linux/ubuntu/http/26.04/user-data.tmpl
+++ b/images/capi/packer/qemu/linux/ubuntu/http/26.04/user-data.tmpl
@@ -86,8 +86,8 @@ autoinstall:
   # 4. Cleans up any packages that are no longer required
   # 5. Removes the cached list of packages
   late-commands:
-    - swapoff -a
-    - rm -f /swapfile
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - apt-get purge --auto-remove -y
-    - rm -rf /var/lib/apt/lists/*
+    - curtin in-target --target=/target -- swapoff -a
+    - curtin in-target --target=/target -- rm -f /swap.img
+    - curtin in-target --target=/target -- sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+    - curtin in-target --target=/target -- apt-get purge --auto-remove -y
+    - curtin in-target --target=/target -- apt-get clean


### PR DESCRIPTION
## Change description

qemu autoinstall user-data tries to disable and remove the swap file via late-commands, but they seem to not work correctly.

- no `curtin in-target` wrapper (like for raw)
- remove `/swapfile` but the file to be removed is at `/swap.img`

This change mirrors the config already in place for the raw Ubuntu templates.


- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) n
- If adding a new provider, are you a representative of that provider? (y/n) n

## Related issues

--

## Additional context

Was currently masked by Ansible `node` role which also disables swap and `sysprep` role deleting `/swap.img` and `/swapfile`. 
