### PR TITLE
🚑 Add LimitNOFILE=1048576 configuration to all OS families

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -154,7 +154,6 @@
     dest: /etc/systemd/system/containerd.service.d/limit-nofile.conf
     src: etc/systemd/system/containerd.service.d/limit-nofile.conf
     mode: "0644"
-  when: ansible_os_family in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux"]
 
 - name: Create containerd http proxy conf file if needed
   ansible.builtin.template:


### PR DESCRIPTION
ContainerD V2 removed LimitNOFILE from his service. It is a regression because now the value is defined as 1024.

It is a problem because it breaks a lot of apps like (mysql/.net/kafka/s3)

We remove this "when" condition, so the limit-nofile.conf will be propagated to every OS.

It will not impact other distributions because the goal of this "when" condition was to remove "LimitNOFILE=infinity"

This value "1048576" was already defined in containerd.service upstream.

<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) no
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) no
- If adding a new provider, are you a representative of that provider? (y/n) no

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #2121 


Linked to : https://github.com/kubernetes-sigs/image-builder/pull/1720