### PR TITLE
Remove dead Azure Linux 2 (CBL-Mariner) references

### DIFF
--- a/docs/book/src/capi/containerd/customizing-containerd.md
+++ b/docs/book/src/capi/containerd/customizing-containerd.md
@@ -88,7 +88,7 @@ default template.
 ## Overriding `LimitNOFILE`
 
 By default a `LimitNOFILE` systemd drop-in (capping the value at `1048576`) is only deployed on
-Common Base Linux Mariner, Flatcar, and Microsoft Azure Linux, where the upstream `infinity` value
+Flatcar and Microsoft Azure Linux, where the upstream `infinity` value
 has been known to cause issues with some containerized software. To opt-in to deploying the same
 drop-in on other operating systems, set `containerd_enable_limit_no_file` to `true`. It defaults to
 `false`.

--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Import RedHat containerd tasks
   ansible.builtin.import_tasks: redhat.yml
-  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux", "RedHat"]
+  when: ansible_facts['os_family'] in ["Microsoft Azure Linux", "RedHat"]
 
 - name: Import Photon containerd tasks
   ansible.builtin.import_tasks: photon.yml
@@ -157,7 +157,7 @@
     dest: /etc/systemd/system/containerd.service.d/limit-nofile.conf
     src: etc/systemd/system/containerd.service.d/limit-nofile.conf
     mode: "0644"
-  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux"] or containerd_enable_limit_no_file | bool
+  when: ansible_facts['os_family'] in ["Flatcar", "Microsoft Azure Linux"] or containerd_enable_limit_no_file | bool
 
 - name: Create containerd http proxy conf file if needed
   ansible.builtin.template:

--- a/images/capi/ansible/roles/kubernetes/tasks/main.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Import Azure Linux Kubernetes tasks
   ansible.builtin.import_tasks: azurelinux.yml
-  when: kubernetes_source_type == "pkg" and ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: kubernetes_source_type == "pkg" and ansible_facts['os_family'] in ["Microsoft Azure Linux"]
 
 - name: Import RedHat Kubernetes tasks
   ansible.builtin.import_tasks: redhat.yml

--- a/images/capi/ansible/roles/node/defaults/main.yml
+++ b/images/capi/ansible/roles/node/defaults/main.yml
@@ -123,7 +123,7 @@ common_raw_photon_rpms: []
 # photon and flatcar do not have backward compatibility for legacy distro behavior for sysctl.conf by default
 # as it uses systemd-sysctl. set this var so we can use for sysctl conf file value.
 sysctl_conf_file: >-
-  {{ '/etc/sysctl.d/99-sysctl.conf' if ansible_facts['os_family'] in ['Common Base Linux Mariner', 'Flatcar', 'Microsoft Azure Linux', 'VMware Photon OS']
+  {{ '/etc/sysctl.d/99-sysctl.conf' if ansible_facts['os_family'] in ['Flatcar', 'Microsoft Azure Linux', 'VMware Photon OS']
     or (ansible_facts['distribution'] == 'Ubuntu' and (ansible_facts['distribution_major_version'] | int) >= 26)
     else '/etc/sysctl.conf' }}
 

--- a/images/capi/ansible/roles/node/meta/main.yml
+++ b/images/capi/ansible/roles/node/meta/main.yml
@@ -53,4 +53,4 @@ dependencies:
   - role: setup
     vars:
       rpms: "{{ common_rpms + azurelinux_rpms + lookup('vars', 'common_' + build_target + '_rpms') }}"
-    when: ansible_facts['distribution'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+    when: ansible_facts['distribution'] in ["Microsoft Azure Linux"]

--- a/images/capi/ansible/roles/node/tasks/main.yml
+++ b/images/capi/ansible/roles/node/tasks/main.yml
@@ -89,7 +89,7 @@
     name: conntrackd
     state: stopped
     enabled: false
-  when: ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Debian", "Flatcar", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] not in ["Debian", "Flatcar", "Microsoft Azure Linux"]
 
 - name: Ensure auditd is running and comes on at reboot
   ansible.builtin.service:

--- a/images/capi/ansible/roles/providers/tasks/azurecli.yml
+++ b/images/capi/ansible/roles/providers/tasks/azurecli.yml
@@ -81,7 +81,7 @@
         state: present
 
 - name: Install Azure CLI
-  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Microsoft Azure Linux"]
   ansible.builtin.package:
     name: azure-cli
     state: present

--- a/images/capi/ansible/roles/setup/tasks/main.yml
+++ b/images/capi/ansible/roles/setup/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Import Azure Linux setup tasks
   ansible.builtin.include_tasks: azurelinux.yml
-  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Microsoft Azure Linux"]
 
 - name: Import RedHat setup tasks
   ansible.builtin.include_tasks: redhat.yml

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -56,7 +56,7 @@
   loop:
     - { path: /etc/machine-id, state: absent, mode: "{{ machine_id_mode }}" }
     - { path: /etc/machine-id, state: touch, mode: "{{ machine_id_mode }}" }
-  when: ansible_facts['os_family'] not in ["Flatcar", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] not in ["Flatcar"]
 
 - name: Truncate hostname file
   ansible.builtin.file:

--- a/images/capi/ansible/roles/sysprep/tasks/main.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - name: Import Azure Linux sysprep tasks
   ansible.builtin.import_tasks: azurelinux.yml
-  when: ansible_facts['os_family'] in ["Common Base Linux Mariner", "Microsoft Azure Linux"]
+  when: ansible_facts['os_family'] in ["Microsoft Azure Linux"]
 
 - name: Import Photon sysprep tasks
   ansible.builtin.import_tasks: photon.yml
@@ -56,7 +56,7 @@
   loop:
     - { path: /etc/machine-id, state: absent, mode: "{{ machine_id_mode }}" }
     - { path: /etc/machine-id, state: touch, mode: "{{ machine_id_mode }}" }
-  when: ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linuz"]
+  when: ansible_facts['os_family'] not in ["Flatcar", "Microsoft Azure Linux"]
 
 - name: Truncate hostname file
   ansible.builtin.file:
@@ -73,7 +73,7 @@
   ansible.builtin.hostname:
     name: localhost.local
   when: >
-    ansible_facts['os_family'] not in ["Common Base Linux Mariner", "Flatcar", "Microsoft Azure Linux", "VMware Photon OS"]
+    ansible_facts['os_family'] not in ["Flatcar", "Microsoft Azure Linux", "VMware Photon OS"]
     and packer_build_name != "nutanix"
 
 - name: Reset hosts file

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -248,11 +248,6 @@ azurelinux:
   azure:
     package:
       open-vm-tools:
-mariner:
-  common-package: *common_azurelinux_rpms
-  azure:
-    package:
-      open-vm-tools:
 rockylinux:
   common-package: *common_rpms
   amazon:


### PR DESCRIPTION
Azure Linux 2 / CBL-Mariner reached end of support in November 2025 and is no longer a build target. This drops the stale `Common Base Linux Mariner` os_family/distribution conditionals and the unused `mariner` goss-vars block.

The `MicrosoftCBLMariner` marketplace publisher is preserved, since that is still the publisher for Azure Linux 3 images.

Also fixes a `Microsoft Azure Linuz` typo in `sysprep` that silently excluded AL3 from the machine-id reset.

Broken out from #2014 to keep that PR focused on the Azure Linux 4 target.