### PR TITLE
capi: retry Azure Linux tdnf installs on transient mirror failures

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/azurelinux.yml
+++ b/images/capi/ansible/roles/setup/tasks/azurelinux.yml
@@ -20,15 +20,27 @@
     name: "*"
     state: latest
     lock_timeout: 60
+  register: dnf_lock_status
+  until: dnf_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: Install baseline dependencies on Azure Linux
   ansible.builtin.dnf:
     name: "{{ rpms }}"
     state: present
     lock_timeout: 60
+  register: dnf_lock_status
+  until: dnf_lock_status is not failed
+  retries: 5
+  delay: 10
 
 - name: Install extra rpms
   ansible.builtin.dnf:
     name: "{{ extra_rpms.split() }}"
     state: present
     lock_timeout: 60
+  register: dnf_lock_status
+  until: dnf_lock_status is not failed
+  retries: 5
+  delay: 10


### PR DESCRIPTION
## What this does

`pull-azure-sigs` has repeatedly failed on Azure Linux 3 targets with errors like:

```
fatal: [default]: FAILED! => {"msg": "Failed to download packages: socat-1.7.4.4-2.azl3.x86_64: Cannot download, all mirrors were already tried without success"}
```

These are transient tdnf mirror availability issues, unrelated to the packages being installed (seen with `socat`, `libmspack`, `lsof` across different unrelated PRs/builds).

`debian.yml`, `redhat.yml`, and the `gpu` role tasks already retry their package-manager calls with `register`/`until`/`retries`/`delay` for exactly this class of transient failure. This applies the same pattern to the Azure Linux `dnf` (tdnf) update and install tasks in the `setup` role.

## Related issues

None filed yet — this flake affects `pull-azure-sigs` on unrelated PRs (Azure Linux mirror download failures for baseline OS packages), not a specific reported issue.

## Testing

- `ansible-lint --project-dir . ansible/roles/setup/tasks/azurelinux.yml` (ansible-lint 25.2.0, matching CI's pinned version) — no new violations
- `python3 -c "import yaml; yaml.safe_load(open('ansible/roles/setup/tasks/azurelinux.yml'))"` — valid YAML
