### PR TITLE
capi: retry Azure SIG builds on transient replication storage errors

### DIFF
--- a/images/capi/scripts/ci-azure-e2e.sh
+++ b/images/capi/scripts/ci-azure-e2e.sh
@@ -128,7 +128,25 @@ run_sig_target() {
     mkdir -p "${AZURE_CONFIG_DIR}"
 
     login
-    make "build-azure-sig-${target}"
+
+    # Shared Image Gallery replication occasionally fails with a transient
+    # storage allocation error in the target region. Retry a couple of times
+    # before giving up, since re-running the same build usually succeeds.
+    local attempt attempt_log
+    attempt_log="$(mktemp)"
+    for attempt in 1 2 3; do
+      if make "build-azure-sig-${target}" 2>&1 | tee "${attempt_log}"; then
+        rm -f "${attempt_log}"
+        return 0
+      fi
+      if ! grep -q "Storage allocation failure" "${attempt_log}"; then
+        rm -f "${attempt_log}"
+        return 1
+      fi
+      echo "build-azure-sig-${target}: retrying after transient SIG replication storage allocation failure (attempt ${attempt}/3)"
+    done
+    rm -f "${attempt_log}"
+    return 1
 }
 
 declare -A PIDS


### PR DESCRIPTION
## What this does

`pull-azure-sigs` has failed with:

```
==> azure-arm.sig-ubuntu-2204-cvm: ERROR: -> InternalOperationError : Replication failed in this region due to 'Some storage account(s) had not been created, all will be cleaned up. Failure count: 1, Storage allocation failure'.
```

This is a transient Azure Shared Image Gallery replication error in the target region, unrelated to the image content of any target — the underlying build/provisioning had already succeeded before the SIG publish step failed.

This retries `make build-azure-sig-<target>` up to 3 times specifically when the failure output matches this known transient "Storage allocation failure" error, since re-running the same build normally succeeds. Any other failure still surfaces immediately on the first attempt, so this does not mask genuine build regressions.

## Related issues

None filed yet — searched existing open/closed issues for Azure SIG replication/storage-allocation failures and found no existing tracking issue for this specific error (related but distinct flakes are tracked in #1656 for `az login` auth failures, and closed issues #766/#1355 for `az cli` install flakiness).

## Testing

- `bash -n scripts/ci-azure-e2e.sh` — syntax OK
- `shellcheck -x scripts/ci-azure-e2e.sh` — no new warnings introduced by this change (pre-existing SC2207/SC2155/SC1091/SC2086 notes on unrelated lines only)
- `git diff --check` — clean
