### PR TITLE
capi: retry apt Kubernetes package install on dpkg lock contention

### DIFF
--- a/images/capi/ansible/roles/kubernetes/tasks/debian.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/debian.yml
@@ -39,3 +39,7 @@
       - kubeadm={{ kubernetes_deb_version }}
       - kubectl={{ kubernetes_deb_version }}
       - kubernetes-cni{{ '=' + kubernetes_cni_deb_version if kubernetes_cni_deb_version else '' }}
+  register: apt_lock_status
+  until: apt_lock_status is not failed
+  retries: 5
+  delay: 10


### PR DESCRIPTION
## What this does

\`pull-azure-sigs\` failed on \`sig-ubuntu-2204-cvm\` with:

\`\`\`
fatal: [default]: FAILED! => {"msg": "'/usr/bin/apt-get -y ... install 'kubelet=1.36.1-1.1' 'kubeadm=1.36.1-1.1' 'kubectl=1.36.1-1.1' 'kubernetes-cni=1.9.1-1.1' --allow-downgrades' failed: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 8229 (apt)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?\n"}
```

This is a transient dpkg lock contention issue, most likely a background \`unattended-upgrades\` or cloud-init apt process racing the kubelet/kubeadm/kubectl/kubernetes-cni install. \`ansible/roles/setup/tasks/debian.yml\` and the \`gpu\` role already retry their apt calls with \`until\`/\`retries\`/\`delay\` for this exact class of failure; this applies the same pattern to the Kubernetes package install task.

## Related issues

None filed yet — searched for existing open issues tracking dpkg lock-frontend contention during the Kubernetes package install step and found none currently open.

## Testing

- \`ansible-lint --project-dir . ansible/roles/kubernetes/tasks/debian.yml\` (ansible-lint 25.2.0, matching CI's pinned version) — 0 failures, 0 warnings
- \`python3 -c "import yaml; yaml.safe_load(open('ansible/roles/kubernetes/tasks/debian.yml'))"\` — valid YAML