### PR TITLE
Add AlmaLinux 9 AMI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The table below shows the currently provided operating systems for each provider
 
 | OS                | ami | azure | digitalocean | gce | hcloud | huaweicloud | maas | nutanix | oci | openstack | outscale | ova | oxide | powervs | proxmox | qemu | raw | scaleway | vultr |
 |-------------------|----|----|----|----|----|----|----|----|----|----|---|----|----|----|----|----|----|----|----|
-| AlmaLinux 9       | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| AlmaLinux 9       | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Amazon Linux 2    | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Amazon Linux 2023 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Azure Linux 3     | ❌ | 💙 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |

--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -393,7 +393,7 @@ NODE_OVA_VSPHERE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-,$(PLATFORMS_AND_V
 NODE_OVA_VSPHERE_BASE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-base-,$(PLATFORMS_AND_VERSIONS))
 NODE_OVA_VSPHERE_CLONE_BUILD_NAMES		:=	$(addprefix node-ova-vsphere-clone-,$(PLATFORMS_AND_VERSIONS))
 
-AMI_BUILD_NAMES			   ?= ami-ubuntu-2204 ami-ubuntu-2404 ami-ubuntu-2604 ami-ubuntu-2204-arm64 ami-ubuntu-2404-arm64 ami-amazon-2 ami-amazon-2023 ami-amazon-2023-arm64 ami-flatcar ami-flatcar-arm64 ami-windows-2019
+AMI_BUILD_NAMES			   ?= ami-ubuntu-2204 ami-ubuntu-2404 ami-ubuntu-2604 ami-ubuntu-2204-arm64 ami-ubuntu-2404-arm64 ami-almalinux-9 ami-amazon-2 ami-amazon-2023 ami-amazon-2023-arm64 ami-flatcar ami-flatcar-arm64 ami-windows-2019
 HUAWEICLOUD_BUILD_NAMES ?= huaweicloud-ubuntu-2204
 GCE_BUILD_NAMES			   ?= gce-ubuntu-2204 gce-ubuntu-2404 gce-ubuntu-2604
 
@@ -741,6 +741,7 @@ $(RAW_CLEAN_TARGETS):
 ## Document dynamic build targets
 ## --------------------------------------
 ##@ Builds
+build-ami-almalinux-9: ## Builds AlmaLinux 9 AMI
 build-ami-amazon-2: ## Builds Amazon-2 Linux AMI
 build-ami-amazon-2023: ## Builds Amazon-2023 Linux AMI
 build-ami-amazon-2023-arm64: ## Builds Amazon-2023 Linux arm64 AMI
@@ -944,6 +945,7 @@ build-scaleway-all: $(SCALEWAY_BUILD_TARGETS) ## Builds all Scaleway images
 ## Document dynamic validate targets
 ## --------------------------------------
 ##@ Validate packer config
+validate-ami-almalinux-9: ## Validates AlmaLinux 9 AMI Packer config
 validate-ami-amazon-2: ## Validates Amazon-2 Linux AMI Packer config
 validate-ami-amazon-2023: ## Validates Amazon-2023 Linux AMI Packer config
 validate-ami-amazon-2023-arm64: ## Validates Amazon-2023 Linux arm64 AMI Packer config

--- a/images/capi/ansible/roles/providers/tasks/awscliv2.yml
+++ b/images/capi/ansible/roles/providers/tasks/awscliv2.yml
@@ -18,10 +18,10 @@
 - name: Install AWS CLI prequisites
   ansible.builtin.dnf:
     name:
-      - gnupg
+      - gnupg2
       - unzip
     state: present
-  when: ansible_facts['distribution'] == "RedHat"
+  when: ansible_facts['os_family'] == "RedHat"
 
 - name: Install AWS CLI prerequisites
   ansible.builtin.apt:

--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
+++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
@@ -30,26 +30,26 @@
   ansible.builtin.command: amazon-linux-extras enable epel
   args:
     creates: /etc/yum.repos.d/epel.repo
-  when: packer_builder_type.startswith('amazon')
+  when: packer_builder_type.startswith('amazon') and ansible_facts['distribution'] == "Amazon"
 
 - name: Install EPEL package
   ansible.builtin.dnf:
     name: epel-release
     state: present
-  when: packer_builder_type.startswith('amazon')
+  when: packer_builder_type.startswith('amazon') and ansible_facts['distribution'] == "Amazon"
 
 - name: Import epel gpg key
   ansible.builtin.rpm_key:
     state: present
     key: "{{ epel_rpm_gpg_key }}"
-  when: epel_rpm_gpg_key != "" and not packer_builder_type.startswith('amazon') and not packer_builder_type.startswith('scaleway')
+  when: epel_rpm_gpg_key != "" and ansible_facts['distribution'] != "Amazon" and not packer_builder_type.startswith('scaleway')
 
 - name: Add epel repo
   ansible.builtin.dnf:
     name: "{{ redhat_epel_rpm }}"
     state: present
     lock_timeout: 60
-  when: redhat_epel_rpm != "" and not packer_builder_type.startswith('amazon') and not packer_builder_type.startswith('scaleway')
+  when: redhat_epel_rpm != "" and ansible_facts['distribution'] != "Amazon" and not packer_builder_type.startswith('scaleway')
 
 - name: Import RPM repository tasks
   ansible.builtin.import_tasks: rpm_repos.yml

--- a/images/capi/packer/ami/almalinux-9.json
+++ b/images/capi/packer/ami/almalinux-9.json
@@ -1,0 +1,16 @@
+{
+  "ami_filter_arch": "x86_64",
+  "ami_filter_name": "AlmaLinux OS 9.* x86_64",
+  "ami_filter_owners": "764336703387",
+  "arch": "amd64",
+  "build_name": "almalinux-9",
+  "distribution": "AlmaLinux",
+  "distribution_release": "AlmaLinux 9",
+  "distribution_version": "9",
+  "distro_version": "9",
+  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
+  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+  "root_device_name": "/dev/sda1",
+  "source_ami": "",
+  "ssh_username": "ec2-user"
+}

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -182,6 +182,22 @@ centos:
       cloud-utils-growpart:
 almalinux:
   common-package: *common_rpms
+  amazon:
+    package:
+      amazon-ssm-agent:
+    command:
+      /usr/local/sbin/aws --version:
+        exit-status: 0
+        stderr: []
+        timeout: 0
+    service:
+      amazon-ssm-agent:
+        enabled: true
+        running: true
+    os_version:
+    - distro_version: "9"
+      package:
+        <<: *rh9_rpms
   ova:
     package:
       open-vm-tools:


### PR DESCRIPTION
## Change description
<!-- What this PR does / why we need it. -->
Adds support for building AlmaLinux 9 AMI. I did this previously for OVA at https://github.com/kubernetes-sigs/image-builder/pull/1946

New `packer/ami/almalinux-9.json` sources the AlmaLinux OS Foundation's official images (owner `764336703387`).

AlmaLinux is the first non-Amazon distro to use the `amazon-ebs` builder, which surfaced three places where existing code used "which Packer builder ran" as a proxy for "which OS is this". Each needed a targeted condition fix:

- **`setup/tasks/redhat.yml`**: EPEL tasks were gated on `packer_builder_type.startswith('amazon')`. On AlmaLinux that runs `amazon-linux-extras` (an Amazon Linux 2 tool) and skips the generic `redhat_epel_rpm` path. Now keyed on `ansible_facts['distribution']`. EPEL is required here: `python3-netifaces` from `rh8_rpms` is in neither AlmaLinux 9 BaseOS nor AppStream.
- **`providers/tasks/awscliv2.yml`**: prerequisites were gated on `distribution == "RedHat"` (strictly RHEL), so AlmaLinux skipped them and the following `gpg --import`/unzip steps failed. Widened to `os_family`, and `gnupg` → `gnupg2` (EL8/EL9 have no `gnupg` package). This task was previously unreachable, which is why the wrong package name went unnoticed.
- **`packer/goss/goss-vars.yaml`**: `almalinux` had no `amazon` section, so `index .Vars .Vars.OS .Vars.PROVIDER` returned nil and the goss templates errored after provisioning completed. Added, mirroring `rockylinux.amazon`.

**No behavior change to existing builds.** `amazon-ebs` is the only builder starting with `amazon`, and Amazon Linux is built only under `packer/ami/`, so the old and new conditions are truth-table identical for every current distro/provider combination.

- Is this change including a new Provider or a new OS? (y/n) y
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) y
- If adding a new provider, are you a representative of that provider? (y/n) -


## Additional context

This work was verified with a real build in an AWS account I manage:
- `make validate-ami-almalinux-9` → `The configuration is valid.`
- `make build-ami-almalinux-9` → succeeded
- Ansible: `ok=115 changed=82 unreachable=0 failed=0`
- goss: `Count: 55, Failed: 0, Skipped: 0`

I'm still new to image-builder, and I did this with Claude assistance! I'd appreciate guidance from maintainers on any changes needed to make this mergeable.

Happy to iterate on feedback. Thanks for your time!

/kind feature