### PR TITLE
maas: unpin kernel, grub and initramfs packages

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -59,10 +59,10 @@
   retries: 30
   delay: 10
 
-- name: Unpin grub packages with apt-mark for MaaS
+- name: Unpin packages with apt-mark for MaaS
   ansible.builtin.shell: |
     set -o pipefail
-    dpkg-query -f '${binary:Package}\n' -W | grep grub | xargs apt-mark unhold
+    dpkg-query -f '${binary:Package}\n' -W | grep -E '^linux-|^grub|^initramfs' | xargs apt-mark unhold
 
   args:
     executable: /bin/bash


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
The sysprep role previously removed apt holds only from grub packages.
Images that also hold linux-* or initramfs packages can fail during MAAS installation because apt is unable to upgrade kernel dependencies.

Expand the unhold pattern to include linux-* and initramfs packages.


<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? N
- If yes, has the Provider/OS matrix been updated in the readme? N/A
- If adding a new provider, are you a representative of that provider? N/A

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->


## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
This change prevents deployment failures such as the following:
(curtin logs)
```
[...]
        Running command ['unshare', '--fork', '--pid', '--', 'chroot', '/tmp/tmp5wb3dkby/target', 'apt-get', '--quiet', '--assume-yes', '--option=Dpkg::options::=--force-unsafe-io', '--option=Dpkg::Options::=--force-confold', 'install', '--download-only', 'linux-generic'] with allowed return codes [0] (capture=False)
        Reading package lists...
        Building dependency tree...
        Reading state information...
        Some packages could not be installed. This may mean that you have
        requested an impossible situation or if you are using the unstable
        distribution that some required packages have not yet been created
        or been moved out of Incoming.
        The following information may help to resolve the situation:
        
        The following packages have unmet dependencies:
         linux-generic : Depends: linux-image-generic (= 5.15.0.187.167) but 5.15.0.186.166 is to be installed
                         Depends: linux-headers-generic (= 5.15.0.187.167) but 5.15.0.186.166 is to be installed
        E: Unable to correct problems, you have held broken packages.
[...]
        Command: ['unshare', '--fork', '--pid', '--', 'chroot', '/tmp/tmp5wb3dkby/target', 'apt-get', '--quiet', '--assume-yes', '--option=Dpkg::options::=--force-unsafe-io', '--option=Dpkg::Options::=--force-confold', 'install', '--download-only', 'linux-generic']
        Exit code: 100
        Reason: -
        Stdout: ''
        Stderr: ''
        Unexpected error while running command.
        Command: ['unshare', '--fork', '--pid', '--', 'chroot', '/tmp/tmp5wb3dkby/target', 'apt-get', '--quiet', '--assume-yes', '--option=Dpkg::options::=--force-unsafe-io', '--option=Dpkg::Options::=--force-confold', 'install', '--download-only', 'linux-generic']
        Exit code: 100
        Reason: -
        Stdout: ''
        Stderr: ''
```