### PR TITLE
maas: avoid packaging EFI system partition in rootfs tarball

### DIFF
--- a/images/capi/packer/maas/scripts/generate-maas-image.sh
+++ b/images/capi/packer/maas/scripts/generate-maas-image.sh
@@ -28,7 +28,7 @@ echo "mounting image..."
 mount /dev/nbd4p2 $TMP_DIR
 mount "/dev/nbd4p1" "$TMP_DIR/boot/efi"
 echo 'Tarring up image...'
-tar -Sczpf $BASE_PATH/$IMAGE_NAME.tar.gz --acls --selinux --xattrs -C $TMP_DIR  .
+tar -Sczpf $BASE_PATH/$IMAGE_NAME.tar.gz --exclude='./boot/efi/*' --exclude='./boot/efi' --acls --selinux --xattrs -C $TMP_DIR  .
 echo 'Unmounting image...'
 umount "$TMP_DIR/boot/efi"
 umount $TMP_DIR


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
The EFI System Partition is recreated during MAAS deployment and
should not be included in the generated rootfs tarball.

Exclude /boot/efi from the archive to avoid carrying EFI partition
contents into the deployed root filesystem.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) No
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) No
- If adding a new provider, are you a representative of that provider? (y/n) No

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
This change prevents deployment failures such as the following:
(curtin logs)
```
[...]
tar: ./boot/efi/EFI/ubuntu/grubx64.efi: Cannot change ownership to uid 0, gid 1000: Operation not permitted
..... ...tar: ./boot/efi/EFI/ubuntu/shimx64.efi: Cannot change ownership to uid 0, gid 1000: Operation not permitted
....tar: ./boot/efi/EFI/ubuntu/mmx64.efi: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/EFI/ubuntu/BOOTX64.CSV: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/EFI/ubuntu/grub.cfg: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/EFI/ubuntu: Cannot change ownership to uid 0, gid 1000: Operation not permitted
. .......tar: ./boot/efi/EFI/BOOT/BOOTX64.EFI: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/EFI/BOOT/fbx64.efi: Cannot change ownership to uid 0, gid 1000: Operation not permitted
. ...tar: ./boot/efi/EFI/BOOT/mmx64.efi: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/EFI/BOOT: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/EFI: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi/NvVars: Cannot change ownership to uid 0, gid 1000: Operation not permitted
tar: ./boot/efi: Cannot change ownership to uid 0, gid 1000: Operation not permitted
[...]
        tar: Exiting with failure status due to previous errors
        finish: cmd-install/stage-extract/builtin/cmd-extract: FAIL: acquiring and extracting image from http://10.107.123.10:5248/images/d7f4ba7/custom/amd64/generic/tks-image/uploaded/root.tgz
        finish: cmd-install/stage-extract/builtin/cmd-extract: FAIL: curtin command extract
        Traceback (most recent call last):
          File "/curtin/curtin/commands/main.py", line 202, in main
            ret = args.func(args)
          File "/curtin/curtin/commands/extract.py", line 258, in extract
            extract_source(source, target)
          File "/curtin/curtin/commands/extract.py", line 211, in extract_source
            extract_root_tgz_url(source['uri'], target=target)
          File "/curtin/curtin/commands/extract.py", line 58, in extract_root_tgz_url
            util.subp(args=['sh', '-cf',
          File "/curtin/curtin/util.py", line 280, in subp
            return _subp(*args, **kwargs)
          File "/curtin/curtin/util.py", line 144, in _subp
            raise ProcessExecutionError(stdout=out, stderr=err,
        curtin.util.ProcessExecutionError: Unexpected error while running command.
        Command: ['sh', '-cf', 'wget "$1" --progress=dot:mega -O - |smtar -C "$2" --xattrs --xattrs-include=* -Sxpf - --numeric-owner', '--', 'http://10.107.123.10:5248/images/d7f4ba7/custom/amd64/generic/tks-image/uploaded/root.tgz', '/tmp/tmpuoir4ien/target']
        Exit code: 2
        Reason: -
        Stdout: ''
        Stderr: ''
        Unexpected error while running command.
        Command: ['sh', '-cf', 'wget "$1" --progress=dot:mega -O - |smtar -C "$2" --xattrs --xattrs-include=* -Sxpf - --numeric-owner', '--', 'http://10.107.123.10:5248/images/d7f4ba7/custom/amd64/generic/tks-image/uploaded/root.tgz', '/tmp/tmpuoir4ien/target']
        Exit code: 2
        Reason: -
        Stdout: ''
        Stderr: ''
```