### PR TITLE
capi: retry shared Debian apt lock contention

### DIFF
--- a/images/capi/ansible/roles/providers/tasks/azure.yml
+++ b/images/capi/ansible/roles/providers/tasks/azure.yml
@@ -48,6 +48,10 @@
   vars:
     packages:
       - iptables-persistent
+  register: providers_azure_iptables_status
+  until: providers_azure_iptables_status is not failed
+  retries: 5
+  delay: 10
   when: ansible_facts['os_family'] == "Debian"
 
 - name: Block traffic to 168.63.129.16 port 80 for cve-2021-27075
@@ -75,6 +79,10 @@
     packages:
       - netbase
       - nfs-common
+  register: providers_azure_base_packages_status
+  until: providers_azure_base_packages_status is not failed
+  retries: 5
+  delay: 10
   when: ansible_facts['os_family'] == "Debian"
 
 ## refer to ../files/etc/cloud/cloud.cfg.d/15_azure-vnet.cfg

--- a/images/capi/ansible/roles/sysprep/tasks/debian.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/debian.yml
@@ -117,6 +117,10 @@
     autoremove: true
     force_apt_get: true
     lock_timeout: 300
+  register: sysprep_apt_cache_status
+  until: sysprep_apt_cache_status is not failed
+  retries: 5
+  delay: 10
 
 - name: Remove apt package lists
   ansible.builtin.file:


### PR DESCRIPTION
Azure image builds repeatedly fail when background apt activity outlives the module lock timeout.

This adds the existing retry pattern to the Azure provider package installs and sysprep apt cache cleanup, covering the shared provider/sysprep lock failures without changing existing PR branches or weakening apt error handling.

Validation:
- ansible-playbook --syntax-check ansible/node.yml
- ansible-lint --profile min on changed task files
- git diff --check