### PR TITLE
capi: remove stale Microsoft prod apt source

### DIFF
--- a/images/capi/ansible/roles/setup/tasks/trust_microsoft_apt_key.yml
+++ b/images/capi/ansible/roles/setup/tasks/trust_microsoft_apt_key.yml
@@ -1,4 +1,27 @@
 ---
+# Canonical's Ubuntu 26.04 Azure image can ship a legacy Microsoft prod source
+# for Ubuntu 18.04. image-builder does not use it, and its missing signing key
+# breaks subsequent apt updates, so remove only that stale source.
+- name: Find stale Microsoft 18.04 prod apt sources
+  ansible.builtin.find:
+    depth: 1
+    paths:
+      - /etc/apt
+      - /etc/apt/sources.list.d
+    patterns:
+      - "*.list"
+      - "*.sources"
+    contains: ".*https?://packages\\.microsoft\\.com/ubuntu/18\\.04/prod/?"
+  register: setup_stale_microsoft_prod_sources
+
+- name: Remove stale Microsoft 18.04 prod apt sources
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ setup_stale_microsoft_prod_sources.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+
 - name: Check for legacy Microsoft apt source
   ansible.builtin.find:
     depth: 1


### PR DESCRIPTION
Ubuntu 26.04 Azure images can contain an obsolete Microsoft Ubuntu 18.04 prod source. Its missing signing key causes apt updates to fail with NO_PUBKEY EB3E94ADBE1229CF.

Remove only matching stale Microsoft 18.04 prod source files before the existing Microsoft key setup, preserving signature verification for current sources.

Validation:
- ansible-playbook --syntax-check ansible/node.yml
- ansible-playbook --syntax-check ansible/firstboot.yml
- ansible-lint --profile min on the changed task
- git diff --check