### PR TITLE
capi: retry upstream artifact downloads

### DIFF
--- a/images/capi/ansible/roles/containerd/tasks/main.yml
+++ b/images/capi/ansible/roles/containerd/tasks/main.yml
@@ -32,12 +32,20 @@
     checksum: sha256:{{ containerd_url }}.sha256sum
     dest: /tmp/{{ containerd_filename }}
     mode: "0600"
+  register: containerd_download
+  until: containerd_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Download containerd.service
   ansible.builtin.get_url:
     url: "{{ containerd_service_url }}"
     dest: /tmp/containerd.service
     mode: "0600"
+  register: containerd_service_download
+  until: containerd_service_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Download runc
   ansible.builtin.get_url:
@@ -45,6 +53,10 @@
     checksum: sha256:{{ containerd_runc_checksum_url }}
     dest: /tmp/runc
     mode: "0600"
+  register: containerd_runc_download
+  until: containerd_runc_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Download containerd-wasm-shims
   vars:
@@ -57,6 +69,10 @@
     mode: "0600"
   when: containerd_wasm_shims_runtimes | length > 0
   loop: "{{ containerd_wasm_shims_runtimes | split(',') }}"
+  register: containerd_wasm_shims_download
+  until: containerd_wasm_shims_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Create a directory if it does not exist
   ansible.builtin.file:
@@ -254,6 +270,10 @@
     - runsc
     - containerd-shim-runsc-v1
   when: containerd_gvisor_runtime | bool
+  register: containerd_gvisor_download
+  until: containerd_gvisor_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Install runsc as a runtime
   ansible.builtin.command:

--- a/images/capi/ansible/roles/gpu/tasks/flatcar-nvidia.yml
+++ b/images/capi/ansible/roles/gpu/tasks/flatcar-nvidia.yml
@@ -36,6 +36,8 @@
     owner: root
     group: root
     mode: "0644"
+  register: gpu_flatcar_nvidia_runtime_download
+  until: gpu_flatcar_nvidia_runtime_download is not failed
   retries: 5
   delay: 3
 

--- a/images/capi/ansible/roles/kubernetes/tasks/crictl-url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/crictl-url.yml
@@ -18,6 +18,10 @@
     checksum: sha256:{{ crictl_url }}.sha256
     dest: /tmp/{{ crictl_filename }}
     mode: "0600"
+  register: crictl_download
+  until: crictl_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Create crictl bin directory
   ansible.builtin.file:

--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
+++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
@@ -28,6 +28,10 @@
     mode: "0755"
     owner: root
     group: root
+  register: kubernetes_cni_tarball_download
+  until: kubernetes_cni_tarball_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Install CNI
   ansible.builtin.unarchive:
@@ -49,6 +53,10 @@
     owner: root
     group: root
   loop: "{{ kubernetes_bins }}"
+  register: kubernetes_bins_download
+  until: kubernetes_bins_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Download Kubernetes images
   ansible.builtin.get_url:
@@ -57,6 +65,10 @@
     dest: /tmp/{{ item }}
     mode: "0600"
   loop: "{{ kubernetes_imgs }}"
+  register: kubernetes_imgs_download
+  until: kubernetes_imgs_download is not failed
+  retries: 5
+  delay: 3
 
 - name: Copy Kubernetes image modification script
   ansible.builtin.copy:

--- a/images/capi/ansible/roles/load_additional_components/tasks/executables.yml
+++ b/images/capi/ansible/roles/load_additional_components/tasks/executables.yml
@@ -18,5 +18,7 @@
     dest: "{{ additional_executables_destination_path }}"
     mode: "0711"
   loop: "{{ additional_executables_list.split(',') }}"
+  register: additional_executables_download
+  until: additional_executables_download is not failed
   retries: 5
   delay: 3

--- a/images/capi/ansible/roles/load_additional_components/tasks/url.yml
+++ b/images/capi/ansible/roles/load_additional_components/tasks/url.yml
@@ -25,6 +25,7 @@
     mode: "0600"
   register: images
   loop: "{{ additional_url_images_list.split(',') }}"
+  until: images is not failed
   retries: 5
   delay: 3
 


### PR DESCRIPTION
## What this PR does / why we need it

The build fetches release artifacts from github.com and storage.googleapis.com. One read timeout stops the whole packer build. Unrelated pull requests then show a red check.

Example from a recent `pull-azure-sigs` run:

```
TASK [kubernetes : Download crictl]
fatal: [default]: FAILED! => {"changed": false, "elapsed": 10,
  "msg": "Connection failure: The read operation timed out",
  "url": ".../cri-tools/releases/download/v1.36.0/crictl-v1.36.0-linux-amd64.tar.gz.sha256"}
```

This change adds a retry loop to the `get_url` tasks in the node build path:

- kubernetes role: crictl, CNI tarball, Kubernetes binaries, Kubernetes images
- containerd role: containerd, containerd.service, runc, wasm shims, gvisor runsc

Three tasks already set `retries` without `until`. Ansible sets `retries` to 1 when `until` is absent, so those retries never run. This change adds `until` to them:

- load_additional_components role: additional executables, additional images
- gpu role: Flatcar nvidia-runtime sysext image

The retry pattern matches the one for apt lock contention in `roles/kubernetes/tasks/debian.yml`.

The downloads keep their checksum. A retry cannot hide a corrupt artifact.

## How this was verified

- `ansible-lint` reports 0 failures on the changed files.
- The changed files parse as valid YAML.

## Which issue(s) this PR fixes

The failure appears on #2072, #2080, #2087 and #2098. None of these pull requests change the download tasks.

## Release note

```release-note
Retry upstream artifact downloads so a transient network failure does not stop an image build.
```