### PR TITLE
fix: skip assertions for packages-x86 during arm64 builds

### DIFF
--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -57,7 +57,7 @@ package:
   {{end}}
 {{end}}
 # x86-only provider packages (hypervisor tools not available on arm64)
-{{if ne .Vars.arch "arm64"}}
+{{if ne .Vars.ARCH "arm64"}}
 {{range $name, $vers := index .Vars .Vars.OS .Vars.PROVIDER "package-x86"}}
   {{$name}}:
     installed: true

--- a/images/capi/packer/goss/goss-vars.yaml
+++ b/images/capi/packer/goss/goss-vars.yaml
@@ -89,6 +89,7 @@ photon_5_rpms: &photon_5_rpms
   logrotate:
 
 arch: "amd64"
+ARCH: "amd64"
 containerd_enable_limit_no_file: ""
 containerd_gvisor_runtime: ""
 containerd_gvisor_version: ""


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description

<!-- What this PR does / why we need it. -->

Fix a variable name bug in the goss package assertions template where arch was used instead of the correct variable ARCH. This caused the packages-x86 assertions to not be properly skipped during arm64 builds, potentially resulting in false failures when running goss validation on arm64 machines.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) n
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->

Relevant results from a failure without this change when running `make build-ami-ubuntu-2404-arm64` despite [these two packages being deliberately excluded](https://github.com/kubernetes-sigs/image-builder/blob/b059f2e4a2c170580212b3193babec65945cc865/images/capi/packer/goss/goss-vars.yaml#L441-L443):

```json
{
    "results": [
        # ...
        {
            "duration": 25444214,
            "err": null,
            "expected": [
                "true"
            ],
            "found": [
                "false"
            ],
            "human": "Expected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
            "meta": null,
            "property": "installed",
            "resource-id": "linux-tools-virtual",
            "resource-type": "Package",
            "result": 1,
            "skipped": false,
            "successful": false,
            "summary-line": "Package: linux-tools-virtual: installed:\nExpected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
            "test-type": 0,
            "title": ""
        },
        # ...
        {
            "duration": 57202398,
            "err": null,
            "expected": [
                "true"
            ],
            "found": [
                "false"
            ],
            "human": "Expected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
            "meta": null,
            "property": "installed",
            "resource-id": "linux-cloud-tools-virtual",
            "resource-type": "Package",
            "result": 1,
            "skipped": false,
            "successful": false,
            "summary-line": "Package: linux-cloud-tools-virtual: installed:\nExpected\n    \u003cbool\u003e: false\nto equal\n    \u003cbool\u003e: true",
            "test-type": 0,
            "title": ""
        },
        # ...
    ],
    "summary": {
        "failed-count": 2,
        "skipped-count": 0,
        "summary-line": "Count: 64, Failed: 2, Skipped: 0, Duration: 2.088s",
        "test-count": 64,
        "total-duration": 2088295529
    }
}
```
