### PR TITLE
Fix RockyLinux 9 qemu kickstart repo baseurl

### DIFF
--- a/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg.tmpl
+++ b/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg.tmpl
@@ -1,6 +1,7 @@
 # Use CDROM installation media
 repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/"
 repo --name="kickstart" --baseurl="http://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/kickstart/"
+repo --name="devel" --baseurl="https://download.rockylinux.org/pub/rocky/9/devel/x86_64/os/"
 cdrom
 
 # Use text install

--- a/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg.tmpl
+++ b/images/capi/packer/qemu/linux/rockylinux/http/9/ks.cfg.tmpl
@@ -1,6 +1,6 @@
 # Use CDROM installation media
 repo --name="AppStream" --baseurl="http://download.rockylinux.org/pub/rocky/9/AppStream/x86_64/os/"
-repo --name="kickstart" --baseurl="http://download.rockylinux.org/pub/rocky/9/devel/x86_64/kickstart/"
+repo --name="kickstart" --baseurl="http://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/kickstart/"
 cdrom
 
 # Use text install


### PR DESCRIPTION
<!--
Thank you so much for taking the time to contribute to `image-builder` ❤️

Before submitting a new PR please ensure the following:
- You have checked the open pull requests to see if there is already similar work in progress
- You have checked for current open issues matching this change to reference below

Please be patient with waiting for a review. We're a small team of contributors but try our best to get to PRs in a timely manner.

If you'd like to discuss your change with us please reach out any of the communication methods listed on the readme (https://github.com/kubernetes-sigs/image-builder#community-discussion-contribution-and-support).

-->

## Change description
<!-- What this PR does / why we need it. -->
The kickstart repo entry in the qemu RockyLinux 9 template pointed at pub/rocky/9/devel/x86_64/kickstart/, which does not exist on Rocky's mirrors - the devel tree has no kickstart subdirectory.
The PR points it at BaseOS/x86_64/kickstart/ instead, matching the OVA builder's copy of this same kickstart file, which already had the correct path.

<!--
If your PR include introducing new Providers or Operating systems to support please fill out the following questions.
If not, please feel free to leave blank or remove.
-->
- Is this change including a new Provider or a new OS? (y/n) ____
- If yes, has the Provider/OS matrix been updated in the readme? (y/n) ____
- If adding a new provider, are you a representative of that provider? (y/n) ____

## Related issues
<!-- A list of any open issues that this PR fixes (in the format `Fixes #1234`) which will cause the issues to be closed when this PR merges -->

- Fixes #

## Additional context
<!--
Anything else you think the reviewer might need to know when reviewing this PR.

This could include:
- Log output
- Commands needed to run the change
- Relevant issues / changes from dependencies
- Slack conversations related to the change
-->
