### PR TITLE
fix: bump kubeadm

### DIFF
--- a/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
+++ b/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
@@ -1,11 +1,11 @@
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 imageRepository: {{ kubernetes_container_registry }}
 kubernetesVersion: {{ kubernetes_semver }}
 dns:
   imageRepository: {{ kubernetes_container_registry }}/coredns
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   criSocket: {{ containerd_cri_socket }}


### PR DESCRIPTION
## Change description
beta3 was deprecated a while ago, beta4 should have been available since 1.31. Bumping now because its been fully removed from 1.37.

more info at kubeadm https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta4/

## Fixes
Fixes https://github.com/kubernetes-sigs/image-builder/issues/2151
Fixes https://github.com/kubernetes-sigs/image-builder/issues/2153

## Additional context
- builds failed during image cache pull, kubeadm refused to run
- build worked after switching to beta4