### PR TITLE
fix: bump kubeadm config API from v1beta3 to v1beta4

### DIFF
--- a/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
+++ b/images/capi/ansible/roles/kubernetes/templates/etc/kubeadm.yml
@@ -1,11 +1,11 @@
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 imageRepository: {{ kubernetes_container_registry }}
 kubernetesVersion: {{ kubernetes_semver }}
 dns:
   imageRepository: {{ kubernetes_container_registry }}/coredns
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   criSocket: {{ containerd_cri_socket }}


### PR DESCRIPTION
### What this PR does

Bumps the kubeadm config template API version from `v1beta3` to `v1beta4`.

The `kubeadm.k8s.io/v1beta3` API was removed in kubeadm 1.36, causing image builds for Kubernetes 1.36+ to fail with:

```
error: your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration").
Please use kubeadm v1.36 instead and run kubeadm config migrate
```

`v1beta4` has been available since kubeadm 1.29, so all currently supported Kubernetes versions (1.29–1.37) accept it. The fields used in the template are unchanged between v1beta3 and v1beta4.

### Which issue(s) this PR fixes

Fixes #2151
Fixes #2153

### Special notes for your reviewer

This is a two-line change that only bumps the `apiVersion` field in the kubeadm config template. No schema changes are needed for the fields currently in use.