### PR TITLE
capi: refresh CentOS Stream 9 and 10 ISO composes and resolve them automatically

### DIFF
--- a/images/capi/Makefile
+++ b/images/capi/Makefile
@@ -1270,11 +1270,13 @@ update-rockylinux-iso-checksums: ## Updates checksums for Rocky Linux ISOs
 
 .PHONY: update-centos-9-iso-checksums
 update-centos-9-iso-checksums: ## Updates checksums for Centos 9 ISOs
+	hack/update-centos-iso-urls.sh centos-9
 	hack/update-iso-checksums.sh centos-9 false SHA256SUM "SHA256 (iso_file_name)" 4
 	$(MAKE) json-sort
 
 .PHONY: update-centos-10-iso-checksums
 update-centos-10-iso-checksums: ## Updates checksums for Centos 10 ISOs
+	hack/update-centos-iso-urls.sh centos-10
 	hack/update-iso-checksums.sh centos-10 false SHA256SUM "SHA256 (iso_file_name)" 4
 	$(MAKE) json-sort
 

--- a/images/capi/hack/update-centos-iso-urls.sh
+++ b/images/capi/hack/update-centos-iso-urls.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Repoints CentOS Stream iso_url values at the newest compose published on the
+# mirror.
+#
+# CentOS Stream keeps only the most recent compose in the BaseOS iso directory
+# and prunes older ones, so a dated iso_url stops resolving after a few weeks
+# and update-iso-checksums.sh can no longer find its entry in SHA256SUM. This
+# resolves the current dated compose from SHA256SUM and rewrites iso_url before
+# the checksum refresh runs.
+#
+# The dated name is used rather than the CentOS-Stream-N-latest-* symlink so the
+# pinned URL keeps naming one specific compose that the checksum belongs to.
+#
+# Usage: hack/update-centos-iso-urls.sh <os>
+#   e.g. hack/update-centos-iso-urls.sh centos-9
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 <os>" >&2
+    exit 1
+fi
+
+_os=$1
+
+_tmp=""
+trap 'rm -f "${_tmp}"' EXIT
+
+for file in packer/*/*"${_os}"*.json; do
+    [ -f "${file}" ] || continue
+
+    iso_url=$(jq -r '.iso_url // empty' "${file}")
+    [ -n "${iso_url}" ] || continue
+
+    # Both dated and -latest- CentOS Stream DVD pins are rewritten to the newest
+    # dated compose; anything else is left alone.
+    case "${iso_url}" in
+        https://mirror.stream.centos.org/*-stream/BaseOS/x86_64/iso/CentOS-Stream-*-x86_64-dvd1.iso) ;;
+        *)
+            echo "${file}: iso_url is not a mirror.stream.centos.org CentOS Stream pin, skipping"
+            continue
+            ;;
+    esac
+
+    stream=$(echo "${iso_url}" | sed -n 's#^https://mirror\.stream\.centos\.org/\([0-9][0-9]*\)-stream/.*#\1#p')
+    if [ -z "${stream}" ]; then
+        echo "ERROR: ${file}: cannot determine CentOS Stream version from ${iso_url}" >&2
+        exit 1
+    fi
+
+    iso_dir=$(dirname "${iso_url}")
+    current_iso=$(basename "${iso_url}")
+
+    if ! sums=$(curl -fSsL "${iso_dir}/SHA256SUM"); then
+        echo "ERROR: ${file}: cannot fetch ${iso_dir}/SHA256SUM" >&2
+        exit 1
+    fi
+
+    # Dated composes only: the 8 digit date excludes the -latest- symlink names.
+    # Version sort so a .10 respin ranks above .9 on the same date.
+    latest_iso=$(echo "${sums}" \
+        | grep -oE "CentOS-Stream-${stream}-[0-9]{8}\.[0-9]+-x86_64-dvd1\.iso" \
+        | sort -V -u \
+        | tail -n 1) || true
+
+    if [ -z "${latest_iso}" ]; then
+        echo "ERROR: ${file}: no dated CentOS Stream ${stream} compose listed in ${iso_dir}/SHA256SUM" >&2
+        exit 1
+    fi
+
+    if [ "${latest_iso}" = "${current_iso}" ]; then
+        echo "${file}: already at ${current_iso}"
+        continue
+    fi
+
+    _tmp=$(mktemp)
+    jq --arg iso_url "${iso_dir}/${latest_iso}" '.iso_url = $iso_url' "${file}" > "${_tmp}"
+    mv "${_tmp}" "${file}"
+    echo "${file}: ${current_iso} -> ${latest_iso}"
+done

--- a/images/capi/packer/qemu/qemu-centos-10.json
+++ b/images/capi/packer/qemu/qemu-centos-10.json
@@ -10,9 +10,9 @@
   "distro_version": "10",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10",
   "guest_os_type": "centos10-64",
-  "iso_checksum": "8548643552a939c189b88cc8bf7100846ffad240ed11b438561f118b2bed49d3",
+  "iso_checksum": "65e11b5d35e6bf94b391945381794262343b2694a0fad1ef85ed7663b127a947",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/iso/CentOS-Stream-10-20260630.0-x86_64-dvd1.iso",
+  "iso_url": "https://mirror.stream.centos.org/10-stream/BaseOS/x86_64/iso/CentOS-Stream-10-20260901.0-x86_64-dvd1.iso",
   "os_display_name": "CentOS 10 Stream",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"

--- a/images/capi/packer/qemu/qemu-centos-9.json
+++ b/images/capi/packer/qemu/qemu-centos-9.json
@@ -10,9 +10,9 @@
   "distro_version": "9",
   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
   "guest_os_type": "centos9-64",
-  "iso_checksum": "280f78ca32547eec2f3150090c21526744851d99af006344a07629f88500d9f6",
+  "iso_checksum": "d372351207b3e4ce28a8f93c21c14be68cbb68195568d54f055b935cbed67dea",
   "iso_checksum_type": "sha256",
-  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20260706.0-x86_64-dvd1.iso",
+  "iso_url": "https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/iso/CentOS-Stream-9-20260902.0-x86_64-dvd1.iso",
   "os_display_name": "CentOS 9 Stream",
   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
   "shutdown_command": "/sbin/halt -h -p"


### PR DESCRIPTION
## Change description

The qemu CentOS Stream packer configs pin dated composes. CentOS has since rotated both off the mirror: 9-stream was pinned at 20260706.0 and 10-stream at 20260630.0, and both ISO URLs now return 404 with neither file listed in the published SHA256SUM. The mirror retains only the newest compose alongside the -latest- symlinks, so the pinned files were pruned.

That also breaks the update flow rather than just the builds. `hack/update-iso-checksums.sh` only ever rewrites `iso_checksum`, never `iso_url`, so once the pinned compose is pruned its SHA256SUM entry is gone, the grep matches nothing and the script aborts under pipefail printing nothing at all. Today `make update-centos-9-iso-checksums` and `make update-centos-10-iso-checksums` exit non-zero and refresh nothing, and the only recovery is a manual repin. Because CentOS Stream keeps only the newest compose in the BaseOS iso directory, this recurs every few weeks.

Two commits:

1. Repin both configs to the current composes, 9-stream 20260902.0 and 10-stream 20260901.0, with checksums produced by the repo's own update flow reading the mirror SHA256SUM.

2. Add `hack/update-centos-iso-urls.sh` and run it ahead of the checksum refresh in the two centos targets. It reads SHA256SUM from the directory the config already points at, picks the newest dated `CentOS-Stream-<N>-<date>.<n>-x86_64-dvd1.iso` listed there, and rewrites `iso_url` to it. The dated name is used rather than the `-latest-` symlink so the pin keeps naming the one specific compose the checksum belongs to. Configs without a CentOS Stream DVD URL on mirror.stream.centos.org are reported and skipped; a fetch failure or a directory with no dated compose is a hard error rather than a silent no-op. `json-sort` still runs last.

Together the two steps make the update targets self-healing: a pruned compose is resolved forward and rechecksummed instead of failing.

The powervs CentOS configs are unaffected. They have no `iso_url` and build from a prebuilt OVA in IBM COS, so they carry no compose pin. There are no ova, raw, proxmox, or maas CentOS Stream configs.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

None.

## Additional context

Validation:
- `curl -fsSI` returns 200 for both new ISO URLs, and both `iso_checksum` values match the SHA256 entry for their file in the mirror SHA256SUM.
- `shellcheck -x` and `bash -n` are clean on the new script; it was exercised under bash 3.2.
- Resetting `qemu-centos-9.json` to the pruned 20260706.0 compose and running `make update-centos-9-iso-checksums` restores the correct URL and checksum. The same input fails silently on main.
- The script no-ops with a short message when already current, and returns 1 with a clear error and leaves the file untouched when the mirror 404s.
- `make update-centos-9-iso-checksums update-centos-10-iso-checksums` run twice: the second run is a no-op.
- `make validate-qemu-centos-9 validate-qemu-centos-10` both report the configuration is valid.
