### PR TITLE
capi: make qemu-boot-smoke.sh fail cleanly on bash 3.2 and bad image paths

### DIFF
--- a/images/capi/hack/qemu-boot-smoke.sh
+++ b/images/capi/hack/qemu-boot-smoke.sh
@@ -72,7 +72,7 @@ shift
 qemu_extra_args=()
 if [[ ${1:-} == "--" ]]; then
   shift
-  qemu_extra_args=("${@}")
+  qemu_extra_args=(${@+"${@}"})
 elif [[ $# -gt 0 ]]; then
   usage
   exit 1
@@ -107,7 +107,8 @@ abs_path() {
 
   dir="$(dirname "${path}")"
   base="$(basename "${path}")"
-  echo "$(cd "${dir}" && pwd -P)/${base}"
+  dir="$(cd "${dir}" && pwd -P)" || return 1
+  echo "${dir}/${base}"
 }
 
 is_flatcar_requested() {
@@ -274,7 +275,8 @@ require_command "${QEMU_BINARY}"
 require_command "${QEMU_IMG}"
 require_command ssh
 
-image="$(abs_path "$(resolve_image "${image_arg}")")"
+resolved_image="$(resolve_image "${image_arg}")" || exit 1
+image="$(abs_path "${resolved_image}")"
 if is_flatcar_requested; then
   echo "qemu-boot-smoke.sh does not support Flatcar images: Flatcar uses Ignition, not cloud-init, and the build removes the SSH user before shutdown, so neither QEMU_SEED=cloud-init nor QEMU_SEED=none can authenticate. Image: ${image}" >&2
   exit 1
@@ -333,7 +335,7 @@ pidfile="${tmp_dir}/qemu.pid"
   -m "${QEMU_MEMORY}" \
   -smp "${QEMU_CPUS}" \
   -drive "file=${runtime_disk},if=virtio,format=qcow2" \
-  "${seed_args[@]}" \
+  ${seed_args[@]+"${seed_args[@]}"} \
   -netdev "user,id=net0,hostfwd=tcp:127.0.0.1:${QEMU_SSH_PORT}-:22" \
   -device "virtio-net-pci,netdev=net0" \
   -display none \
@@ -342,7 +344,7 @@ pidfile="${tmp_dir}/qemu.pid"
   -no-reboot \
   -pidfile "${pidfile}" \
   -daemonize \
-  "${qemu_extra_args[@]}"
+  ${qemu_extra_args[@]+"${qemu_extra_args[@]}"}
 
 qemu_pid="$(cat "${pidfile}")"
 deadline=$((SECONDS + QEMU_SSH_TIMEOUT))


### PR DESCRIPTION
## Change description

`hack/qemu-boot-smoke.sh` aborted before starting QEMU on any host whose `/usr/bin/env bash` is older than 4.4 (macOS ships bash 3.2 as `/bin/bash`), and it ignored image resolution failures on every platform, reporting an unrelated `qemu-img` error instead of the real one. This fixes both.

Root cause. `"${seed_args[@]}"` and `"${qemu_extra_args[@]}"` are empty in the common invocation (`QEMU_SEED=none`, no trailing `-- QEMU_ARGS`). bash before 4.4 treats an empty array as unset under `set -o nounset`, so the run died with `seed_args[@]: unbound variable` before QEMU was launched. `qemu_extra_args=("${@}")` after `shift` past `--` aborts the same way on a trailing `--` with no arguments. Because the array aborts happen after the EXIT trap is installed, bash 3.2 takes the script's status from the trap's successful `rm -rf`, so `make test-qemu-boot-smoke` exited 0 without booting anything.

Separately, in `image="$(abs_path "$(resolve_image "${image_arg}")")"` the `exit 1` inside `resolve_image` only exits the inner subshell. The assignment takes the status of `abs_path`, which succeeds on an empty argument, so the script printed `image does not exist: ...` and then continued with the current working directory as the image path. `abs_path` had the same masking one level down.

Fix. Guard all three expansions with the portable `${array[@]+"${array[@]}"}` form. Resolve the image into a variable and check its status before calling `abs_path`, and make `abs_path` return non-zero rather than echo a bogus path when it cannot enter the directory.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

None.

## Additional context

Verified under /bin/bash 3.2 (macOS) with a stub QEMU: `QEMU_SEED=none` with no extra arguments and a trailing `--` with no arguments both reach the QEMU invocation with no empty argv entries, `-- -cpu max` still lands as the last two arguments, and the default cloud-init seed still passes the cidata drive. A nonexistent image path now exits 1 with a single `image does not exist` line and never reaches `qemu-img`. Recorded argv for the default invocation is identical to the unfixed script. `shellcheck -x` and `bash -n` are clean.

```release-note
Fix `hack/qemu-boot-smoke.sh` aborting with an "unbound variable" error on bash 3.2 (macOS) and continuing past a failed image path resolution.
```
