### PR TITLE
capi: pin installed packages on Azure Linux in sysprep

### DIFF
--- a/images/capi/ansible/roles/sysprep/tasks/azurelinux.yml
+++ b/images/capi/ansible/roles/sysprep/tasks/azurelinux.yml
@@ -24,6 +24,20 @@
   ansible.builtin.set_fact:
     package_list: "{{ ansible_facts.packages.keys() | join(' ') }}"
 
+- name: Exclude packages from tdnf upgrades
+  ansible.builtin.lineinfile:
+    path: /etc/tdnf/tdnf.conf
+    regexp: ^excludepkgs=
+    line: excludepkgs={{ package_list }}
+    insertafter: '^\[main\]$'
+
+- name: Exclude packages from dnf upgrades
+  ansible.builtin.lineinfile:
+    path: /etc/dnf/dnf.conf
+    regexp: ^excludepkgs=
+    line: excludepkgs={{ package_list }}
+    insertafter: '^\[main\]$'
+
 - name: Import RPM repository tasks
   ansible.builtin.import_tasks: rpm_repos.yml
 


### PR DESCRIPTION
## Change description

The Azure Linux sysprep tasks gather the installed package list into `package_list` and then never use it. Every other RPM family pins what the build installed: `redhat.yml` writes `exclude=` into `/etc/yum.conf` (and `excludepkgs=` into `/etc/dnf/dnf.conf` on Amazon Linux 2023), and `photon.yml` writes `excludepkgs=` into `/etc/tdnf/tdnf.conf`. On Azure Linux nothing is pinned, so a `tdnf update` or `dnf update` on a running node can replace kubelet, containerd or kubernetes-cni out from under the image.

This is a copy-paste omission rather than a deliberate choice. `sysprep/tasks/mariner.yml` was created in 4b2f2858f as a copy of `photon.yml`, and the exclude task was dropped in that copy while `package_list` was kept. The file was renamed to `azurelinux.yml` in b706ce41c and nothing since restored it.

The fix adds the exclude task back, mirroring the Photon ordering (immediately after "Create the package list"). It writes `excludepkgs=` into both package manager configs:

- `/etc/tdnf/tdnf.conf`, because tdnf is Azure Linux's package manager. Verified on `mcr.microsoft.com/azurelinux/base/core:3.0` that tdnf honors the key: with `excludepkgs=vim` under `[main]`, `tdnf install -y vim` reports "The following packages are excluded from tdnf.conf" and does nothing.
- `/etc/dnf/dnf.conf`, because this role drives every Azure Linux package operation through `ansible.builtin.dnf`. That module requires `python3-dnf`, which requires `dnf-data`, which owns `/etc/dnf/dnf.conf`. The file is therefore present wherever this role runs, and skipping it would leave the manager the build actually uses unpinned.

`insertafter: '^\[main\]$'` anchors the key inside the `[main]` section. Both config files have exactly one section today so this behaves the same as the plain append in `photon.yml`, and lineinfile falls back to end of file if the anchor is ever absent.

No goss change: `images/capi/packer/goss/` has no pinning assertion for any distro, so there is nothing to mirror.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

None.

## Additional context

- `ansible-playbook --syntax-check -i localhost, ansible/node.yml` passes.
- `ansible-lint --project-dir . ansible/` reports the same finding count before and after the change; the only delta is a line-number shift on a pre-existing `var-naming[no-role-prefix]` warning in the same file.
- The two lineinfile tasks were run on localhost against copies of the real Azure Linux 3 `/etc/tdnf/tdnf.conf` and `/etc/dnf/dnf.conf`. Both gain `excludepkgs=<packages>` as the first line under `[main]` with nothing else touched, and a second run reports `changed=0`.
- The packer validate step of `make validate-azure-sig-azurelinux-3` reports "The configuration is valid."
