### PR TITLE
capi: stop set-ssh-password.sh echoing rendered templates and quote paths

### DIFF
--- a/images/capi/hack/set-ssh-password.sh
+++ b/images/capi/hack/set-ssh-password.sh
@@ -43,15 +43,42 @@ fi
 
 export SSH_PASSWORD=${SSH_PASSWORD:-"$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)"}
 SALT=$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)
-export ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt $SALT -stdin <<< $SSH_PASSWORD)
+ENCRYPTED_SSH_PASSWORD=$($openssl_binary passwd -6 -salt "$SALT" -stdin <<< "$SSH_PASSWORD")
+export ENCRYPTED_SSH_PASSWORD
 
-for file in $(find $PACKER_DIR -type f -name "*.tmpl"); do
-  if [ -f "${file%.*}" ]; then
+# The values are injected with sed, so every character that is special in a sed
+# replacement has to be escaped first: a backslash, an ampersand (the whole
+# match) and the "|" delimiter. A newline cannot be escaped this way, so reject
+# it instead of silently producing a broken template.
+if [[ "$SSH_PASSWORD" == *$'\n'* ]]; then
+  echo "SSH_PASSWORD must not contain a newline" 1>&2
+  exit 1
+fi
+
+# escape_sed_replacement prints its argument escaped for use as the replacement
+# text of a "s|...|...|" expression.
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[|&\\]/\\&/g'
+}
+
+escaped_ssh_password=$(escape_sed_replacement "$SSH_PASSWORD")
+escaped_encrypted_ssh_password=$(escape_sed_replacement "$ENCRYPTED_SSH_PASSWORD")
+
+# The rendered files are written with a redirect rather than piped through tee:
+# they contain the plaintext password, the password hash and whatever other
+# credentials a template carries, and tee would copy all of it into the build
+# log. Only the path of each rendered file is printed.
+find "$PACKER_DIR" -type f -name "*.tmpl" -print0 | while IFS= read -r -d '' file; do
+  rendered=${file%.*}
+  if [ -f "$rendered" ]; then
     # HACK: There seems to be a case where this can actually
     # fail with the file not being found, leading to test failures.
     # If we fail to remove the file we just continue and assume
     # that the file was already removed.
-    rm ${file%.*} || true
+    rm "$rendered" || true
   fi
-  sed -e "s|\$SSH_PASSWORD|$SSH_PASSWORD|g" -e "s|\$ENCRYPTED_SSH_PASSWORD|$ENCRYPTED_SSH_PASSWORD|g" $file | tee ${file%.*}
+  sed -e "s|\$SSH_PASSWORD|$escaped_ssh_password|g" \
+      -e "s|\$ENCRYPTED_SSH_PASSWORD|$escaped_encrypted_ssh_password|g" \
+      "$file" > "$rendered"
+  echo "rendered $rendered"
 done


### PR DESCRIPTION
## Change description

`hack/set-ssh-password.sh` renders every `*.tmpl` under `images/capi/packer` and had three problems in its render loop.

It piped each substituted template through `tee`, so the build log received a full copy of every rendered file. Those files contain the plaintext `SSH_PASSWORD`, its SHA-512 crypt hash, and any other credential a template carries, for example mirror credentials in the Ubuntu autoinstall `user-data`. A `make validate-qemu-ubuntu-2404` run printed every rendered template in full, several thousand lines containing dozens of copies of the plaintext password and its `$6$` hash. The rendered file is now written with a plain redirect and only its path is printed; the same target now logs 70 `rendered <path>` lines and zero secrets.

The loop iterated over unquoted `find` output and used unquoted `$file` and `${file%.*}` (shellcheck SC2044 and SC2086), so a template path containing whitespace or a glob character was word-split and the script aborted. It now uses `find -print0` with a NUL-delimited `read`, and every path is quoted. Verified against a template placed at `.../http/24.04 test/user-data.tmpl`, which previously killed the run with `sed: test/user-data.tmpl: No such file or directory` and now renders correctly.

The password was interpolated into the `sed` replacement text unescaped, so a password containing `|`, `&` or `\` either corrupted the rendered file or made sed fail outright (`bad flag in substitute command`). The generator only emits `A-Za-z0-9`, but `SSH_PASSWORD` can be supplied by the caller. The replacement text is now escaped for `\`, `&` and the `|` delimiter, and a password containing a newline, which cannot be escaped this way, is rejected with a clear error.

The `rm ... || true` HACK and its comment, and the OpenSSL version check, are unchanged.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

None.

## Additional context

Verified on macOS with `/bin/bash` 3.2.57 and with GNU and BSD `sed`, since CI runs on both.

- `bash -n` passes; `shellcheck -x` goes from SC2044 x1, SC2086 x6, SC2155 x1 to no findings, so `make lint` is clean for this file.
- Running the old and the new script over two identical copies of the packer tree with the same password produces byte-for-byte identical rendered files once the randomly salted hash is normalised, so there is no behaviour change for ordinary passwords.
- With `SSH_PASSWORD='pw|a&b\c d'` the rendered file contains the password verbatim, and recomputing `openssl passwd -6` with the salt read back out of the rendered hash reproduces that hash exactly.
- Rerunning the script over an already-rendered tree still succeeds, which exercises the `rm ... || true` path.
- `make -C images/capi validate-qemu-ubuntu-2404` passes.
- Nothing consumes the script's stdout: the Makefile target only invokes it, `scripts/ci-ova.sh` calls it through `make` without capturing, and `packer/qemu/scripts/render_ubuntu_autoinstall.py` reads the rendered file from disk.
