### PR TITLE
capi: give Get-WindowsFeature goss checks time to answer on Windows Server 2025

### DIFF
--- a/images/capi/packer/goss/goss-package.yaml
+++ b/images/capi/packer/goss/goss-package.yaml
@@ -85,6 +85,12 @@ package:
 
 {{ if eq .Vars.OS "windows"}} # Windows
 # Workaround until windows features are added to goss
+# The first Get-WindowsFeature call after boot is slow on Windows Server 2025:
+# in CI it usually takes 60-140s and has been observed to take over 300s,
+# while every later call takes about 1s. Keep this timeout well above that
+# tail. It must also stay larger than goss_retry_timeout (goss-args.json):
+# once a single command times out, goss has already used up its retry budget
+# and does not run a second pass.
 command:
 {{range $name, $vers := index .Vars .Vars.OS "common-windows-features"}}
   "Windows Feature - {{ $name }}":
@@ -92,7 +98,7 @@ command:
     exit-status: 0
     stdout: {{range $vers.expected}}
     - {{.}}
-    timeout: 180000
+    timeout: 600000
     {{end}}
 {{end}}
 {{end}}


### PR DESCRIPTION
## Change description

The `Windows Feature - <name>` goss checks run `powershell -command "(Get-WindowsFeature <name> | select *)"` with a 180s command timeout (`images/capi/packer/goss/goss-package.yaml`, raised from 60s in #2045). On Windows Server 2025 that is still not enough and the Azure SIG `windows-2025-containerd` build keeps failing on unrelated PRs (#2100, #2101 and #2141 today) with:

    Windows Feature - Hyper-V-PowerShell: exit-status: Error: Command execution timed out (3m0s)
    Error: timeout of 3m0s reached before tests entered a passing state

Looking at the `windows-2025-containerd.log` artifact of the last 28 `pull-azure-sigs` runs (Aug 22 to Sep 4), the pattern is the same every time: the first `Get-WindowsFeature` call after boot takes 60 to 140s, the second one about 1s. Which of the two feature checks pays the cost depends on goss ordering. The three failures are the tail of that distribution: in the PR #2141 run the first check hit the 180s timeout and the second one still needed 139s, so the cmdlet took over 300s to answer. Windows Server 2022 pays 17s for the first call and passes.

A timed out check also cannot be rescued by goss retries: the check timeout equals `goss_retry_timeout` (180s, `goss-args.json`), so when the first pass finishes goss has already exceeded its retry budget and exits instead of running a second pass, even though the second pass would succeed.

This raises the command timeout to 600s, well above the observed tail, and documents why it has to stay above `goss_retry_timeout`. Trade-off: if `Get-WindowsFeature` genuinely hangs, the failure surfaces after 10 minutes instead of 3, for the first of the two checks only.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

Follow-up to #2045 and #1603.

## Additional context

`make validate-azure-sig-windows-2025-containerd` passes. Windows builds cannot be run locally; the change only affects the goss spec uploaded to the VM.
