### PR TITLE
capi: retry ansible-galaxy collection installs

### DIFF
--- a/images/capi/hack/ensure-ansible.sh
+++ b/images/capi/hack/ensure-ansible.sh
@@ -48,7 +48,7 @@ fi
 
 echo ${ansible_version[*]}
 
-ansible-galaxy collection install \
+galaxy_collection_install \
   'community.general:<=12.0.0' \
   'ansible.posix' \
   'ansible.windows:>=1.7.0' \

--- a/images/capi/hack/ensure-s3.sh
+++ b/images/capi/hack/ensure-s3.sh
@@ -30,4 +30,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 export PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore
 
 # S3 interaction requires the following galaxy collection
-ansible-galaxy collection install amazon.aws:5.5.0
+galaxy_collection_install amazon.aws:5.5.0

--- a/images/capi/hack/utils.sh
+++ b/images/capi/hack/utils.sh
@@ -119,6 +119,44 @@ pip3_install() {
   fi
 }
 
+galaxy_collection_install() {
+  # Wrapper around "ansible-galaxy collection install" that retries on
+  # transient Galaxy API failures, for example the HTTP 502/503/504 responses
+  # galaxy.ansible.com returns while it is degraded. All arguments are passed
+  # through to ansible-galaxy unchanged.
+  #
+  # Tunables:
+  #   GALAXY_INSTALL_RETRIES          total number of attempts (default 5)
+  #   GALAXY_INSTALL_RETRY_DELAY      seconds to sleep before retry 2 (default 5)
+  #   GALAXY_INSTALL_RETRY_MAX_DELAY  upper bound for the backoff (default 40)
+  #   GALAXY_INSTALL_TIMEOUT          per-request timeout in seconds (default 60)
+  local attempts="${GALAXY_INSTALL_RETRIES:-5}"
+  local delay="${GALAXY_INSTALL_RETRY_DELAY:-5}"
+  local max_delay="${GALAXY_INSTALL_RETRY_MAX_DELAY:-40}"
+  local request_timeout="${GALAXY_INSTALL_TIMEOUT:-60}"
+  local attempt=1
+  local rc=0
+
+  while true; do
+    rc=0
+    ansible-galaxy collection install --timeout "${request_timeout}" "${@}" || rc=$?
+    if [ "${rc}" -eq 0 ]; then
+      return 0
+    fi
+    if [ "${attempt}" -ge "${attempts}" ]; then
+      echo "ansible-galaxy collection install failed after ${attempt} attempt(s), last exit code ${rc}" 1>&2
+      return "${rc}"
+    fi
+    echo "ansible-galaxy collection install attempt ${attempt}/${attempts} failed with exit code ${rc}, retrying in ${delay}s" 1>&2
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+    if [ "${delay}" -gt "${max_delay}" ]; then
+      delay="${max_delay}"
+    fi
+  done
+}
+
 hostarch_without_darwin_arm64() {
   if [ "${HOSTOS}" == "darwin" ] && [ "${HOSTARCH}" == "arm64" ]; then
     echo "amd64"


### PR DESCRIPTION
## Change description

`make deps-common` calls `ansible-galaxy collection install` exactly once in `images/capi/hack/ensure-ansible.sh` and once in `images/capi/hack/ensure-s3.sh`. When galaxy.ansible.com is briefly degraded the whole CI job dies on the first bad response. `pull-azure-sigs` failed this way on #2156 and #2160 with:

```
ERROR! Error when getting the collection info for ansible.posix from default (https://galaxy.ansible.com/api/) (HTTP Code: 504, Message: Gateway Timeout)
```

This adds a shared `galaxy_collection_install` helper to `hack/utils.sh`, which both scripts already source, and routes both installs through it. The helper retries up to `GALAXY_INSTALL_RETRIES` times (default 5) with exponential backoff starting at `GALAXY_INSTALL_RETRY_DELAY` seconds (default 5) and capped at `GALAXY_INSTALL_RETRY_MAX_DELAY` (default 40), so the default schedule is 5s, 10s, 20s, 40s. It also passes `--timeout` (`GALAXY_INSTALL_TIMEOUT`, default 60, the same value ansible-galaxy uses on its own) so one hung request cannot consume the entire retry budget.

Failures are not swallowed. Each failed attempt prints a line to stderr, the last attempt prints the attempt count and exit code, and the helper returns the original non-zero status so `set -o errexit` still fails the script. The set of collections installed and their version constraints are unchanged, and the Makefile is untouched.

- Is this change including a new Provider or a new OS? (y/n) n

## Related issues

None.

## Additional context

Validated on macOS with /bin/bash 3.2:

- `bash -n` and `shellcheck` (plain and `-x`, as the Makefile runs it) on all three scripts produce findings identical to main, with nothing new.
- With a fake `ansible-galaxy` on PATH that returns the 504 message above twice and then succeeds, both scripts print two retry lines, succeed on the third attempt and exit 0. An xtrace run confirms the surrounding steps such as the `ansible --version` check still run exactly once while the install is retried.
- With a stub that always fails, both scripts stop after 5 attempts, surface the last error, and exit non-zero. With `GALAXY_INSTALL_RETRIES=3` they stop after 3. A stub exiting 2 makes the script exit 2, so the original status is preserved.
- With a stub that succeeds right away, `ansible-galaxy` is invoked exactly once.
- A real run of `hack/ensure-ansible.sh` against galaxy.ansible.com still succeeds with a single invocation.
- `--timeout` was verified against ansible-core 2.18.18, the version pinned in `hack/utils.sh`, both in `--help` and in an actual install.
